### PR TITLE
Extremely minor clear-up of Semantics.ml

### DIFF
--- a/src/lib/Quote.ml
+++ b/src/lib/Quote.ml
@@ -34,7 +34,7 @@ let contractum_or x =
 let rec quote_con (tp : D.tp) con =
   QuM.abort_if_inconsistent (ret S.tm_abort) @@
   let* tp = contractum_or tp <@> lift_cmp @@ Sem.whnf_tp tp in
-  let* con = contractum_or con <@> lift_cmp @@ Sem.whnf_con ~style:{unfolding = true} con in
+  let* con = contractum_or con <@> lift_cmp @@ Sem.whnf_con con in
   match tp, con with
   | _, D.Split branches ->
     let branch_body (phi, clo) =

--- a/src/lib/Quote.ml
+++ b/src/lib/Quote.ml
@@ -34,7 +34,7 @@ let contractum_or x =
 let rec quote_con (tp : D.tp) con =
   QuM.abort_if_inconsistent (ret S.tm_abort) @@
   let* tp = contractum_or tp <@> lift_cmp @@ Sem.whnf_tp tp in
-  let* con = contractum_or con <@> lift_cmp @@ Sem.whnf_con con in
+  let* con = contractum_or con <@> lift_cmp @@ Sem.whnf_con ~style:{unfolding = true} con in
   match tp, con with
   | _, D.Split branches ->
     let branch_body (phi, clo) =

--- a/src/lib/Semantics.ml
+++ b/src/lib/Semantics.ml
@@ -1138,7 +1138,7 @@ and inst_tm_clo : D.tm_clo -> D.con -> D.con CM.m =
     eval bdy
 
 (* reduces a constructor to something that is stable to pattern match on *)
-and whnf_inspect_con ?(style = {unfolding = false}) con =
+and whnf_inspect_con ?(style = default_whnf_style) con =
   let open CM in
   whnf_con ~style con |>>
   function
@@ -1147,7 +1147,7 @@ and whnf_inspect_con ?(style = {unfolding = false}) con =
 
 (* reduces a constructor to something that is stable to pattern match on,
  * _including_ type annotations on cuts *)
-and inspect_con ?(style = {unfolding = false}) con =
+and inspect_con ?(style = default_whnf_style) con =
   let open CM in
   whnf_inspect_con ~style con |>>
   function


### PR DESCRIPTION
@jonsterling Here is a quick dirty fix for #139, but I do not think this is what we want...? So the issue seems to be that both normalization and goal displaying are using `quote_con`. Not sure what is the most Immortal design here.

How about types? Should we also pass the style in `whnf_tp` (and maybe `quote_tp`) as well.