### PR TITLE
Universal quantification of cofibrations via quantifier elimination (#102)

### DIFF
--- a/src/lib/Semantics.ml
+++ b/src/lib/Semantics.ml
@@ -90,10 +90,10 @@ struct
       | Cof.Cof phi ->
         match phi with
         | Cof.Join psis ->
-          let+ psis = MU.commute_list @@ List.map loop psis in
+          let+ psis = MU.map loop psis in
           Cof.Cof (Cof.Join psis)
         | Cof.Meet psis ->
-          let+ psis = MU.commute_list @@ List.map loop psis in
+          let+ psis = MU.map loop psis in
           Cof.Cof (Cof.Meet psis)
         | Cof.Eq (r, s) ->
           gen @@ `CofEq (r, s)

--- a/src/lib/Semantics.ml
+++ b/src/lib/Semantics.ml
@@ -100,6 +100,7 @@ struct
     loop
 
   let forall sym =
+    let i = D.DimProbe sym in
     extend @@
     function
     | `CofEq (r, s) ->
@@ -107,7 +108,6 @@ struct
       function
       | true -> ret Cof.top
       | false ->
-        let i = D.DimProbe sym in
         test_sequent [] (Cof.join [Cof.eq i r; Cof.eq i s]) |>>
         function
         | true -> ret Cof.bot

--- a/src/lib/Semantics.ml
+++ b/src/lib/Semantics.ml
@@ -65,15 +65,16 @@ let rec normalize_cof phi =
 
 module FaceLattice :
 sig
+  (** An atomic formula *)
   type atom = [`CofEq of D.dim * D.dim]
 
-  (* A generator for a lattice homomorphism *)
+  (** A generator for a lattice homomorphism *)
   type gen = atom -> D.cof CM.m
 
-  (* Extend a generator to a lattice homomorphism *)
+  (** Extend a generator to a lattice homomorphism *)
   val extend : gen -> D.cof -> D.cof CM.m
 
-  (* Quantifier elimination *)
+  (** Quantifier elimination *)
   val forall : Symbol.t -> D.cof -> D.cof CM.m
 end =
 struct

--- a/src/lib/Semantics.ml
+++ b/src/lib/Semantics.ml
@@ -109,10 +109,14 @@ struct
       function
       | true -> ret Cof.top
       | false ->
-        test_sequent [] (Cof.join [Cof.eq i r; Cof.eq i s]) |>>
+        test_sequent [] (Cof.eq i r) |>>
         function
         | true -> ret Cof.bot
-        | false -> ret @@ Cof.eq r s
+        | false ->
+          test_sequent [] (Cof.eq i s) |>>
+          function
+          | true -> ret Cof.bot
+          | false -> ret @@ Cof.eq r s
 end
 
 let con_to_dim =

--- a/src/lib/Semantics.ml
+++ b/src/lib/Semantics.ml
@@ -313,6 +313,11 @@ and eval : S.t -> D.con EvM.m =
           let+ phis = MU.map eval tphis in
           D.Cof (Cof.Meet phis)
       end
+    | S.ForallCof tm ->
+      let sym = Symbol.named "forall_probe" in
+      let i = D.DimProbe sym in
+      let* phi = append [D.dim_to_con i] @@ eval_cof tm in
+      D.cof_to_con <@> lift_cmp @@ FaceLattice.forall sym phi
     | S.CofSplit (ttp, branches) ->
       let* tp = eval_tp ttp in
       let tphis, tms = List.split branches in

--- a/src/lib/Syntax.ml
+++ b/src/lib/Syntax.ml
@@ -124,6 +124,13 @@ let rec pp env fmt tm =
     Format.fprintf fmt "#t"
   | Cof (Cof.Meet phis) ->
     Format.pp_print_list ~pp_sep:(fun fmt () -> Uuseg_string.pp_utf_8 fmt " ∧ ") (pp_atomic env) fmt phis
+  | ForallCof phi ->
+    let x, envx = ppenv_bind env `Anon in
+    Format.fprintf fmt "%a %a %a %a"
+      Uuseg_string.pp_utf_8 "∀"
+      Uuseg_string.pp_utf_8 x
+      Uuseg_string.pp_utf_8 "→"
+      (pp envx) phi
   | Fst tm ->
     Format.fprintf fmt "fst %a" (pp_atomic env) tm
   | Snd tm ->

--- a/src/lib/SyntaxData.ml
+++ b/src/lib/SyntaxData.ml
@@ -23,6 +23,7 @@ type t =
   | Dim0
   | Dim1
   | Cof of (t, t) Cof.cof_f
+  | ForallCof of t
   | CofSplit of tp * (t * t) list
   | CofAbort
   | Prf


### PR DESCRIPTION
I believe this is sound & complete. It is _only_ possible because we do not allow cofibration variables of higher type: there is no type `A -> cof`.

Resolves #102 