### PR TITLE
Push frames through splits in quotation

### DIFF
--- a/src/lib/Domain.ml
+++ b/src/lib/Domain.ml
@@ -71,13 +71,13 @@ and pp_hd : hd Pp.printer =
     Format.fprintf fmt "global[%a]" Symbol.pp sym
   | Var lvl ->
     Format.fprintf fmt "var[%i]" lvl
-  | Split (tp, branches) ->
+  | Split branches ->
     let sep fmt () = Format.fprintf fmt "@ | " in
     pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep
       pp_split_branch
       fmt
       branches
-  | SubOut (cut, phi, clo) ->
+  | SubOut (cut, _, phi, clo) ->
     Format.fprintf fmt "sub/out[(%a), %a, %a]" pp_cut cut pp_cof phi pp_clo clo
   | _ ->
     Format.fprintf fmt "<hd>"

--- a/src/lib/DomainData.ml
+++ b/src/lib/DomainData.ml
@@ -67,8 +67,8 @@ and hd =
   | HCom of cut * dim * dim * cof * con
   | Cap of dim * dim * cof * con * cut
   | VProj of dim * con * con * con * cut
-  | SubOut of cut * cof * tm_clo
-  | Split of tp * (cof * tm_clo) list
+  | SubOut of cut * tp * cof * tm_clo
+  | Split of (cof * tm_clo) list
 
 and cut = hd * frm list
 

--- a/src/lib/Quote.mli
+++ b/src/lib/Quote.mli
@@ -2,7 +2,7 @@ module D := Domain
 module S := Syntax
 open Monads
 
-val quote_con : D.tp -> D.con -> S.t quote 
+val quote_con : D.tp -> D.con -> S.t quote
 val quote_tp : D.tp -> S.tp quote
-val quote_cut : D.cut -> S.t quote
+val quote_cut : D.tp -> D.cut -> S.t quote
 val quote_cof : D.cof -> S.t quote

--- a/src/lib/Refiner.ml
+++ b/src/lib/Refiner.ml
@@ -69,12 +69,12 @@ struct
     in
 
     let cut = go_tm (D.Global sym, []) @@ Env.locals env in
-    EM.ret (D.SubOut (D.push KGoalProj cut, phi, clo), [])
+    EM.ret (D.SubOut (D.push KGoalProj cut, tp, phi, clo), [])
 
   let unleash_hole name flexity : T.BChk.tac =
     fun (tp, phi, clo) ->
     let* cut = make_hole name flexity (tp, phi, clo) in
-    EM.lift_qu @@ Qu.quote_cut cut
+    EM.lift_qu @@ Qu.quote_cut tp cut
 
   let unleash_tp_hole name flexity : T.tp_tac =
     T.Tp.make @@

--- a/src/lib/Semantics.ml
+++ b/src/lib/Semantics.ml
@@ -1121,9 +1121,6 @@ and do_goal_proj con =
     | D.GoalRet con -> ret con
     | D.Cut {tp = D.GoalTp (_, tp); cut} ->
       ret @@ cut_frm ~tp ~cut D.KGoalProj
-    | D.Cut {tp; cut} ->
-      Format.eprintf "bad: %a @." D.pp_tp tp;
-      CM.throw @@ NbeFailed "do_goal_proj"
     | con ->
       Format.eprintf "bad: %a@." D.pp_con con;
       CM.throw @@ NbeFailed "do_goal_proj"

--- a/src/lib/Splice.ml
+++ b/src/lib/Splice.ml
@@ -7,21 +7,6 @@ module TB = TermBuilder
 
 type 'a t = D.env -> 'a TB.m * D.env
 
-let foreign con k : _ t =
-  fun env ->
-  let env' = {env with conenv = env.conenv <>< [con]} in
-  let var = TB.lvl @@ Bwd.length env.conenv in
-  k var env'
-
-let foreign_cof phi = foreign @@ D.cof_to_con phi
-let foreign_dim r = foreign @@ D.dim_to_con r
-let foreign_clo clo = foreign @@ D.Lam (`Anon, clo)
-
-let foreign_tp tp k : _ t =
-  fun env ->
-  let env' = {env with tpenv = env.tpenv <>< [tp]} in
-  let var = TB.tplvl @@ Bwd.length env.tpenv in
-  k var env'
 
 let compile (t : 'a t) : D.env *'a  =
   let m, env = t {tpenv = Emp; conenv = Emp} in
@@ -32,6 +17,59 @@ let compile (t : 'a t) : D.env *'a  =
 let term (m : 'a TB.m) : 'a t =
   fun env ->
   m, env
+
+let foreign con k : _ t =
+  fun env ->
+  let env' = {env with conenv = env.conenv <>< [con]} in
+  let var = TB.lvl @@ Bwd.length env.conenv in
+  k var env'
+
+let foreign_cof phi = foreign @@ D.cof_to_con phi
+let foreign_dim r = foreign @@ D.dim_to_con r
+let foreign_clo clo = foreign @@ D.Lam (`Anon, clo)
+
+let foreign_frm frm (k : S.t TB.m -> 'a t) : 'a t =
+  match frm with
+  | D.KAp (_, arg) ->
+    foreign arg @@ fun arg ->
+    k @@ TB.lam @@ fun f -> TB.ap f [arg]
+  | D.KFst ->
+    k @@ TB.lam TB.fst
+  | D.KSnd ->
+    k @@ TB.lam TB.fst
+  | D.KGoalProj ->
+    k @@ TB.lam TB.goal_proj
+  | D.KElOut ->
+    k @@ TB.lam TB.el_out
+  | D.KNatElim (mot, zero, suc) ->
+    foreign mot @@ fun mot ->
+    foreign zero @@ fun zero ->
+    foreign suc @@ fun suc ->
+    k @@ TB.lam @@ fun n ->
+    TB.nat_elim mot zero suc n
+  | D.KCircleElim (mot, base, loop) ->
+    foreign mot @@ fun mot ->
+    foreign base @@ fun base ->
+    foreign loop @@ fun loop ->
+    k @@ TB.lam @@ fun n ->
+    TB.circle_elim mot base loop n
+
+let rec foreign_spine spine (k : S.t TB.m -> 'a t) : 'a t=
+  match spine with
+  | [] ->
+    k @@ TB.lam @@ fun x -> x
+  | frm :: spine ->
+    foreign_frm frm @@ fun frm ->
+    foreign_spine spine @@ fun spine ->
+    k @@ TB.lam @@ fun x -> TB.ap spine [TB.ap frm [x]]
+
+
+let foreign_tp tp k : _ t =
+  fun env ->
+  let env' = {env with tpenv = env.tpenv <>< [tp]} in
+  let var = TB.tplvl @@ Bwd.length env.tpenv in
+  k var env'
+
 
 module Macro =
 struct

--- a/src/lib/Splice.mli
+++ b/src/lib/Splice.mli
@@ -18,6 +18,7 @@ val foreign : D.con -> (S.t TB.m -> 'a t) -> 'a t
 val foreign_dim : D.dim -> (S.t TB.m -> 'a t) -> 'a t
 val foreign_cof : D.cof -> (S.t TB.m -> 'a t) -> 'a t
 val foreign_clo : D.tm_clo -> (S.t TB.m -> 'a t) -> 'a t
+val foreign_frm : D.frm -> (S.t TB.m -> 'a t) -> 'a t
 val foreign_spine : D.frm list -> (S.t TB.m -> 'a t) -> 'a t
 val foreign_tp : D.tp -> (S.tp TB.m -> 'a t) -> 'a t
 val compile : 'a t -> D.env * 'a

--- a/src/lib/Splice.mli
+++ b/src/lib/Splice.mli
@@ -18,6 +18,7 @@ val foreign : D.con -> (S.t TB.m -> 'a t) -> 'a t
 val foreign_dim : D.dim -> (S.t TB.m -> 'a t) -> 'a t
 val foreign_cof : D.cof -> (S.t TB.m -> 'a t) -> 'a t
 val foreign_clo : D.tm_clo -> (S.t TB.m -> 'a t) -> 'a t
+val foreign_spine : D.frm list -> (S.t TB.m -> 'a t) -> 'a t
 val foreign_tp : D.tp -> (S.tp TB.m -> 'a t) -> 'a t
 val compile : 'a t -> D.env * 'a
 val term : 'a TB.m -> 'a t

--- a/src/lib/TermBuilder.ml
+++ b/src/lib/TermBuilder.ml
@@ -71,6 +71,10 @@ let el_out m : _ m =
   let+ tm = m in
   S.ElOut tm
 
+let goal_proj m : _ m =
+  let+ tm = m in
+  S.GoalProj tm
+
 let lam ?(ident = `Anon) mbdy : _ m =
   scope @@ fun var ->
   let+ bdy = mbdy var in
@@ -132,7 +136,6 @@ let cof_abort =
 
 let const (m : S.t m) : S.t b =
   fun _ -> m
-
 
 let cof_split mtp mbranches =
   let mphis, mtms = List.split mbranches in

--- a/src/lib/TermBuilder.mli
+++ b/src/lib/TermBuilder.mli
@@ -39,6 +39,8 @@ val cof_abort : t m
 val sub_out : t m -> t m
 val sub_in : t m -> t m
 
+val goal_proj : t m -> t m
+
 val el_in : t m -> t m
 val el_out : t m -> t m
 


### PR DESCRIPTION
This results in more readable output.

It would produce `[i=0 -> x]` instead of `fst [i=0 -> [x,y]]`. Please note that this is only changing the meaning of quotation: conversion still implements the exact same theory. We can't really have full "normal forms" in such a strict calculus, so it's up to us to choose the quasi-normal forms that are most readable in practice.