### PR TITLE
Fix the OPAM file.

### DIFF
--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -7,13 +7,12 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        ocaml-version: [ '4.10.0' ]
+        ocaml-version: ['4.10.0']
     steps:
-    - uses: actions/checkout@master
-    - uses: avsm/setup-ocaml@master
+    - uses: actions/checkout@v2
+    - uses: avsm/setup-ocaml@v1
       with:
         ocaml-version: ${{ matrix.ocaml-version }}
-    - run: opam install dune
     - run: opam pin add -y cooltt .
     - run: make
     - run: make test

--- a/cooltt.opam
+++ b/cooltt.opam
@@ -9,9 +9,10 @@ dev-repo: "git+https://github.com/RedPRL/cooltt.git"
 synopsis: "Experimental implementation of Cartesian cubical type theory"
 license: "Apache-2.0"
 depends: [
-  "dune"  {build}
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.10.0"}
   "ppx_deriving" {>= "4.4.1"}
-  "cmdliner" {>= "1.0" & < "1.1"}
+  "cmdliner" {>= "1.0"}
   "menhir" {>= "20180703"}
   "uuseg" {>= "12.0.0"}
   "uutf" {>= "1.0.2"}


### PR DESCRIPTION
This is to address #157. `List.concat_map` was introduced in 4.10.0.

We should either specify the dependency in the opam file or avoid that function.