### PR TITLE
Experimenting with SIMPLE-MINDED explicit substitutions

### DIFF
--- a/src/basis/Monad.ml
+++ b/src/basis/Monad.ml
@@ -1,3 +1,5 @@
+open Bwd
+
 module type S = sig
   type 'a m
 
@@ -58,6 +60,14 @@ struct
       let+ y = f x
       and+ ys = map f xs in
       y :: ys
+
+  let rec map_bwd f =
+    function
+    | Emp -> M.ret Emp
+    | Snoc (xs, x) ->
+      let+ xs = map_bwd f xs
+      and+ x = f x in
+      Snoc (xs, x)
 
   let rec iter f =
     function

--- a/src/basis/Monad.mli
+++ b/src/basis/Monad.mli
@@ -1,3 +1,5 @@
+open Bwd
+
 module type S = sig
   type 'a m
 
@@ -24,6 +26,7 @@ module Notation (M : S) : Notation with type 'a m = 'a M.m
 module Util (M : S) : sig
   val commute_list : 'a M.m list -> 'a list M.m
   val map : ('a -> 'b M.m) -> 'a list -> 'b list M.m
+  val map_bwd : ('a -> 'b M.m) -> 'a bwd -> 'b bwd M.m
   val iter : ('a -> unit M.m) -> 'a list -> unit M.m
 end
 

--- a/src/lib/Domain.ml
+++ b/src/lib/Domain.ml
@@ -142,6 +142,8 @@ and pp_con : con Pp.printer =
     Format.fprintf fmt "<sub/in>"
   | FHCom _ ->
     Format.fprintf fmt "<fhcom>"
+  | LetSym _ ->
+    Format.fprintf fmt "<let-sym>"
   | _ ->
     Format.fprintf fmt "<don't know how to print>"
 

--- a/src/lib/DomainData.ml
+++ b/src/lib/DomainData.ml
@@ -24,6 +24,8 @@ and tm_clo =
 
 and con =
   | Lam of Ident.t * tm_clo
+  | BindSym of Symbol.t * con
+  | LetSym of dim * Symbol.t * con
   | Cut of {tp : tp; cut : cut}
   | Zero
   | Suc of con

--- a/src/lib/DomainData.ml
+++ b/src/lib/DomainData.ml
@@ -5,15 +5,6 @@ open Bwd
 include Dim
 type cof = (dim, int) Cof.cof
 
-(** Destructors: exotic semantic operations that don't exist in syntax; these
-  * are meant to fail on things in improper form, rather than become neutral. *)
-type dst =
-  | DCodePiSplit
-  | DCodeSgSplit
-  | DCodePathSplit
-  | DCodeHComSplit
-
-
 type env = {tpenv : tp bwd; conenv: con bwd}
 
 and tp_clo =
@@ -47,8 +38,6 @@ and con =
 
   | FHCom of [`Nat | `Univ] * dim * dim * cof * con
   | Box of dim * dim * cof * con * con
-
-  | DestructLine of CofEnv.env * dst * con
 
 and tp =
   | Sub of tp * cof * tm_clo

--- a/src/lib/Quote.ml
+++ b/src/lib/Quote.ml
@@ -201,6 +201,9 @@ let rec quote_con (tp : D.tp) con : S.t m =
     in
     S.Box (tr, ts, tphi, tcap, tsides)
 
+  | _, D.LetSym (r, x, con) ->
+    quote_con tp @<< lift_cmp @@ Sem.push_subst_con r x con
+
   | _ ->
     throw @@ QuotationError (Error.IllTypedQuotationProblem (tp, con))
 

--- a/src/lib/Semantics.mli
+++ b/src/lib/Semantics.mli
@@ -1,6 +1,7 @@
 module S := Syntax
 module D := Domain
 
+open CoolBasis
 open Monads
 
 val eval : S.t -> D.con evaluate
@@ -36,3 +37,6 @@ val do_rigid_cap : D.dim -> D.dim -> D.cof -> D.con -> D.con -> D.con compute
 
 val splice_tm : S.t Splice.t -> D.con compute
 val splice_tp : S.tp Splice.t -> D.tp compute
+
+val subst_con : D.dim -> Symbol.t -> D.con -> D.con compute
+val push_subst_con : D.dim -> Symbol.t -> D.con -> D.con compute


### PR DESCRIPTION
This is an alternative to the existing approach to evaluating `coe`; in the existing code, we avoid substitution but must instantiate the binder many times. Maybe that's worse than some very restricted use of substitution! Not sure yet.

In `redtt`, the dimension substitution was a nightmare because we had swapping everywhere, as things were getting drawn underneath binders. That's all been totally eliminated in `cooltt`, using the `TermBuilder`. So, maybe this small bit of substitution is rational.