### PR TITLE
Restore all warnings except unused exceptions.

### DIFF
--- a/src/basis/dune
+++ b/src/basis/dune
@@ -1,7 +1,7 @@
 (library
  (name CoolBasis)
  (flags
-  (:standard -w -9-32-37))
+  (:standard -w -38 -warn-error -a+31))
  (preprocess
   (pps ppx_deriving.std))
  (libraries uuseg uuseg.string uutf)

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -10,5 +10,5 @@
  (preprocess
   (pps ppx_deriving.std))
  (flags
-  (:standard -w -9-32-37-38-39-27))
+  (:standard -w -38 -warn-error -a+31))
  (public_name cooltt.core))


### PR DESCRIPTION
See https://dune.readthedocs.io/en/stable/faq.html#how-to-make-warnings-non-fatal