### PR TITLE
Unicode version of =>.

### DIFF
--- a/src/lib/Lex.mll
+++ b/src/lib/Lex.mll
@@ -133,6 +133,8 @@ rule token = parse
     { RIGHT_ARROW }
   | "=>"
     { RRIGHT_ARROW }
+  | "⇒"
+    { RRIGHT_ARROW }
   | '_'
     { UNDERSCORE }
   | "?" hole_atom

--- a/test/circle.cooltt
+++ b/test/circle.cooltt
@@ -1,15 +1,15 @@
 def Ω1s1 : type =
-  pathd {_ => circle} base base
+  pathd {_ ⇒ circle} base base
 
-def loopn : nat -> Ω1s1 =
+def loopn : nat → Ω1s1 =
   elim [
-  | zero => _ => base
-  | suc {n => loopn} =>
-    i =>
-    hcom circle 0 1 {∂ i} {k _ =>
-      [ k=0 => loopn i
-      | i=0 => base
-      | i=1 => loop k
+  | zero ⇒ _ ⇒ base
+  | suc {n ⇒ loopn} ⇒
+    i ⇒
+    hcom circle 0 1 {∂ i} {k _ ⇒
+      [ k=0 ⇒ loopn i
+      | i=0 ⇒ base
+      | i=1 ⇒ loop k
       ]
     }
   ]

--- a/test/com.cooltt
+++ b/test/com.cooltt
@@ -5,7 +5,7 @@ def mycoe/fun
   (r : 𝕀) (f : (_ : A r) → B r) (i : 𝕀)
   : sub {(_ : A i) → B i} {i=r} f
   =
-  x =>
+  x ⇒
   coe/B r {f {coe/A i x r}} i
 
 def mycom/fun
@@ -16,8 +16,8 @@ def mycom/fun
   (r : 𝕀) (φ : 𝔽) (p : (i : 𝕀) (_ : [i=r ∨ φ]) (_ : A i) → B i) (i : 𝕀)
   : sub {(_ : A i) → B i} {i=r ∨ φ} {p i _}
   =
-  x =>
-  com/B r φ {j _ => p j _ {com/A i #f {_ _ => x} j}} i
+  x ⇒
+  com/B r φ {j _ ⇒ p j _ {com/A i #f {_ _ ⇒ x} j}} i
 
 normalize mycom/fun
 
@@ -28,9 +28,9 @@ def coe/pi
   (A : 𝕀 → type) (B : (i : 𝕀) → A i → type)
   (r : 𝕀) (r' : 𝕀)
   (f : (x : A r) → B r x)
-  : sub {(x : A r') → B r' x} #t {x => coe {i => B i {coe A r' i x}} r r' {f {coe A r' r x}}}
+  : sub {(x : A r') → B r' x} #t {x ⇒ coe {i ⇒ B i {coe A r' i x}} r r' {f {coe A r' r x}}}
   =
-  coe {i => (x : A i) → B i x} r r' f
+  coe {i ⇒ (x : A i) → B i x} r r' f
 
 normalize coe/pi
 
@@ -38,9 +38,9 @@ def coe/sigma
   (A : 𝕀 → type) (B : (i : 𝕀) → A i → type)
   (r : 𝕀) (r' : 𝕀)
   (p : (x : A r) × B r x)
-  : sub {(x : A r') × B r' x} #t [coe A r r' {fst p}, coe {i => B i {coe A r i {fst p}}} r r' {snd p}]
+  : sub {(x : A r') × B r' x} #t [coe A r r' {fst p}, coe {i ⇒ B i {coe A r i {fst p}}} r r' {snd p}]
   =
-  coe {i => (x : A i) × B i x} r r' p
+  coe {i ⇒ (x : A i) × B i x} r r' p
 
 normalize coe/sigma
 
@@ -51,13 +51,13 @@ def coe/pathd
   (a : (i : 𝕀) -> A i 0)
   (b : (i : 𝕀) -> A i 1)
   (m : pathd {A r} {a r} {b r})
-  : sub {pathd {A r'} {a r'} {b r'}} #t {j =>
-      com {i => A i j} r r' {∂ j} {i p =>
-        [j=0 => a i | j=1 => b i | i=r => m j]
+  : sub {pathd {A r'} {a r'} {b r'}} #t {j ⇒
+      com {i ⇒ A i j} r r' {∂ j} {i p ⇒
+        [j=0 ⇒ a i | j=1 ⇒ b i | i=r ⇒ m j]
       }
     }
   =
-  coe {i => pathd {A i} {a i} {b i}} r r' m
+  coe {i ⇒ pathd {A i} {a i} {b i}} r r' m
 
 normalize coe/pathd
 
@@ -71,7 +71,7 @@ def hcom/intro
 def hcom/fun
   (A : type) (B : type) (r : 𝕀) (r' : 𝕀) (φ : 𝔽)
   (p : (i : 𝕀) (_ : [i=r ∨ φ]) → A → B)
-  : sub {A → B} #t {x => hcom B r r' φ {j _ => p j _ x}}
+  : sub {A → B} #t {x ⇒ hcom B r r' φ {j _ ⇒ p j _ x}}
   =
   hcom {A → B} r r' φ p
 
@@ -89,6 +89,6 @@ normalize com/intro
 def com/decomposition
   (A : 𝕀 → type) (r : 𝕀) (r' : 𝕀) (φ : 𝔽)
   (p : (i : 𝕀) (_ : [i=r ∨ φ]) → A i)
-  : sub {A r'} #t {hcom {A r'} r r' φ {j _ => coe A j r' {p j _}}}
+  : sub {A r'} #t {hcom {A r'} r r' φ {j _ ⇒ coe A j r' {p j _}}}
   =
   com A r r' φ p

--- a/test/elab.cooltt
+++ b/test/elab.cooltt
@@ -1,21 +1,21 @@
 def boundary-test : (i : 𝕀) (_ : [∂ i]) → nat = {
-  i _ =>
-  [ i=1 => 5
-  | i=0 => 19
+  i _ ⇒
+  [ i=1 ⇒ 5
+  | i=0 ⇒ 19
   ]
 }
 
 normalize boundary-test
 
 def reflexivity : (A : type) (a : A) (i : 𝕀) → A = {
-  A a _ => a
+  A a _ ⇒ a
 }
 
 
 def pi-code-test : type = (x : nat) → nat
 
 def foo : pi-code-test =
-  x => x
+  x ⇒ x
 
 normalize pi-code-test
 
@@ -23,7 +23,7 @@ normalize pi-code-test
 def simple-let : {
   (A : type) (a : A) -> A
 } = {
-  A a =>
+  A a ⇒
   let b : A = a in
   b
 }
@@ -35,10 +35,10 @@ def hole-in-type : {
   (x : nat) (y : nat) (z : nat)
   → ?tyhole
 } = {
-  y z => ?tmhole
+  y z ⇒ ?tmhole
 }
 
-def foo : (x : nat) → (y : nat) × pathd {i => nat} x y = {
-  x =>
+def foo : (x : nat) → (y : nat) × pathd {i ⇒ nat} x y = {
+  x ⇒
   [x, ?hole1]
 }

--- a/test/groupoid-laws.cooltt
+++ b/test/groupoid-laws.cooltt
@@ -2,40 +2,40 @@
 -- (by carrying around cofibrations everywhere instead)
 
 def path (A : type) (x : A) (y : A) : type =
-  pathd {_ => A} x y
+  pathd {_ ⇒ A} x y
 
 -- pretend we have CCHM Id-types
 def special-j (A : type) (x : A) (B : (φ : 𝔽) → {(i : 𝕀) → sub A {i=0 ∨ φ} x} → type)
-  (d : B #t {_ => x})
+  (d : B #t {_ ⇒ x})
   (φ : 𝔽) (p : (i : 𝕀) → sub A {i=0 ∨ φ} x)
   : sub {B φ p} φ d
   =
   let filler : 𝕀 → 𝕀 → A =
-    j i =>
-    hcom A 0 i {∂ j ∨ φ} {i _ =>
-      [ i=0 ∨ j=0 ∨ φ => p 0
-      | j=1 => p i
+    j i ⇒
+    hcom A 0 i {∂ j ∨ φ} {i _ ⇒
+      [ i=0 ∨ j=0 ∨ φ ⇒ p 0
+      | j=1 ⇒ p i
       ]
     }
   in
-  com {j => B {φ ∨ j=0} {filler j}} 0 1 {φ} {j _ => d}
+  com {j ⇒ B {φ ∨ j=0} {filler j}} 0 1 {φ} {j _ ⇒ d}
 
 def trans (A : type) (p : (i : 𝕀) → A)
   : (φ : 𝔽) (q : (i : 𝕀) → sub A {i=0 ∨ φ} {p 1})
   → sub {path A {p 0} {q 1}} φ p
   =
-  special-j A {p 1} {_ q => path A {p 0} {q 1}} p
+  special-j A {p 1} {_ q ⇒ path A {p 0} {q 1}} p
 
 def assoc (A : type)
   (p : (i : 𝕀) → A)
   (φ : 𝔽) (q : (i : 𝕀) → sub A {i=0 ∨ φ} {p 1})
   : (ψ : 𝔽) (r : (i : 𝕀) → sub A {i=0 ∨ ψ} {q 1})
   → sub {path {path A {p 0} {r 1}} {trans A p {φ ∧ ψ} {trans A q ψ r}} {trans A {trans A p φ q} ψ r}}
-    ψ {_ => trans A p φ q}
+    ψ {_ ⇒ trans A p φ q}
   =
   special-j A {q 1}
-    {ψ r => path {path A {p 0} {r 1}} {trans A p {φ ∧ ψ} {trans A q ψ r}} {trans A {trans A p φ q} ψ r}}
-    {_ => trans A p φ q}
+    {ψ r ⇒ path {path A {p 0} {r 1}} {trans A p {φ ∧ ψ} {trans A q ψ r}} {trans A {trans A p φ q} ψ r}}
+    {_ ⇒ trans A p φ q}
 
 -- get the standard functions by instantiating at #f everywhere
 

--- a/test/hcom-type.cooltt
+++ b/test/hcom-type.cooltt
@@ -1,19 +1,19 @@
 def v-test (r : 𝕀) (A : type) : type =
-  V r {_ => A} A {_ =>
-    [ x => x
-    , x =>
-      [ [x, _ => x]
-      , p i =>
-        let aux = hfill A 1 {∂ i} {k _ => [ k=1 => x | i=1 => {snd p} k | i=0 => x ] } in
+  V r {_ ⇒ A} A {_ ⇒
+    [ x ⇒ x
+    , x ⇒
+      [ [x, _ ⇒ x]
+      , p i ⇒
+        let aux = hfill A 1 {∂ i} {k _ ⇒ [ k=1 ⇒ x | i=1 ⇒ {snd p} k | i=0 ⇒ x ] } in
         [aux 0, aux]
       ]
     ]
   }
 
 def hcom-type (i : 𝕀) : type =
-  hcom type 0 1 {∂ i} {j _ => [j=0 => v-test i nat | ∂ i => nat]}
+  hcom type 0 1 {∂ i} {j _ ⇒ [j=0 ⇒ v-test i nat | ∂ i ⇒ nat]}
 
 def hcom-box (i : 𝕀) : hcom-type i =
-  [_ => ?asdf, ?]
+  [_ ⇒ ?asdf, ?]
 
 

--- a/test/hlevel.cooltt
+++ b/test/hlevel.cooltt
@@ -1,5 +1,5 @@
 def path (C : type) (a : C) (b : C) : type =
-  pathd {_ => C} a b
+  pathd {_ ⇒ C} a b
 
 def is-contr (C : type) : type =
   (c : C) × {(c' : C) → path C c c'}
@@ -10,14 +10,14 @@ def is-prop (C : type) : type =
 def has-hlevel : nat → type → type =
   let aux : nat → type → type =
     elim [
-    | zero => is-prop
-    | suc {l => ih} =>
-      A => (a : A) (a' : A) → ih {path A a a'}
+    | zero ⇒ is-prop
+    | suc {l ⇒ ih} ⇒
+      A ⇒ (a : A) (a' : A) → ih {path A a a'}
     ]
   in
   elim [
-  | zero => is-contr
-  | suc l => aux l
+  | zero ⇒ is-contr
+  | suc l ⇒ aux l
   ]
 
 def hLevel (n : nat) : type =

--- a/test/nat-path.cooltt
+++ b/test/nat-path.cooltt
@@ -1,20 +1,20 @@
 def path (A : type) (x : A) (y : A) : type =
-  pathd {_ => A} x y
+  pathd {_ ⇒ A} x y
 
 def symm/filler (A : type) (p : 𝕀 → A) (i : 𝕀) : 𝕀 → A =
-  hfill A 0 {∂ i} {j _ =>
-    [ j=0 ∨ i=1 => p 0
-    | i=0 => p j
+  hfill A 0 {∂ i} {j _ ⇒
+    [ j=0 ∨ i=1 ⇒ p 0
+    | i=0 ⇒ p j
     ]
   }
 
 def symm (A : type) (p : 𝕀 → A) : path A {p 1} {p 0} =
-  i => symm/filler A p i 1
+  i ⇒ symm/filler A p i 1
 
 def trans/filler (A : type) (p : 𝕀 → A) (q : (i : 𝕀) → sub A {i=0} {p 1}) (j : 𝕀) (i : 𝕀) : A =
-  hcom A 0 j {∂ i} {j _ =>
-    [ j=0 ∨ i=0 => p i
-    | i=1 => q j
+  hcom A 0 j {∂ i} {j _ ⇒
+    [ j=0 ∨ i=0 ⇒ p i
+    | i=1 ⇒ q j
     ]
   }
 
@@ -22,9 +22,9 @@ def trans (A : type) (p : 𝕀 → A) (q : (i : 𝕀) → sub A {i=0} {p 1}) : p
   trans/filler A p q 1
 
 
-def J (A : type) (p : 𝕀 → A) (C : {(i : 𝕀) → sub A {i=0} {p 0}} → type) (d : C {_ => p 0}) : C p =
-  coe {i =>
-    C {hfill A 0 {∂ i} {k _ => [k=0 ∨ i=0 => p 0 | i=1 => p k]}}
+def J (A : type) (p : 𝕀 → A) (C : {(i : 𝕀) → sub A {i=0} {p 0}} → type) (d : C {_ ⇒ p 0}) : C p =
+  coe {i ⇒
+    C {hfill A 0 {∂ i} {k _ ⇒ [k=0 ∨ i=0 ⇒ p 0 | i=1 ⇒ p k]}}
   } 0 1 d
 
 normalize J
@@ -33,38 +33,38 @@ def J/eq
   (A : type)
   (p : 𝕀 → A)
   (C : {(i : 𝕀) → sub A {i=0} {p 0}} → type)
-  (d : C {_ => p 0})
-  : path {C {_ => p 0}} {J A {_ => p 0} C d} d
+  (d : C {_ ⇒ p 0})
+  : path {C {_ ⇒ p 0}} {J A {_ ⇒ p 0} C d} d
   =
-  let square : 𝕀 → 𝕀 → A = i => hfill A 0 {∂ i} {_ _ => p 0} in
-  k =>
+  let square : 𝕀 → 𝕀 → A = i ⇒ hfill A 0 {∂ i} {_ _ ⇒ p 0} in
+  k ⇒
   let mot : 𝕀 → type =
-    i => C {hfill A 0 {∂ k ∨ ∂ i} {j _ => [k=0 => square i j | j=0 ∨ k=1 ∨ ∂ i => p 0]}}
+    i ⇒ C {hfill A 0 {∂ k ∨ ∂ i} {j _ ⇒ [k=0 ⇒ square i j | j=0 ∨ k=1 ∨ ∂ i ⇒ p 0]}}
   in
-  com mot 0 1 {∂ k} {i _ => [k=0 => coe {j => C {square j}} 0 i d | k=1 ∨ i=0 => d]}
+  com mot 0 1 {∂ k} {i _ ⇒ [k=0 ⇒ coe {j ⇒ C {square j}} 0 i d | k=1 ∨ i=0 ⇒ d]}
 
-def trans-left-unit (A : type) (p : 𝕀 → A) : path {path A {p 0} {p 1}} p {trans A {_ => p 0} p} =
-  k i =>
-  hcom A 0 1 {k=0 ∨ ∂ i} {j _ =>
-    [ j=0 ∨ i=0 => p 0
-    | i=1 => p j
-    | k=0 =>
-      hcom A 0 1 {∂ i ∨ ∂ j} {l _ =>
-        let filler : 𝕀 → A = k => trans/filler A {_ => p 0} p k l in
-        [ l=0 ∨ i=0 ∨ j=1 => filler i
-        | i=1 ∨ j=0 => filler j
+def trans-left-unit (A : type) (p : 𝕀 → A) : path {path A {p 0} {p 1}} p {trans A {_ ⇒ p 0} p} =
+  k i ⇒
+  hcom A 0 1 {k=0 ∨ ∂ i} {j _ ⇒
+    [ j=0 ∨ i=0 ⇒ p 0
+    | i=1 ⇒ p j
+    | k=0 ⇒
+      hcom A 0 1 {∂ i ∨ ∂ j} {l _ ⇒
+        let filler : 𝕀 → A = k ⇒ trans/filler A {_ ⇒ p 0} p k l in
+        [ l=0 ∨ i=0 ∨ j=1 ⇒ filler i
+        | i=1 ∨ j=0 ⇒ filler j
         ]
       }
     ]
   }
 
-def trans-right-unit (A : type) (p : 𝕀 → A) : path {path A {p 0} {p 1}} p {trans A p {_ => p 1}} =
-  trans/filler A p {_ => p 1}
+def trans-right-unit (A : type) (p : 𝕀 → A) : path {path A {p 0} {p 1}} p {trans A p {_ ⇒ p 1}} =
+  trans/filler A p {_ ⇒ p 1}
 
 
-def trans-symm-refl (A : type) (p : 𝕀 → A) : path {path A {p 0} {p 0}} {_ => p 0} {trans A p {symm A p}} =
-  k i =>
-  hcom A 0 1 {k=0 ∨ ∂ i} {j _ =>
+def trans-symm-refl (A : type) (p : 𝕀 → A) : path {path A {p 0} {p 0}} {_ ⇒ p 0} {trans A p {symm A p}} =
+  k i ⇒
+  hcom A 0 1 {k=0 ∨ ∂ i} {j _ ⇒
     symm/filler A p j i
   }
 
@@ -74,63 +74,63 @@ normalize trans-symm-refl
 
 def + : nat → nat → nat =
   elim [
-  | zero => n => n
-  | suc {_ => ih} => n => suc {ih n}
+  | zero ⇒ n ⇒ n
+  | suc {_ ⇒ ih} ⇒ n ⇒ suc {ih n}
   ]
 
 def +-right-unit : (x : nat) → path nat {+ x 0} x =
   elim [
-  | zero =>
-    _ => 0
-  | suc {y => ih} =>
-    i => suc {ih i}
+  | zero ⇒
+    _ ⇒ 0
+  | suc {y ⇒ ih} ⇒
+    i ⇒ suc {ih i}
   ]
 
 def +-left-unit (x : nat) : path nat {+ 0 x} x =
-  _ => x
+  _ ⇒ x
 
 def +-suc-r : (x : nat) (y : nat) → path nat {+ x {suc y}} {suc {+ x y}} =
   elim [
-  | zero =>
-    x i => {suc x}
-  | suc {x => ih} =>
-    y i => suc {ih y i}
+  | zero ⇒
+    x i ⇒ {suc x}
+  | suc {x ⇒ ih} ⇒
+    y i ⇒ suc {ih y i}
   ]
 
 def +-comm : (x : nat) (y : nat) → path nat {+ y x} {+ x y} =
   elim [
-  | zero => +-right-unit
-  | suc {y => ih} =>
-    z =>
-    trans nat {+-suc-r z y} {j => suc {ih z j}}
+  | zero ⇒ +-right-unit
+  | suc {y ⇒ ih} ⇒
+    z ⇒
+    trans nat {+-suc-r z y} {j ⇒ suc {ih z j}}
   ]
 
 def +-assoc : (x : nat) (y : nat) (z : nat) → path nat {+ {+ x y} z} {+ x {+ y z}} =
   elim [
-  | zero => y z i => + y z
-  | suc {x => ih} => y z i => suc {ih y z i}
+  | zero ⇒ y z i ⇒ + y z
+  | suc {x ⇒ ih} ⇒ y z i ⇒ suc {ih y z i}
   ]
 
 
 def test (p : 𝕀 → nat) : (i : 𝕀) → nat =
   let fun : nat → nat =
     elim [
-    | zero => zero
-    | suc _ => zero
+    | zero ⇒ zero
+    | suc _ ⇒ zero
     ]
   in
-  i => fun {symm nat p i}
+  i ⇒ fun {symm nat p i}
 
 
 def test2 : (i : 𝕀) → nat =
   let fun : nat → nat =
     elim [
-    | zero => zero
-    | suc _ => zero
+    | zero ⇒ zero
+    | suc _ ⇒ zero
     ]
   in
-  i =>
-  fun {symm nat {_ => zero} i}
+  i ⇒
+  fun {symm nat {_ ⇒ zero} i}
 
 normalize test
 
@@ -142,4 +142,4 @@ normalize test2
 -- reduced as they could be, it is of no consequence for definitional
 -- equivalence. That is, we don't bother pushing eliminators through all the
 -- branches of a disjunction split, but our equational theory acts as if we do.
-def test2' : sub {𝕀 → nat} #t {i => hcom nat 0 1 {∂ i} {_ _ => 0}} = test2
+def test2' : sub {𝕀 → nat} #t {i ⇒ hcom nat 0 1 {∂ i} {_ _ ⇒ 0}} = test2

--- a/test/path-types.cooltt
+++ b/test/path-types.cooltt
@@ -3,26 +3,26 @@
 def formation : {
   (A : 𝕀 → type) (a : A 0) (b : A 1) → type
 } = {
-  A a b =>
+  A a b ⇒
   pathd A a b
 }
 
 normalize formation
 
 def myrefl : {
-  (A : type) (a : A) → pathd {_ => A} a a
+  (A : type) (a : A) → pathd {_ ⇒ A} a a
 } = {
-  A a i => a
+  A a i ⇒ a
 }
 
 normalize myrefl
 
 def funext : {
   (A : type) (B : type) (f : (x : A) → B) (g : (x : A) → B)
-  (h : (x : A) → pathd {_ => B} {f x} {g x})
-  → pathd {_ => (x : A) → B} f g
+  (h : (x : A) → pathd {_ ⇒ B} {f x} {g x})
+  → pathd {_ ⇒ (x : A) → B} f g
 } = {
-  A B f g h i x =>
+  A B f g h i x ⇒
   h x i
 }
 
@@ -30,10 +30,10 @@ normalize funext
 
 def pairext : {
   (A : type) (B : type) (p : (x : A) × B) (q : (x : A) × B)
-  (h : (x : pathd {_ => A} {fst p} {fst q}) × pathd {_ => B} {snd p} {snd q})
-  → pathd {_ => (x : A) × B} p q
+  (h : (x : pathd {_ ⇒ A} {fst p} {fst q}) × pathd {_ ⇒ B} {snd p} {snd q})
+  → pathd {_ ⇒ (x : A) × B} p q
 } = {
-  A B p q h i =>
+  A B p q h i ⇒
   [ {fst h} i
   , {snd h} i
   ]

--- a/test/pre-path-types.cooltt
+++ b/test/pre-path-types.cooltt
@@ -5,29 +5,29 @@
 -/
 
 def myrefl : {
-  (A : type) (a : A) → (i : 𝕀) → sub A {∂ i} [∂ i => a]
+  (A : type) (a : A) → (i : 𝕀) → sub A {∂ i} [∂ i ⇒ a]
 } = {
-  A a i => a
+  A a i ⇒ a
 }
 
 
 def funext : {
   (A : type) (B : type) (f : (x : A) → B) (g : (x : A) → B)
-  (h : (x : A) (i : 𝕀) → sub B {∂ i} [i=0 => f x | i=1 => g x])
-  → (i : 𝕀) → sub {(x : A) → B} {∂ i} [i=0 => f | i=1 => g]
+  (h : (x : A) (i : 𝕀) → sub B {∂ i} [i=0 ⇒ f x | i=1 ⇒ g x])
+  → (i : 𝕀) → sub {(x : A) → B} {∂ i} [i=0 ⇒ f | i=1 ⇒ g]
 } = {
-  A B f g h i x =>
+  A B f g h i x ⇒
   h x i
 }
 
 def pairext : {
   (A : type) (B : type) (p : (x : A) × B) (q : (x : A) × B)
   (h :
-     (x : (i : 𝕀) → sub A {∂ i} [i=0 => fst p | i=1 => fst q]) ×
-     (i : 𝕀) → sub B {∂ i} [i=0 => snd p | i=1 => snd q])
-  → (i : 𝕀) → sub {(x : A) × B} {∂ i} [i=0 => p | i=1 => q]
+     (x : (i : 𝕀) → sub A {∂ i} [i=0 ⇒ fst p | i=1 ⇒ fst q]) ×
+     (i : 𝕀) → sub B {∂ i} [i=0 ⇒ snd p | i=1 ⇒ snd q])
+  → (i : 𝕀) → sub {(x : A) × B} {∂ i} [i=0 ⇒ p | i=1 ⇒ q]
 } = {
-  A B p q h i =>
+  A B p q h i ⇒
   [ {fst h} i
   , {snd h} i
   ]

--- a/test/selfification.cooltt
+++ b/test/selfification.cooltt
@@ -2,7 +2,7 @@ def testing : {
   (Z : type) (A : type) (B : A → type) (p : Z → (x : A) × B x) →
   (z : Z) → {sub A #t {fst {p z}}} × {sub {B {fst {p z}}} #t {snd {p z}}}
 } = {
-  _ _ _ p => p
+  _ _ _ p ⇒ p
 }
 
 normalize testing

--- a/test/v.cooltt
+++ b/test/v.cooltt
@@ -1,10 +1,10 @@
 def v-test (r : 𝕀) (A : type) : type =
-  V r {_ => A} A {_ =>
-    [ x => x
-    , x =>
-      [ [x, _ => x]
-      , p i =>
-        let aux = hfill A 1 {∂ i} {k _ => [ k=1 => x | i=1 => {snd p} k | i=0 => x ] } in
+  V r {_ ⇒ A} A {_ ⇒
+    [ x ⇒ x
+    , x ⇒
+      [ [x, _ ⇒ x]
+      , p i ⇒
+        let aux = hfill A 1 {∂ i} {k _ ⇒ [ k=1 ⇒ x | i=1 ⇒ {snd p} k | i=0 ⇒ x ] } in
         [aux 0, aux]
       ]
     ]
@@ -12,17 +12,17 @@ def v-test (r : 𝕀) (A : type) : type =
 
 normalize v-test
 
-def cool (A : type) (a : A) : sub A #t {coe {_ => A} 0 1 a} =
-  coe {i => v-test i A} 0 1 a
+def cool (A : type) (a : A) : sub A #t {coe {_ ⇒ A} 0 1 a} =
+  coe {i ⇒ v-test i A} 0 1 a
 
 def cool2 (A : type) (a : A) (i : 𝕀) : A =
-  coe {i => v-test i A} i 0 [_ => a, a]
+  coe {i ⇒ v-test i A} i 0 [_ ⇒ a, a]
 
 normalize cool
 normalize cool2
 
 def cool3 (A : type) (a : A) (i : 𝕀) : sub A #t a =
-  let vin : v-test i A = [_ => a, a] in
+  let vin : v-test i A = [_ ⇒ a, a] in
   vproj vin
 
 normalize cool3

--- a/vim/README.md
+++ b/vim/README.md
@@ -25,6 +25,7 @@ there are ASCII equivalents.
 | ∨    | `C-k OR`  | `\/`  |
 | ×    | `C-k *X`  | `*`   |
 | →    | `C-k ->`  | `->`  |
+| ⇒    | `C-k =>`  | `=>`  |
 
 ## Setup
 

--- a/vim/syntax/cooltt.vim
+++ b/vim/syntax/cooltt.vim
@@ -27,7 +27,7 @@ syn keyword coolttKeyw cof sub pathd coe hcom com hfill V vproj
 
 syn keyword coolttDecl def let normalize print quit
 
-syn match   coolttSymb '=>\|[|,*×:=_𝕀𝔽∂∧∨→]\|->\|#t\|#f'
+syn match   coolttSymb '=>\|[|,*×:=_𝕀𝔽∂∧∨→⇒]\|->\|#t\|#f'
 syn match   coolttSymb '\\/\|/\\'
 
 syn region  coolttComm excludenl start="\k\@1<!--" end="$" contains=coolttTodo


### PR DESCRIPTION
I was kind of hoping that we would change the syntax but at this point I am finding the non-Unicode version ugly enough that I wanted to do this.

(Possible improvement: use the Unicode in the pretty-printer also, as with single arrow.)