### PR TITLE
Fix things being unfolded prematurely

### DIFF
--- a/src/lib/Conversion.ml
+++ b/src/lib/Conversion.ml
@@ -130,8 +130,8 @@ let rec equate_tp (tp0 : D.tp) (tp1 : D.tp) =
 and equate_con tp con0 con1 =
   QuM.abort_if_inconsistent () @@
   let* tp = contractum_or tp <@> lift_cmp @@ whnf_tp tp in
-  let* con0 = contractum_or con0 <@> lift_cmp @@ whnf_con con0 in
-  let* con1 = contractum_or con1 <@> lift_cmp @@ whnf_con con1 in
+  let* con0 = contractum_or con0 <@> lift_cmp @@ whnf_con ~style:{unfolding = true} con0 in
+  let* con1 = contractum_or con1 <@> lift_cmp @@ whnf_con ~style:{unfolding = true} con1 in
   match tp, con0, con1 with
   | D.TpPrf _, _, _ -> ret ()
   | _, D.Abort, _ -> ret ()
@@ -280,8 +280,8 @@ and equate_cut cut0 cut1 =
   | _, D.Split (tp, branches) ->
     let phis = List.map (fun (phi, _) -> phi) branches in
     QuM.left_invert_under_cofs [Cof.join phis] @@
-    let* con0 = contractum_or (D.Cut {tp; cut = cut0}) <@> lift_cmp @@ whnf_cut cut0 in
-    let* con1 = contractum_or (D.Cut {tp; cut = cut1}) <@> lift_cmp @@ whnf_cut cut1 in
+    let* con0 = contractum_or (D.Cut {tp; cut = cut0}) <@> lift_cmp @@ whnf_cut ~style:{unfolding = true} cut0 in
+    let* con1 = contractum_or (D.Cut {tp; cut = cut1}) <@> lift_cmp @@ whnf_cut ~style:{unfolding = true} cut1 in
     equate_con tp con0 con1
   | _ ->
     let* () = equate_hd hd0 hd1 in
@@ -359,13 +359,13 @@ and equate_frm k0 k1 =
     conv_err @@ ExpectedFrmEq (k0, k1)
 
 and assert_done_hd hd =
-  let* w = lift_cmp @@ whnf_hd hd in
+  let* w = lift_cmp @@ whnf_hd ~style:{unfolding = true} hd in
   match w with
   | `Done -> ret ()
   | _ -> failwith "internal error: assert_done_hd failed"
 
 and assert_done_cut cut =
-  let* w = lift_cmp @@ whnf_cut cut in
+  let* w = lift_cmp @@ whnf_cut ~style:{unfolding = true} cut in
   match w with
   | `Done -> ret ()
   | _ -> failwith "internal error: assert_done_cut failed"

--- a/src/lib/Elaborator.ml
+++ b/src/lib/Elaborator.ml
@@ -159,8 +159,8 @@ and chk_tm_in_tele (args : CS.cell list) (con : CS.con) : T.Chk.tac =
 and bchk_tm : CS.con -> T.BChk.tac =
   fun con ->
   T.BChk.update_span con.info @@
-  R.Tactic.intro_implicit_connectives @@
   T.BChk.whnf @@
+  R.Tactic.intro_implicit_connectives @@
   match con.node with
   | CS.Hole name ->
     R.Hole.unleash_hole name `Rigid

--- a/src/lib/Elaborator.ml
+++ b/src/lib/Elaborator.ml
@@ -150,7 +150,6 @@ and chk_tm_in_tele (args : CS.cell list) (con : CS.con) : T.Chk.tac =
     | CS.Cell {name; tp} :: args ->
       T.BChk.update_span tp.info @@
       R.Tactic.intro_implicit_connectives @@
-      T.BChk.whnf @@
       R.Pi.intro ~ident:name @@ fun _ ->
       loop args
   in
@@ -163,7 +162,6 @@ and bchk_tm : CS.con -> T.BChk.tac =
     R.Hole.unleash_hole name `Rigid
   | _ ->
     T.BChk.update_span con.info @@
-    T.BChk.whnf @@
     R.Tactic.intro_implicit_connectives @@
     match con.node with
     | CS.Underscore ->

--- a/src/lib/Monads.mli
+++ b/src/lib/Monads.mli
@@ -16,7 +16,6 @@ module CmpM : sig
   include Monad.MonadReaderResult
     with type 'a m = 'a compute
 
-  val read_veil : Veil.t m
   val read_global : ElabState.t m
   val read_cof_env : CofEnv.env m
 

--- a/src/lib/Monads.mli
+++ b/src/lib/Monads.mli
@@ -35,7 +35,6 @@ module EvM : sig
 
   val lift_cmp : 'a compute -> 'a m
 
-  val read_veil : Veil.t m
   val read_global : ElabState.t m
   val read_local : D.env m
 

--- a/src/lib/Quote.ml
+++ b/src/lib/Quote.ml
@@ -64,6 +64,21 @@ let rec quote_con (tp : D.tp) con : S.t m =
           S.Var ix
     end
 
+  | _, D.Cut {cut = (D.Global sym, sp) as cut; tp} ->
+    let* st = QuM.read_global in
+    let* veil = QuM.read_veil in
+    begin
+      let _, ocon = ElabState.get_global sym st in
+      begin
+        match ocon, Veil.policy sym veil with
+        | Some con, `Transparent ->
+          let* con' = lift_cmp @@ Sem.do_spine con sp in
+          quote_con tp con'
+        | _ ->
+          quote_cut cut
+      end
+    end
+
   | _, D.Cut {cut = (hd, sp); tp} ->
     quote_cut (hd, sp)
 

--- a/src/lib/Refiner.ml
+++ b/src/lib/Refiner.ml
@@ -63,7 +63,7 @@ struct
         let ident =
           match name with
           | None -> `Anon
-          | Some str -> `Machine str
+          | Some str -> `Machine ("?" ^ str)
         in
         EM.add_global ident vtp None
     in

--- a/src/lib/Refiner.ml
+++ b/src/lib/Refiner.ml
@@ -875,6 +875,7 @@ struct
 
   let rec intro_implicit_connectives : T.BChk.tac -> T.BChk.tac =
     fun tac ->
+    T.BChk.whnf @@
     match_goal @@ function
     | D.Sub _, _, _ ->
       EM.ret @@ Sub.intro @@ intro_implicit_connectives tac

--- a/src/lib/Refiner.ml
+++ b/src/lib/Refiner.ml
@@ -962,9 +962,10 @@ struct
         Pi.intro @@ fun var -> (* of inductive type *)
         T.BChk.chk @@ fun goal ->
         let* fib = EM.lift_cmp @@ Sem.inst_tp_clo fam @@ D.ElIn (T.Var.con var) in
-        match fib with
-        | D.El code ->
-          EM.lift_qu @@ Qu.quote_con D.Univ code
+        let* tfib = EM.lift_qu @@ Quote.quote_tp fib in
+        match tfib with
+        | S.El code ->
+          EM.ret code
         | _ ->
           EM.expected_connective `El fib
       in

--- a/src/lib/Semantics.ml
+++ b/src/lib/Semantics.ml
@@ -845,7 +845,7 @@ and whnf_hd ?(style = default_whnf_style) hd =
       | true -> reduce_to ~style con
       | false ->
         begin
-          dispatch_rigid_coe abs |>>
+          dispatch_rigid_coe ~style abs |>>
           function
           | `Done ->
             ret `Done
@@ -864,7 +864,7 @@ and whnf_hd ?(style = default_whnf_style) hd =
           ret `Done
         | `Reduce code ->
           begin
-            dispatch_rigid_hcom code |>>
+            dispatch_rigid_hcom ~style code |>>
             function
             | `Done _ ->
               ret `Done
@@ -1252,7 +1252,7 @@ and do_el : D.con -> D.tp CM.m =
   fun con ->
     abort_if_inconsistent D.TpAbort @@
     begin
-      inspect_con ~style:{unfolding = true} con |>>
+      inspect_con con |>>
       function
       | D.Cut {cut} ->
         ret @@ D.ElCut cut
@@ -1321,7 +1321,7 @@ and do_coe r s (abs : D.con) con =
   | _ -> do_rigid_coe abs r s con
 
 
-and dispatch_rigid_coe line =
+and dispatch_rigid_coe ?(style = default_whnf_style) line =
   let open CM in
   let go x codex =
     match codex with
@@ -1348,7 +1348,7 @@ and dispatch_rigid_coe line =
   in
   let peek line =
     let x = Symbol.named "do_rigid_coe" in
-    go x <@> whnf_inspect_con ~style:{unfolding = true} @<< do_ap line @@ D.dim_to_con @@ D.DimProbe x |>>
+    go x <@> whnf_inspect_con ~style @<< do_ap line @@ D.dim_to_con @@ D.DimProbe x |>>
     function
     | `Reduce _ | `Done as res -> ret res
     | `Unknown ->
@@ -1364,7 +1364,7 @@ and dispatch_rigid_coe line =
   | _ ->
     peek line
 
-and dispatch_rigid_hcom code =
+and dispatch_rigid_hcom ?(style = default_whnf_style) code =
   let open CM in
   let go code =
     match code with
@@ -1389,7 +1389,7 @@ and dispatch_rigid_hcom code =
     | _ ->
       throw @@ NbeFailed "Invalid arguments to dispatch_rigid_hcom"
   in
-  go @<< whnf_inspect_con ~style:{unfolding = true} code
+  go @<< whnf_inspect_con ~style code
 
 and enact_rigid_coe line r r' con tag =
   let open CM in

--- a/src/lib/Semantics.mli
+++ b/src/lib/Semantics.mli
@@ -8,11 +8,16 @@ val eval : S.t -> D.con evaluate
 val eval_cof : S.t -> D.cof evaluate
 val eval_tp : S.tp -> D.tp evaluate
 
+type whnf_style =
+  {unfolding : bool}
+
 type 'a whnf = [`Done | `Reduce of 'a]
-val whnf_con : D.con -> D.con whnf compute
-val whnf_cut : D.cut -> D.con whnf compute
-val whnf_hd : D.hd -> D.con whnf compute
+val whnf_con : ?style:whnf_style -> D.con -> D.con whnf compute
+val whnf_cut : ?style:whnf_style -> D.cut -> D.con whnf compute
+val whnf_hd : ?style:whnf_style -> D.hd -> D.con whnf compute
 val whnf_tp : D.tp -> D.tp whnf compute
+
+val whnf_tp_ : D.tp -> D.tp compute
 
 val normalize_cof : D.cof -> D.cof compute
 
@@ -28,6 +33,7 @@ val do_el_out : D.con -> D.con compute
 val unfold_el : D.con -> D.tp compute
 val do_el : D.con -> D.tp compute
 val do_goal_proj : D.con -> D.con compute
+val do_spine : D.con -> D.frm list -> D.con compute
 
 val con_to_dim : D.con -> D.dim compute
 val con_to_cof : D.con -> D.cof compute

--- a/src/lib/Syntax.ml
+++ b/src/lib/Syntax.ml
@@ -1,6 +1,8 @@
 open CoolBasis open Bwd
 include SyntaxData
 
+let debug_mode = false
+
 let rec to_numeral =
   function
   | Zero -> Some 0
@@ -161,28 +163,80 @@ let rec pp env fmt tm =
       (pp_atomic env) mot
       (pp env) base
       (pp env) loop
+  | SubIn tm when debug_mode ->
+    Format.fprintf fmt "sub/in %a" (pp_atomic env) tm
+  | SubOut tm when debug_mode ->
+    Format.fprintf fmt "sub/out %a" (pp_atomic env) tm
+  | ElIn tm when debug_mode ->
+    Format.fprintf fmt "el/in %a" (pp_atomic env) tm
+  | ElOut tm when debug_mode ->
+    Format.fprintf fmt "el/out %a" (pp_atomic env) tm
+  | GoalRet tm when debug_mode ->
+    Format.fprintf fmt "goal/in %a" (pp_atomic env) tm
+  | GoalProj tm when debug_mode ->
+    Format.fprintf fmt "goal/out %a" (pp_atomic env) tm
   | SubIn tm | SubOut tm | GoalRet tm | GoalProj tm | ElIn tm | ElOut tm ->
     pp env fmt tm
-  | CodePi (base, fam) ->
+
+  | CodePi (base, fam) when debug_mode ->
+    Format.fprintf fmt "@[%a %a %a@]"
+      Uuseg_string.pp_utf_8 "<∏>"
+      (pp_atomic env) base
+      (pp_atomic env) fam
+  | CodePi (base, Lam (ident, fam)) ->
+    let x, envx = ppenv_bind env ident in
+    Format.fprintf fmt "(%a : %a) %a %a"
+      Uuseg_string.pp_utf_8 x
+      (pp env) base
+      Uuseg_string.pp_utf_8 "→"
+      (pp envx) fam
+  | CodePi (base, tm) ->
     Format.fprintf fmt "@[%a %a %a@]"
       Uuseg_string.pp_utf_8 "∏"
       (pp_atomic env) base
+      (pp_atomic env) tm
+
+  | CodeSg (base, fam) when debug_mode ->
+    Format.fprintf fmt "@[%a %a %a@]"
+      Uuseg_string.pp_utf_8 "<Σ>"
+      (pp_atomic env) base
       (pp_atomic env) fam
-  | CodeSg (base, fam) ->
+  | CodeSg (base, Lam (ident, fam)) ->
+    let x, envx = ppenv_bind env ident in
+    Format.fprintf fmt "(%a : %a) %a %a"
+      Uuseg_string.pp_utf_8 x
+      (pp env) base
+      Uuseg_string.pp_utf_8 "×"
+      (pp envx) fam
+  | CodeSg (base, tm) ->
     Format.fprintf fmt "@[%a %a %a@]"
       Uuseg_string.pp_utf_8 "Σ"
       (pp_atomic env) base
-      (pp_atomic env) fam
-  | CodePath (fam, bdry) ->
-    Format.fprintf fmt "@[prim-path %a %a@]"
+      (pp_atomic env) tm
+
+  | CodePath (fam, bdry) when debug_mode ->
+    Format.fprintf fmt "@[`path %a %a@]"
       (pp_atomic env) fam
       (pp_atomic env) bdry
+
+  | CodePath (fam, bdry) ->
+    Format.fprintf fmt "@[ext {i => ∂ i} %a %a@]"
+      (pp_atomic env) fam
+      (pp_atomic env) bdry
+
+  | CodeNat when debug_mode ->
+    Format.fprintf fmt "`nat"
+  | CodeCircle when debug_mode ->
+    Format.fprintf fmt "`circle"
+  | CodeUniv when debug_mode ->
+    Format.fprintf fmt "`type"
   | CodeNat ->
-    Format.fprintf fmt "<nat>"
+    Format.fprintf fmt "nat"
   | CodeCircle ->
-    Format.fprintf fmt "<circle>"
+    Format.fprintf fmt "circle"
   | CodeUniv ->
-    Format.fprintf fmt "<type>"
+    Format.fprintf fmt "type"
+
   | Dim0 ->
     Format.fprintf fmt "0"
   | Dim1 ->
@@ -217,16 +271,21 @@ let rec pp env fmt tm =
       (pp_atomic env) pcode
       (pp_atomic env) code
       (pp_atomic env) pequiv
-  | VIn (r, equiv, pivot, base) ->
+  | VIn (r, equiv, pivot, base) when debug_mode ->
     Format.fprintf fmt "@[<hv2>vin %a %a %a %a@]"
       (pp_atomic env) r
       (pp_atomic env) equiv
       (pp_atomic env) pivot
       (pp_atomic env) base
-  | VProj (r, equiv, v) ->
+  | VIn (_, _, pivot, base) ->
+    pp_tuple (pp env) fmt [pivot; base]
+  | VProj (r, equiv, v) when debug_mode ->
     Format.fprintf fmt "@[<hv2>vproj %a %a %a@]"
       (pp_atomic env) r
       (pp_atomic env) equiv
+      (pp_atomic env) v
+  | VProj (r, equiv, v) ->
+    Format.fprintf fmt "@[<hv2>vproj %a@]"
       (pp_atomic env) v
 
 and pp_tp env fmt tp =
@@ -261,8 +320,10 @@ and pp_tp env fmt tp =
     Format.fprintf fmt "nat"
   | Circle ->
     Format.fprintf fmt "circle"
-  | El tm ->
+  | El tm when debug_mode ->
     Format.fprintf fmt "el %a" (pp_atomic env) tm
+  | El tm ->
+    Format.fprintf fmt "%a" (pp env) tm
   | TpVar ix ->
     Format.fprintf fmt "#var[%i]" ix
   | GoalTp (_, tp) ->
@@ -286,7 +347,7 @@ and pp_atomic env fmt tm =
   | Var _ | Global _ | Pair _ | CofAbort | CofSplit _ | Dim0 | Dim1 | Cof (Cof.Meet [] | Cof.Join []) | CodeNat | CodeCircle | CodeUniv
   | Zero | Base | Prf ->
     pp env fmt tm
-  | SubIn tm | SubOut tm | GoalRet tm | GoalProj tm | ElIn tm | ElOut tm ->
+  | (SubIn tm | SubOut tm | GoalRet tm | GoalProj tm | ElIn tm | ElOut tm) when not debug_mode ->
     pp_atomic env fmt tm
   | _ ->
     pp_braced (pp env) fmt tm
@@ -295,7 +356,7 @@ and pp_applications env fmt tm =
   match tm with
   | Ap (tm0, tm1) ->
     Format.fprintf fmt "%a %a" (pp_applications env) tm0 (pp_atomic env) tm1
-  | SubIn tm | SubOut tm | GoalRet tm | GoalProj tm | ElIn tm | ElOut tm ->
+  | (SubIn tm | SubOut tm | GoalRet tm | GoalProj tm | ElIn tm | ElOut tm) when not debug_mode ->
     pp_applications env fmt tm
   | _ ->
     pp env fmt tm
@@ -307,14 +368,11 @@ and pp_lambdas env fmt tm =
     Format.fprintf fmt "%a %a"
       Uuseg_string.pp_utf_8 x
       (pp_lambdas envx) tm
-  | SubIn tm | SubOut tm | GoalRet tm | GoalProj tm | ElIn tm | ElOut tm ->
+  | (SubIn tm | SubOut tm | GoalRet tm | GoalProj tm | ElIn tm | ElOut tm) when not debug_mode ->
     pp_lambdas env fmt tm
   | _ ->
     Format.fprintf fmt "=>@ @[%a@]"
       (pp env) tm
-
-
-
 
 
 

--- a/test/hlevel.cooltt
+++ b/test/hlevel.cooltt
@@ -28,3 +28,4 @@ def hSet : type = hLevel 2
 def hGroupoid : type = hLevel 3
 
 print hProp
+normalize hProp


### PR DESCRIPTION
This PR fixes a lot of conceptual issues with the way the unfolding is controlled. I believe the current design here makes some sense. Let me describe it.

First of all, there is a notion of _veil_, which is a policy about what identifiers are to be unfolded during quotation; this does *not* affect conversion or evaluation. It is important to remember that definitional equivalence in `cooltt` is closed under unfolding of definitions, so the point of `unfold` is only to control the display. Things get unfolded under the hood when necessary *no matter what*; this would be revisited when we add support for abstraction.

Separately, there is a notion of `whnf` that mediates two things: the reduction of cubically unstable stuff, and the unfolding of definitions, in order to support the algorithms that match on semantic types and elements. You always need to reduce the cubically unstable stuff, but depending on what the algorithm is, it may or may not be a good idea to unfold definitions. Whether you should unfold a definition has nothing to do with the user's _veil_, but everything to do with the invariants of the algorithm. To deal with this, we support some internal unfolding policies in the evaluator.