### PR TITLE
Smoother tactic interface; bug fixes

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -2,7 +2,7 @@ open Core
 open Cmdliner
 
 let _ =
-  Printexc.record_backtrace true;
+  Printexc.record_backtrace false;
   ()
 
 type options = {mode: [`Interactive | `Scripting of [`Stdin | `File of string]]; width: int}

--- a/src/lib/Conversion.ml
+++ b/src/lib/Conversion.ml
@@ -70,8 +70,8 @@ let contractum_or x =
 (* Invariant: tp0 and tp1 not necessarily whnf *)
 let rec equate_tp (tp0 : D.tp) (tp1 : D.tp) =
   ConvM.abort_if_inconsistent (ret ()) @@
-  let* tp0 = contractum_or tp0 <@> lift_cmp @@ whnf_tp tp0 in
-  let* tp1 = contractum_or tp1 <@> lift_cmp @@ whnf_tp tp1 in
+  let* tp0 = contractum_or tp0 <@> lift_cmp @@ whnf_tp ~style:`UnfoldAll tp0 in
+  let* tp1 = contractum_or tp1 <@> lift_cmp @@ whnf_tp ~style:`UnfoldAll tp1 in
   match tp0, tp1 with
   | D.TpSplit branches, _
   | _, D.TpSplit branches ->
@@ -166,7 +166,7 @@ and equate_stable_code univ code0 code1 =
 (* Invariant: tp, con0, con1 not necessarily whnf *)
 and equate_con tp con0 con1 =
   ConvM.abort_if_inconsistent (ret ()) @@
-  let* tp = contractum_or tp <@> lift_cmp @@ whnf_tp tp in
+  let* tp = contractum_or tp <@> lift_cmp @@ whnf_tp ~style:`UnfoldAll tp in
   let* con0 = contractum_or con0 <@> lift_cmp @@ whnf_con ~style:`UnfoldAll con0 in
   let* con1 = contractum_or con1 <@> lift_cmp @@ whnf_con ~style:`UnfoldAll con1 in
   match tp, con0, con1 with

--- a/src/lib/Driver.ml
+++ b/src/lib/Driver.ml
@@ -137,10 +137,10 @@ let process_file input =
   match Load.load_file input with
   | Ok sign -> process_sign sign
   | Error (Load.ParseError span) ->
-    Log.pp_message ~loc:(Some span) ~lvl:`Error pp_message @@ ParseError;
+    Log.pp_message ~loc:(Some span) ~lvl:`Error pp_message ParseError;
     Error ()
   | Error (Load.LexingError span) ->
-    Log.pp_message ~loc:(Some span) ~lvl:`Error pp_message @@ LexingError;
+    Log.pp_message ~loc:(Some span) ~lvl:`Error pp_message LexingError;
     Error ()
 
 let execute_command =

--- a/src/lib/Driver.ml
+++ b/src/lib/Driver.ml
@@ -147,21 +147,21 @@ let execute_command =
   let open Monad.Notation (EM) in
   function
   | CS.Decl decl -> execute_decl decl
-  | NoOp -> EM.ret `Continue
+  | CS.NoOp -> EM.ret `Continue
   | CS.EndOfFile -> EM.ret `Quit
 
 let rec repl (ch : in_channel) lexbuf =
   let open Monad.Notation (EM) in
   match Load.load_cmd lexbuf with
   | Error (Load.ParseError span) ->
-    let* () = EM.emit ~lvl:`Error (Some span) pp_message @@ ParseError in
+    let* () = EM.emit ~lvl:`Error (Some span) pp_message ParseError in
     repl ch lexbuf
   | Error (Load.LexingError span) ->
-    let* () = EM.emit ~lvl:`Error (Some span) pp_message @@ LexingError in
+    let* () = EM.emit ~lvl:`Error (Some span) pp_message LexingError in
     repl ch lexbuf
   | Ok cmd ->
-    let* res = protect @@ execute_command cmd in
-    match res with
+    protect @@ execute_command cmd |>>
+    function
     | Ok `Continue ->
       repl ch lexbuf
     | Error _  ->

--- a/src/lib/Driver.ml
+++ b/src/lib/Driver.ml
@@ -59,7 +59,7 @@ let elaborate_typed_term name (args : CS.cell list) tp tm =
   let* vtp = EM.lift_ev @@ Sem.eval_tp tp in
   let* tm =
     EM.push_problem "tm" @@
-    Elaborator.chk_tm_in_tele args tm vtp
+    Tactic.Chk.run (Elaborator.chk_tm_in_tele args tm) vtp
   in
   let+ vtm = EM.lift_ev @@ Sem.eval tm in
   tp, vtp, tm, vtm
@@ -74,7 +74,7 @@ let execute_decl =
   | CS.NormalizeTerm term ->
     EM.veil (Veil.const `Transparent)
       begin
-        EM.trap (Elaborator.syn_tm term) |>>
+        EM.trap (Tactic.Syn.run @@ Elaborator.syn_tm term) |>>
         function
         | Ok (tm, vtp) ->
           let* vtm = EM.lift_ev @@ Sem.eval tm in

--- a/src/lib/Driver.ml
+++ b/src/lib/Driver.ml
@@ -109,9 +109,9 @@ let protect m =
   | Error (Err.ElabError (err, info)) ->
     let+ () = EM.emit ~lvl:`Error info ElabError.pp err in
     Error ()
-  | Error _ ->
-    Format.eprintf "foo??@.";
-    EM.ret @@ Error ()
+  | Error exn ->
+    let+ () = EM.emit ~lvl:`Error None PpExn.pp exn in
+    Error ()
 
 let rec execute_signature ~status sign =
   let open Monad.Notation (EM) in

--- a/src/lib/Driver.ml
+++ b/src/lib/Driver.ml
@@ -110,7 +110,8 @@ let protect m =
     let+ () = EM.emit ~lvl:`Error info ElabError.pp err in
     Error ()
   | Error exn ->
-    let+ () = EM.emit ~lvl:`Error None PpExn.pp exn in
+    let* env = EM.read in
+    let+ () = EM.emit ~lvl:`Error (ElabEnv.location env) PpExn.pp exn in
     Error ()
 
 let rec execute_signature ~status sign =

--- a/src/lib/Driver.ml
+++ b/src/lib/Driver.ml
@@ -34,8 +34,8 @@ let pp_message fmt =
     Format.fprintf fmt
       "@[<v>%a@ : %a@ = %a@]"
       Ident.pp ident
-      (S.pp_atomic_tp env) tp
-      (S.pp_atomic env) tm
+      (S.pp_tp env) tp
+      (S.pp env) tm
   | Definition {ident; tp; tm = None} ->
     let env = Pp.Env.emp in
     Format.fprintf fmt

--- a/src/lib/Driver.ml
+++ b/src/lib/Driver.ml
@@ -41,7 +41,7 @@ let pp_message fmt =
     Format.fprintf fmt
       "@[%a : %a@]"
       Ident.pp ident
-      (S.pp_atomic_tp env) tp
+      (S.pp_tp env) tp
   | UnboundIdent ident ->
     Format.fprintf fmt
       "@[Unbound identifier %a@]"

--- a/src/lib/ElabBasics.ml
+++ b/src/lib/ElabBasics.ml
@@ -14,7 +14,7 @@ open Monad.Notation (Monads.ElabM)
 
 let elab_err err =
   let* env = read in
-  raise @@ Err.ElabError (err, Env.location env)
+  throw @@ Err.ElabError (err, Env.location env)
 
 let resolve id =
   let* env = read in

--- a/src/lib/Elaborator.ml
+++ b/src/lib/Elaborator.ml
@@ -49,10 +49,10 @@ struct
     | Tp of T.Tp.tac
     | Code of T.Chk.tac
 
-  let whnf =
+  let whnf ?(style = `UnfoldAll) =
     function
-    | Tp tac -> Tp (T.Tp.whnf tac)
-    | Code tac -> Code (T.Chk.whnf tac)
+    | Tp tac -> Tp (T.Tp.whnf ~style tac)
+    | Code tac -> Code (T.Chk.whnf ~style tac)
 
   let update_span span =
     function

--- a/src/lib/Elaborator.ml
+++ b/src/lib/Elaborator.ml
@@ -166,8 +166,10 @@ and bchk_tm : CS.con -> T.BChk.tac =
   | CS.Hole name ->
     R.Hole.unleash_hole name `Rigid
   | CS.Unfold (idents, c) ->
+    (* TODO: move to a trusted rule *)
+    T.BChk.make @@
     fun goal ->
-      unfold idents @@ bchk_tm c goal
+      unfold idents @@ T.BChk.run (bchk_tm c) goal
   | CS.Generalize (ident, c) ->
     T.BChk.chk @@ R.Structural.generalize ident (chk_tm c)
   | _ ->
@@ -311,7 +313,8 @@ and syn_tm : CS.con -> T.Syn.tac =
     | CS.Ann {term; tp} ->
       T.Syn.ann (chk_tm term) (chk_tp tp)
     | CS.Unfold (idents, c) ->
-      unfold idents @@ syn_tm c
+      (* TODO: move to a primitive rule *)
+      T.Syn.make @@ unfold idents @@ T.Syn.run @@ syn_tm c
     | CS.Coe (tp, src, trg, body) ->
       R.Univ.coe (chk_tm tp) (chk_tm src) (chk_tm trg) (chk_tm body)
     | CS.HCom (tp, src, trg, cof, tm) ->
@@ -330,6 +333,7 @@ and syn_tm : CS.con -> T.Syn.tac =
     | CS.Com (fam, src, trg, cof, tm) ->
       R.Univ.com (chk_tm fam) (chk_tm src) (chk_tm trg) (chk_tm cof) (chk_tm tm)
     | _ ->
+      T.Syn.make @@
       EM.throw @@ Err.ElabError (Err.ExpectedSynthesizableTerm con.node, con.info)
 
 and chk_cases cases =

--- a/src/lib/Elaborator.ml
+++ b/src/lib/Elaborator.ml
@@ -49,7 +49,7 @@ struct
     | Tp of T.Tp.tac
     | Code of T.Chk.tac
 
-  let whnf ?(style = `UnfoldAll) =
+  let whnf ~style =
     function
     | Tp tac -> Tp (T.Tp.whnf ~style tac)
     | Code tac -> Code (T.Chk.whnf ~style tac)

--- a/src/lib/Elaborator.ml
+++ b/src/lib/Elaborator.ml
@@ -309,7 +309,7 @@ and syn_tm : CS.con -> T.Syn.tac =
       T.Syn.ann (chk_tm term) (chk_tp tp)
     | CS.Unfold (idents, c) ->
       (* TODO: move to a primitive rule *)
-      T.Syn.make @@ unfold idents @@ T.Syn.run @@ syn_tm c
+      T.Syn.rule @@ unfold idents @@ T.Syn.run @@ syn_tm c
     | CS.Coe (tp, src, trg, body) ->
       R.Univ.coe (chk_tm tp) (chk_tm src) (chk_tm trg) (chk_tm body)
     | CS.HCom (tp, src, trg, cof, tm) ->
@@ -328,7 +328,7 @@ and syn_tm : CS.con -> T.Syn.tac =
     | CS.Com (fam, src, trg, cof, tm) ->
       R.Univ.com (chk_tm fam) (chk_tm src) (chk_tm trg) (chk_tm cof) (chk_tm tm)
     | _ ->
-      T.Syn.make @@
+      T.Syn.rule @@
       EM.throw @@ Err.ElabError (Err.ExpectedSynthesizableTerm con.node, con.info)
 
 and chk_cases cases =

--- a/src/lib/Elaborator.ml
+++ b/src/lib/Elaborator.ml
@@ -158,6 +158,7 @@ and chk_tm_in_tele (args : CS.cell list) (con : CS.con) : T.Chk.tac =
 
 and chk_tm : CS.con -> T.Chk.tac =
   fun con ->
+  T.Chk.update_span con.info @@
   match con.node with
   | CS.Hole name ->
     R.Hole.unleash_hole name `Rigid
@@ -169,7 +170,6 @@ and chk_tm : CS.con -> T.Chk.tac =
   | CS.Generalize (ident, c) ->
     R.Structural.generalize ident (chk_tm c)
   | _ ->
-    T.Chk.update_span con.info @@
     R.Tactic.intro_implicit_connectives @@
     match con.node with
     | CS.Underscore ->

--- a/src/lib/Elaborator.ml
+++ b/src/lib/Elaborator.ml
@@ -22,7 +22,9 @@ let rec unfold idents k =
       let veil = Veil.unfold [sym] @@ Env.get_veil env in
       EM.veil veil @@ unfold idents k
     | _ ->
-      unfold idents k
+      let* env = EM.read in
+      let span = Env.location env in
+      EM.throw @@ Err.ElabError (Err.UnboundVariable ident, span)
 
 module CoolTp :
 sig
@@ -174,7 +176,6 @@ and chk_tm : CS.con -> T.Chk.tac =
     match con.node with
     | CS.Underscore ->
       R.Prf.intro
-    (* R.Hole.unleash_hole None `Flex *)
     | CS.Lit n ->
       begin
         R.Tactic.match_goal @@ function

--- a/src/lib/Elaborator.mli
+++ b/src/lib/Elaborator.mli
@@ -9,5 +9,4 @@ val chk_tp : CS.con -> Tp.tac
 val chk_tp_in_tele : CS.cell list -> CS.con -> Tp.tac
 val chk_tm : CS.con -> Chk.tac
 val chk_tm_in_tele : CS.cell list -> CS.con -> Chk.tac
-val bchk_tm : CS.con -> Chk.tac
 val syn_tm : CS.con -> Syn.tac

--- a/src/lib/Elaborator.mli
+++ b/src/lib/Elaborator.mli
@@ -5,9 +5,9 @@ module D := Domain
 
 open Tactic
 
-val chk_tp : CS.con -> tp_tac
-val chk_tp_in_tele : CS.cell list -> CS.con -> tp_tac
+val chk_tp : CS.con -> Tp.tac
+val chk_tp_in_tele : CS.cell list -> CS.con -> Tp.tac
 val chk_tm : CS.con -> Chk.tac
 val chk_tm_in_tele : CS.cell list -> CS.con -> Chk.tac
-val bchk_tm : CS.con -> BChk.tac
+val bchk_tm : CS.con -> Chk.tac
 val syn_tm : CS.con -> Syn.tac

--- a/src/lib/Quote.ml
+++ b/src/lib/Quote.ml
@@ -35,7 +35,7 @@ let contractum_or x =
 let rec quote_con (tp : D.tp) con =
   QuM.abort_if_inconsistent (ret S.tm_abort) @@
   let* veil = read_veil in
-  let* tp = contractum_or tp <@> lift_cmp @@ Sem.whnf_tp tp in
+  let* tp = contractum_or tp <@> lift_cmp @@ Sem.whnf_tp ~style:`UnfoldAll tp in
   let* con = contractum_or con <@> lift_cmp @@ Sem.whnf_con ~style:(`Veil veil) con in
   match tp, con with
   | _, D.Split branches ->
@@ -349,6 +349,8 @@ and quote_tp_clo base fam =
   quote_tp tp
 
 and quote_tp (tp : D.tp) =
+  let* veil = read_veil in
+  let* tp = contractum_or tp <@> lift_cmp @@ Sem.whnf_tp ~style:(`Veil veil) tp in
   match tp with
   | D.Nat -> ret S.Nat
   | D.Circle -> ret S.Circle

--- a/src/lib/Refiner.ml
+++ b/src/lib/Refiner.ml
@@ -83,12 +83,12 @@ struct
     EM.quote_cut cut
 
   let unleash_tp_hole name flexity : T.Tp.tac =
-    T.Tp.make @@
+    T.Tp.rule @@
     let* cut = make_hole name flexity @@ (D.Univ, Cubical.Cof.bot, D.Clo (S.tm_abort, {tpenv = Emp; conenv = Emp})) in
     EM.quote_tp @@ D.ElCut cut
 
   let unleash_syn_hole name flexity : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* cut = make_hole name `Flex @@ (D.Univ, Cubical.Cof.bot, D.Clo (S.tm_abort, {tpenv = Emp; conenv = Emp})) in
     let tp = D.ElCut cut in
     let+ tm = tp |> T.Chk.run @@ unleash_hole name flexity in
@@ -99,7 +99,7 @@ end
 module Goal =
 struct
   let formation lbl tac =
-    T.Tp.make @@
+    T.Tp.rule @@
     let+ tp = T.Tp.run tac in
     S.GoalTp (lbl, tp)
 end
@@ -108,7 +108,7 @@ end
 module Sub =
 struct
   let formation (tac_base : T.Tp.tac) (tac_phi : T.Chk.tac) (tac_tm : T.var -> T.Chk.tac) : T.Tp.tac =
-    T.Tp.make @@
+    T.Tp.rule @@
     let* base = T.Tp.run tac_base in
     let* vbase = EM.lift_ev @@ Sem.eval_tp base in
     let* phi = T.Chk.run tac_phi D.TpCof in
@@ -141,7 +141,7 @@ struct
       EM.expected_connective `Sub tp
 
   let elim (tac : T.Syn.tac) : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* tm, subtp = T.Syn.run tac in
     match subtp with
     | D.Sub (tp, _, _) ->
@@ -153,7 +153,7 @@ end
 module Dim =
 struct
   let formation : T.Tp.tac =
-    T.Tp.make_virtual @@
+    T.Tp.virtual_rule @@
     EM.ret S.TpDim
 
   let dim0 : T.Chk.tac =
@@ -184,7 +184,7 @@ end
 module Cof =
 struct
   let formation : T.Tp.tac =
-    T.Tp.make_virtual @@
+    T.Tp.virtual_rule @@
     EM.ret S.TpCof
 
   let expected_cof =
@@ -310,7 +310,7 @@ end
 module Prf =
 struct
   let formation tac_phi =
-    T.Tp.make_virtual @@
+    T.Tp.virtual_rule @@
     let+ phi = T.Chk.run tac_phi D.TpCof in
     S.TpPrf phi
 
@@ -334,7 +334,7 @@ module Pi =
 struct
   let formation : (T.Tp.tac, T.Tp.tac) quantifier =
     fun tac_base (nm, tac_fam) ->
-      T.Tp.make @@
+      T.Tp.rule @@
       let* base = T.Tp.run_virtual tac_base in
       let* vbase = EM.lift_ev @@ Sem.eval_tp base in
       let+ fam = T.abstract ~ident:nm vbase @@ fun var -> T.Tp.run @@ tac_fam var in
@@ -352,7 +352,7 @@ struct
       EM.expected_connective `Pi tp
 
   let apply tac_fun tac_arg : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* tfun, tp = T.Syn.run tac_fun in
     match tp with
     | D.Pi (base, _, fam) ->
@@ -371,7 +371,7 @@ module Sg =
 struct
   let formation : (T.Tp.tac, T.Tp.tac) quantifier =
     fun tac_base (nm, tac_fam) ->
-      T.Tp.make @@
+      T.Tp.rule @@
       let* base = T.Tp.run tac_base in
       let* vbase = EM.lift_ev @@ Sem.eval_tp base in
       let+ fam = T.abstract ~ident:nm vbase @@ fun var -> T.Tp.run @@ tac_fam var in
@@ -392,7 +392,7 @@ struct
       EM.expected_connective `Sg tp
 
   let pi1 tac : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* tpair, tp = T.Syn.run tac in
     match tp with
     | D.Sg (base, _, _) ->
@@ -402,7 +402,7 @@ struct
 
 
   let pi2 tac : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* tpair, tp = T.Syn.run tac in
     match tp with
     | D.Sg (_, _, fam) ->
@@ -420,7 +420,7 @@ end
 module Univ =
 struct
   let formation : T.Tp.tac =
-    T.Tp.make @@
+    T.Tp.rule @@
     EM.ret S.Univ
 
   let univ_tac : (D.tp -> S.t EM.m) -> T.Chk.tac =
@@ -516,7 +516,7 @@ struct
     S.CodeV (r, pcode, code, pequiv)
 
   let coe (tac_fam : T.Chk.tac) (tac_src : T.Chk.tac) (tac_trg : T.Chk.tac) (tac_tm : T.Chk.tac) : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* piuniv =
       EM.lift_cmp @@
       Sem.splice_tp @@
@@ -545,7 +545,7 @@ struct
     vtp
 
   let hcom (tac_code : T.Chk.tac) (tac_src : T.Chk.tac) (tac_trg : T.Chk.tac) (tac_cof : T.Chk.tac) (tac_tm : T.Chk.tac) : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* code = T.Chk.run tac_code D.Univ in
     let* src = T.Chk.run tac_src D.TpDim in
     let* trg = T.Chk.run tac_trg D.TpDim in
@@ -558,7 +558,7 @@ struct
     S.HCom (code, src, trg, cof, tm), vtp
 
   let com (tac_fam : T.Chk.tac) (tac_src : T.Chk.tac) (tac_trg : T.Chk.tac) (tac_cof : T.Chk.tac) (tac_tm : T.Chk.tac) : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* piuniv =
       EM.lift_cmp @@
       Sem.splice_tp @@
@@ -592,7 +592,7 @@ end
 module El =
 struct
   let formation tac =
-    T.Tp.make @@
+    T.Tp.rule @@
     let+ tm = T.Chk.run tac D.Univ in
     S.El tm
 
@@ -610,7 +610,7 @@ struct
     S.ElIn tm
 
   let elim tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* tm, tp = T.Syn.run tac in
     let+ unfolded = dest_el tp in
     S.ElOut tm, unfolded
@@ -675,7 +675,7 @@ struct
       EM.expected_connective `ElV tp
 
   let elim (tac_v : T.Syn.tac) : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* tm, tp = T.Syn.run tac_v in
     match tp with
     | D.ElUnstable (`V (r, pcode, code, pequiv)) ->
@@ -753,7 +753,7 @@ struct
       EM.expected_connective `ElHCom tp
 
   let elim (tac_box : T.Syn.tac) : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* box, box_tp = T.Syn.run tac_box in
     match box_tp with
     | D.ElUnstable (`HCom (r, r', phi, bdy)) ->
@@ -778,7 +778,7 @@ struct
 
 
   let lookup_var id : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* res = EM.resolve id in
     match res with
     | `Local ix ->
@@ -795,7 +795,7 @@ struct
     S.Var ix, tp
 
   let level lvl =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* env = EM.read in
     let ix = ElabEnv.size env - lvl - 1 in
     index ix
@@ -857,7 +857,7 @@ struct
     EM.ret @@ S.Let (S.SubIn tdef, ident, tbdy)
 
   let let_syn ?(ident = `Anon) (tac_def : T.Syn.tac) (tac_bdy : T.var -> T.Syn.tac) : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     let* tdef, tp_def = T.Syn.run tac_def in
     let* vdef = EM.lift_ev @@ Sem.eval tdef in
     let* tbdy, tbdytp =
@@ -878,7 +878,7 @@ end
 module Nat =
 struct
   let formation =
-    T.Tp.make @@
+    T.Tp.rule @@
     EM.ret S.Nat
 
   let assert_nat =
@@ -905,7 +905,7 @@ struct
     S.Suc t
 
   let elim (tac_mot : T.Chk.tac) (tac_case_zero : T.Chk.tac) (tac_case_suc : T.Chk.tac) (tac_scrut : T.Syn.tac) : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     EM.push_problem "elim" @@
     let* tscrut, nattp = T.Syn.run tac_scrut in
     let* () = assert_nat nattp in let* tmot =
@@ -946,7 +946,7 @@ end
 module Circle =
 struct
   let formation =
-    T.Tp.make @@
+    T.Tp.rule @@
     EM.ret S.Circle
 
   let assert_circle =
@@ -966,7 +966,7 @@ struct
     S.Loop r
 
   let elim (tac_mot : T.Chk.tac) (tac_case_base : T.Chk.tac) (tac_case_loop : T.Chk.tac) (tac_scrut : T.Syn.tac) : T.Syn.tac =
-    T.Syn.make @@
+    T.Syn.rule @@
     EM.push_problem "elim" @@
     let* tscrut, circletp = T.Syn.run tac_scrut in
     let* () = assert_circle circletp in
@@ -1020,14 +1020,14 @@ struct
 
   let rec elim_implicit_connectives : T.Syn.tac -> T.Syn.tac =
     fun tac ->
-    T.Syn.make @@
+    T.Syn.rule @@
     let* tm, tp = T.Syn.run @@ T.Syn.whnf tac in
     match tp with
     | D.Sub _ ->
-      T.Syn.run @@ elim_implicit_connectives @@ Sub.elim @@ T.Syn.make @@ EM.ret (tm, tp)
+      T.Syn.run @@ elim_implicit_connectives @@ Sub.elim @@ T.Syn.rule @@ EM.ret (tm, tp)
         (* The above code only makes sense because I know that the argument to Sub.elim will not be called under a further binder *)
     | D.ElStable _ ->
-      T.Syn.run @@ elim_implicit_connectives @@ El.elim @@ T.Syn.make @@ EM.ret (tm, tp)
+      T.Syn.run @@ elim_implicit_connectives @@ El.elim @@ T.Syn.rule @@ EM.ret (tm, tp)
     | _ ->
       EM.ret (tm, tp)
 
@@ -1062,9 +1062,9 @@ struct
         None
 
     let elim (mot : T.Chk.tac) (cases : case_tac list) (scrut : T.Syn.tac) : T.Syn.tac =
-      T.Syn.make @@
+      T.Syn.rule @@
       let* tscrut, ind_tp = T.Syn.run scrut in
-      let scrut = T.Syn.make @@ EM.ret (tscrut, ind_tp) (* only makes sense because because I know 'scrut' won't be used under some binder *) in
+      let scrut = T.Syn.rule @@ EM.ret (tscrut, ind_tp) (* only makes sense because because I know 'scrut' won't be used under some binder *) in
       match ind_tp, mot with
       | D.Nat, mot ->
         let* tac_zero : T.Chk.tac =

--- a/src/lib/Refiner.ml
+++ b/src/lib/Refiner.ml
@@ -78,7 +78,7 @@ struct
 
 
   let unleash_hole name flexity : T.BChk.tac =
-    fun (tp, phi, clo) ->
+    T.BChk.make @@ fun (tp, phi, clo) ->
     let* cut = make_hole name flexity (tp, phi, clo) in
     EM.quote_cut cut
 
@@ -88,9 +88,10 @@ struct
     EM.quote_tp @@ D.ElCut cut
 
   let unleash_syn_hole name flexity : T.Syn.tac =
+    T.Syn.make @@
     let* cut = make_hole name `Flex @@ (D.Univ, Cubical.Cof.bot, D.Clo (S.tm_abort, {tpenv = Emp; conenv = Emp})) in
     let tp = D.ElCut cut in
-    let+ tm = T.Chk.bchk (unleash_hole name flexity) tp in
+    let+ tm = tp |> T.Chk.run @@ T.Chk.bchk (unleash_hole name flexity) in
     tm, tp
 end
 
@@ -110,15 +111,16 @@ struct
     T.Tp.make @@
     let* base = T.Tp.run tac_base in
     let* vbase = EM.lift_ev @@ Sem.eval_tp base in
-    let* phi = tac_phi D.TpCof in
+    let* phi = T.Chk.run tac_phi D.TpCof in
     let+ tm =
       let* vphi = EM.lift_ev @@ Sem.eval_cof phi in
       T.abstract (D.TpPrf vphi) @@ fun prf ->
-      tac_tm prf vbase
+      vbase |> T.Chk.run @@ tac_tm prf
     in
     S.Sub (base, phi, tm)
 
   let intro (tac : T.BChk.tac) : T.BChk.tac =
+    T.BChk.make @@
     function
     | D.Sub (tp_a, phi_a, clo_a), phi_sub, clo_sub ->
       let phi = Cubical.Cof.join [phi_a; phi_sub] in
@@ -133,13 +135,14 @@ struct
           [phi_a, TB.ap fn_a [TB.prf];
            phi_sub, TB.sub_out @@ TB.ap fn_sub [TB.prf]]
       in
-      let+ tm = tac (tp_a, phi, D.un_lam partial) in
+      let+ tm = T.BChk.run tac (tp_a, phi, D.un_lam partial) in
       S.SubIn tm
     | tp, _, _ ->
       EM.expected_connective `Sub tp
 
   let elim (tac : T.Syn.tac) : T.Syn.tac =
-    let* tm, subtp = tac in
+    T.Syn.make @@
+    let* tm, subtp = T.Syn.run tac in
     match subtp with
     | D.Sub (tp, _, _) ->
       EM.ret (S.SubOut tm, tp)
@@ -154,6 +157,7 @@ struct
     EM.ret S.TpDim
 
   let dim0 : T.Chk.tac =
+    T.Chk.make @@
     function
     | D.TpDim ->
       EM.ret S.Dim0
@@ -161,6 +165,7 @@ struct
       EM.expected_connective `Dim tp
 
   let dim1 : T.Chk.tac =
+    T.Chk.make @@
     function
     | D.TpDim ->
       EM.ret S.Dim1
@@ -172,8 +177,8 @@ struct
     | 0 -> dim0
     | 1 -> dim1
     | n ->
-      fun _ ->
-        EM.elab_err @@ Err.ExpectedDimensionLiteral n
+      T.Chk.make @@ fun _ ->
+      EM.elab_err @@ Err.ExpectedDimensionLiteral n
 end
 
 module Cof =
@@ -186,26 +191,29 @@ struct
     EM.expected_connective `Cof
 
   let eq tac0 tac1 =
+    T.Chk.make @@
     function
     | D.TpCof ->
-      let+ r0 = tac0 D.TpDim
-      and+ r1 = tac1 D.TpDim in
+      let+ r0 = T.Chk.run tac0 D.TpDim
+      and+ r1 = T.Chk.run tac1 D.TpDim in
       S.Cof (Cubical.Cof.Eq (r0, r1))
     | tp ->
       expected_cof tp
 
   let join tacs =
+    T.Chk.make @@
     function
     | D.TpCof ->
-      let+ phis = MU.map (fun t -> t D.TpCof) tacs in
+      let+ phis = MU.map (fun t -> T.Chk.run t D.TpCof) tacs in
       S.Cof (Cubical.Cof.Join phis)
     | tp ->
       expected_cof tp
 
   let meet tacs =
+    T.Chk.make @@
     function
     | D.TpCof ->
-      let+ phis = MU.map (fun t -> t D.TpCof) tacs in
+      let+ phis = MU.map (fun t -> T.Chk.run t D.TpCof) tacs in
       S.Cof (Cubical.Cof.Meet phis)
     | tp ->
       expected_cof tp
@@ -227,27 +235,28 @@ struct
     match branches with
     | [] -> EM.ret ([], [])
     | (tac_phi, tac_tm) :: branches ->
-      let* tphi = tac_phi D.TpCof in
+      let* tphi = T.Chk.run tac_phi D.TpCof in
       let* vphi = EM.lift_ev @@ Sem.eval_cof tphi in
       let+ phis, tacs = gather_cofibrations branches in
       (vphi :: phis), tac_tm :: tacs
 
   let split0 : T.BChk.tac =
-    fun _ ->
+    T.BChk.make @@ fun _ ->
     let* _ = assert_true Cubical.Cof.bot in
     EM.ret S.tm_abort
 
   let split1 (phi : D.cof) (tac : T.var -> T.BChk.tac) : T.BChk.tac =
-    fun goal ->
+    T.BChk.make @@ fun goal ->
     let* _ = assert_true phi in
-    tac (T.Var.prf phi) goal
+    T.BChk.run (tac @@ T.Var.prf phi) goal
 
   let split2 (phi0 : D.cof) (tac0 : T.var -> T.BChk.tac) (phi1 : D.cof) (tac1 : T.var -> T.BChk.tac) : T.BChk.tac =
+    T.BChk.make @@
     fun (tp, psi, psi_clo) ->
     let* _ = assert_true @@ Cubical.Cof.join [phi0; phi1] in
     let* tm0 =
       T.abstract (D.TpPrf phi0) @@ fun prf ->
-      tac0 prf (tp, psi, psi_clo)
+      T.BChk.run (tac0 prf) (tp, psi, psi_clo)
     in
     let+ tm1 =
       let* phi0_fn = EM.lift_ev @@ Sem.eval @@ S.Lam (`Anon, tm0) in
@@ -264,7 +273,7 @@ struct
         TB.cof_split [phi0, TB.ap phi0_fn [TB.prf]; psi, TB.ap psi_fn [TB.prf]]
       in
       T.abstract (D.TpPrf phi1) @@ fun prf ->
-      tac1 prf (tp, psi', D.un_lam psi'_fn)
+      T.BChk.run (tac1 prf) (tp, psi', D.un_lam psi'_fn)
     and+ tphi0 = EM.quote_cof phi0
     and+ tphi1 = EM.quote_cof phi1 in
     S.CofSplit [tphi0, tm0; tphi1, tm1]
@@ -275,13 +284,13 @@ struct
     match branches with
     | [] -> EM.ret ([], [])
     | (tac_phi, tac_tm) :: branches ->
-      let* tphi = tac_phi D.TpCof in
+      let* tphi = T.Chk.run tac_phi D.TpCof in
       let* vphi = EM.lift_ev @@ Sem.eval_cof tphi in
       let+ phis, tacs = gather_cofibrations branches in
       (vphi :: phis), tac_tm :: tacs
 
   let split (branches : branch_tac list) : T.BChk.tac =
-    fun goal ->
+    T.BChk.make @@ fun goal ->
     let* phis, tacs = gather_cofibrations branches in
     let disj_phi = Cubical.Cof.join phis in
     let* _ = assert_true disj_phi in
@@ -295,17 +304,18 @@ struct
         split0
       | _ -> failwith "internal error"
     in
-    go phis tacs goal
+    T.BChk.run (go phis tacs) goal
 end
 
 module Prf =
 struct
   let formation tac_phi =
     T.Tp.make_virtual @@
-    let+ phi = tac_phi D.TpCof in
+    let+ phi = T.Chk.run tac_phi D.TpCof in
     S.TpPrf phi
 
   let intro =
+    T.BChk.make @@
     function
     | D.TpPrf phi, _, _ ->
       begin
@@ -331,20 +341,22 @@ struct
       S.Pi (base, nm, fam)
 
   let intro ?(ident = `Anon) (tac_body : T.var -> T.BChk.tac) : T.BChk.tac =
+    T.BChk.make @@
     function
     | D.Pi (base, _, fam), phi, phi_clo ->
       T.abstract ~ident base @@ fun var ->
       let* fib = EM.lift_cmp @@ Sem.inst_tp_clo fam @@ T.Var.con var in
-      let+ tm = tac_body var (fib, phi, D.un_lam @@ D.compose (D.Lam (`Anon, D.apply_to (T.Var.con var))) @@ D.Lam (`Anon, phi_clo)) in
+      let+ tm = T.BChk.run (tac_body var) (fib, phi, D.un_lam @@ D.compose (D.Lam (`Anon, D.apply_to (T.Var.con var))) @@ D.Lam (`Anon, phi_clo)) in
       S.Lam (ident, tm)
     | tp, _, _ ->
       EM.expected_connective `Pi tp
 
   let apply tac_fun tac_arg : T.Syn.tac =
-    let* tfun, tp = tac_fun in
+    T.Syn.make @@
+    let* tfun, tp = T.Syn.run tac_fun in
     match tp with
     | D.Pi (base, _, fam) ->
-      let* targ = tac_arg base in
+      let* targ = T.Chk.run tac_arg base in
       let+ fib =
         let* varg = EM.lift_ev @@ Sem.eval targ in
         EM.lift_cmp @@ Sem.inst_tp_clo fam varg
@@ -366,20 +378,22 @@ struct
       S.Sg (base, nm, fam)
 
   let intro (tac_fst : T.BChk.tac) (tac_snd : T.BChk.tac) : T.BChk.tac =
+    T.BChk.make @@
     function
     | D.Sg (base, _, fam), phi, phi_clo ->
-      let* tfst = tac_fst (base, phi, D.un_lam @@ D.compose D.fst @@ D.Lam (`Anon, phi_clo)) in
+      let* tfst = T.BChk.run tac_fst (base, phi, D.un_lam @@ D.compose D.fst @@ D.Lam (`Anon, phi_clo)) in
       let+ tsnd =
         let* vfst = EM.lift_ev @@ Sem.eval tfst in
         let* fib = EM.lift_cmp @@ Sem.inst_tp_clo fam vfst in
-        tac_snd (fib, phi, D.un_lam @@ D.compose D.snd @@ D.Lam (`Anon, phi_clo))
+        T.BChk.run tac_snd (fib, phi, D.un_lam @@ D.compose D.snd @@ D.Lam (`Anon, phi_clo))
       in
       S.Pair (tfst, tsnd)
     | tp , _, _ ->
       EM.expected_connective `Sg tp
 
   let pi1 tac : T.Syn.tac =
-    let* tpair, tp = tac in
+    T.Syn.make @@
+    let* tpair, tp = T.Syn.run tac in
     match tp with
     | D.Sg (base, _, _) ->
       EM.ret (S.Fst tpair, base)
@@ -388,7 +402,8 @@ struct
 
 
   let pi2 tac : T.Syn.tac =
-    let* tpair, tp = tac in
+    T.Syn.make @@
+    let* tpair, tp = T.Syn.run tac in
     match tp with
     | D.Sg (_, _, fam) ->
       let+ fib =
@@ -408,8 +423,9 @@ struct
     T.Tp.make @@
     EM.ret S.Univ
 
-  let univ_tac : T.Chk.tac -> T.Chk.tac =
+  let univ_tac : (D.tp -> S.t EM.m) -> T.Chk.tac =
     fun m ->
+    T.Chk.make @@
     function
     | D.Univ -> m D.Univ
     | tp ->
@@ -426,9 +442,9 @@ struct
   let circle : T.Chk.tac =
     univ_tac @@ fun _ -> EM.ret S.CodeCircle
 
-  let quantifier tac_base tac_fam =
+  let quantifier (tac_base : T.Chk.tac) (tac_fam : T.Chk.tac) =
     fun univ ->
-    let* base = tac_base univ in
+    let* base = T.Chk.run tac_base univ in
     let* vbase = EM.lift_ev @@ Sem.eval base in
     let* famtp =
       EM.lift_cmp @@
@@ -437,7 +453,7 @@ struct
       Splice.tp univ @@ fun univ ->
       Splice.term @@ TB.pi (TB.el base) @@ fun _ -> univ
     in
-    let+ fam = tac_fam famtp in
+    let+ fam = T.Chk.run tac_fam famtp in
     base, fam
 
   let pi tac_base tac_fam : T.Chk.tac =
@@ -455,12 +471,12 @@ struct
     univ_tac @@ fun univ ->
     let* tcof =
       let* tp_cof_fam = EM.lift_cmp @@ Sem.splice_tp @@ Splice.term @@ TB.cube n @@ fun _ -> TB.tp_cof in
-      EM.globally @@ tac_cof tp_cof_fam
+      EM.globally @@ T.Chk.run tac_cof tp_cof_fam
     in
     let* cof = EM.lift_ev @@ EvM.drop_all_cons @@ Sem.eval tcof in
     let* tfam =
       let* tp_fam = EM.lift_cmp @@ Sem.splice_tp @@ Splice.tp univ @@ fun univ -> Splice.term @@ TB.cube n @@ fun _ -> univ in
-      tac_fam tp_fam
+      T.Chk.run tac_fam tp_fam
     in
     let+ tbdry =
       let* fam = EM.lift_ev @@ Sem.eval tfam in
@@ -473,24 +489,24 @@ struct
         TB.pi (TB.tp_prf @@ TB.ap cof js) @@ fun _ ->
         TB.el @@ TB.ap fam js
       in
-      tac_bdry tp_bdry
+      T.Chk.run tac_bdry tp_bdry
     in
     S.CodeExt (n, tfam, `Global tcof, tbdry)
 
   let code_v (tac_dim : T.Chk.tac) (tac_pcode: T.Chk.tac) (tac_code : T.Chk.tac) (tac_pequiv : T.Chk.tac) : T.Chk.tac =
     univ_tac @@ fun _univ ->
-    let* r = tac_dim D.TpDim in
+    let* r = T.Chk.run tac_dim D.TpDim in
     let* vr : D.dim =
       let* vr_con = EM.lift_ev @@ Sem.eval r in
       EM.lift_cmp @@ Sem.con_to_dim vr_con
     in
     let* pcode =
       let tp_pcode = D.Pi (D.TpPrf (Cubical.Cof.eq vr Cubical.Dim.Dim0), `Anon, D.const_tp_clo D.Univ) in
-      tac_pcode tp_pcode
+      T.Chk.run tac_pcode tp_pcode
     in
-    let* code = tac_code D.Univ in
+    let* code = T.Chk.run tac_code D.Univ in
     let+ pequiv =
-      tac_pequiv @<<
+      T.Chk.run tac_pequiv @<<
       let* vpcode = EM.lift_ev @@ Sem.eval pcode in
       let* vcode = EM.lift_ev @@ Sem.eval code in
       EM.lift_cmp @@
@@ -499,7 +515,8 @@ struct
     in
     S.CodeV (r, pcode, code, pequiv)
 
-  let coe tac_fam tac_src tac_trg tac_tm : T.Syn.tac =
+  let coe (tac_fam : T.Chk.tac) (tac_src : T.Chk.tac) (tac_trg : T.Chk.tac) (tac_tm : T.Chk.tac) : T.Syn.tac =
+    T.Syn.make @@
     let* piuniv =
       EM.lift_cmp @@
       Sem.splice_tp @@
@@ -507,11 +524,11 @@ struct
       TB.pi TB.tp_dim @@ fun _i ->
       TB.univ
     in
-    let* fam = tac_fam piuniv in
-    let* src = tac_src D.TpDim in
-    let* trg = tac_trg D.TpDim in
+    let* fam = T.Chk.run tac_fam piuniv in
+    let* src = T.Chk.run tac_src D.TpDim in
+    let* trg = T.Chk.run tac_trg D.TpDim in
     let* fam_src = EM.lift_ev @@ Sem.eval_tp @@ S.El (S.Ap (fam, src)) in
-    let+ tm = tac_tm fam_src
+    let+ tm = T.Chk.run tac_tm fam_src
     and+ fam_trg = EM.lift_ev @@ Sem.eval_tp @@ S.El (S.Ap (fam, trg)) in
     S.Coe (fam, src, trg, tm), fam_trg
 
@@ -527,19 +544,21 @@ struct
     TB.pi (TB.tp_prf (TB.join [TB.eq i src; cof])) @@ fun _ ->
     vtp
 
-  let hcom tac_code tac_src tac_trg tac_cof tac_tm : T.Syn.tac =
-    let* code = tac_code D.Univ in
-    let* src = tac_src D.TpDim in
-    let* trg = tac_trg D.TpDim in
-    let* cof = tac_cof D.TpCof in
+  let hcom (tac_code : T.Chk.tac) (tac_src : T.Chk.tac) (tac_trg : T.Chk.tac) (tac_cof : T.Chk.tac) (tac_tm : T.Chk.tac) : T.Syn.tac =
+    T.Syn.make @@
+    let* code = T.Chk.run tac_code D.Univ in
+    let* src = T.Chk.run tac_src D.TpDim in
+    let* trg = T.Chk.run tac_trg D.TpDim in
+    let* cof = T.Chk.run tac_cof D.TpCof in
     let* vsrc = EM.lift_ev @@ Sem.eval src in
     let* vcof = EM.lift_ev @@ Sem.eval_cof cof in
     let* vtp = EM.lift_ev @@ Sem.eval_tp @@ S.El code in
     (* (i : dim) -> (_ : [i=src \/ cof]) -> A *)
-    let+ tm = tac_tm @<< hcom_bdy_tp vtp vsrc vcof in
+    let+ tm = T.Chk.run tac_tm @<< hcom_bdy_tp vtp vsrc vcof in
     S.HCom (code, src, trg, cof, tm), vtp
 
-  let com tac_fam tac_src tac_trg tac_cof tac_tm : T.Syn.tac =
+  let com (tac_fam : T.Chk.tac) (tac_src : T.Chk.tac) (tac_trg : T.Chk.tac) (tac_cof : T.Chk.tac) (tac_tm : T.Chk.tac) : T.Syn.tac =
+    T.Syn.make @@
     let* piuniv =
       EM.lift_cmp @@
       Sem.splice_tp @@
@@ -547,16 +566,16 @@ struct
       TB.pi TB.tp_dim @@ fun _i ->
       TB.univ
     in
-    let* fam = tac_fam piuniv in
-    let* src = tac_src D.TpDim in
-    let* trg = tac_trg D.TpDim in
-    let* cof = tac_cof D.TpCof in
+    let* fam = T.Chk.run tac_fam piuniv in
+    let* src = T.Chk.run tac_src D.TpDim in
+    let* trg = T.Chk.run tac_trg D.TpDim in
+    let* cof = T.Chk.run tac_cof D.TpCof in
     let* vfam = EM.lift_ev @@ Sem.eval fam in
     let* vsrc = EM.lift_ev @@ Sem.eval src in
     let* vcof = EM.lift_ev @@ Sem.eval_cof cof in
     (* (i : dim) -> (_ : [i=src \/ cof]) -> A i *)
     let+ tm =
-      tac_tm @<<
+      T.Chk.run tac_tm @<<
       EM.lift_cmp @@
       Sem.splice_tp @@
       Splice.con vfam @@ fun vfam ->
@@ -574,7 +593,7 @@ module El =
 struct
   let formation tac =
     T.Tp.make @@
-    let+ tm = tac D.Univ in
+    let+ tm = T.Chk.run tac D.Univ in
     S.El tm
 
   let dest_el tp =
@@ -585,13 +604,14 @@ struct
       EM.expected_connective `El tp
 
   let intro tac =
-    fun (tp, phi, clo) ->
+    T.BChk.make @@ fun (tp, phi, clo) ->
     let* unfolded = dest_el tp in
-    let+ tm = tac (unfolded, phi, D.un_lam @@ D.compose D.el_out @@ D.Lam (`Anon, clo)) in
+    let+ tm = T.BChk.run tac (unfolded, phi, D.un_lam @@ D.compose D.el_out @@ D.Lam (`Anon, clo)) in
     S.ElIn tm
 
   let elim tac =
-    let* tm, tp = tac in
+    T.Syn.make @@
+    let* tm, tp = T.Syn.run tac in
     let+ unfolded = dest_el tp in
     S.ElOut tm, unfolded
 end
@@ -600,6 +620,7 @@ end
 module ElV =
 struct
   let intro (tac_part : T.BChk.tac) (tac_tot : T.BChk.tac) : T.BChk.tac =
+    T.BChk.make @@
     function
     | D.ElUnstable (`V (r, pcode, code, pequiv)), phi, clo ->
       let* part =
@@ -619,7 +640,7 @@ struct
           TB.lam @@ fun _ ->
           TB.ap clo [TB.prf]
         in
-        tac_part (tp_part, phi, D.un_lam bdry_fn)
+        T.BChk.run tac_part (tp_part, phi, D.un_lam bdry_fn)
       in
       let* tot =
         let* tp = EM.lift_cmp @@ Sem.do_el code in
@@ -639,7 +660,7 @@ struct
             [TB.eq r TB.dim0, TB.ap (TB.Equiv.equiv_fwd (TB.ap pequiv [TB.prf])) [TB.ap part [TB.prf]];
              phi, TB.vproj r pcode code pequiv @@ TB.ap clo [TB.prf]]
         in
-        tac_tot (tp, Cubical.Cof.join [Cubical.Cof.eq r Cubical.Dim.Dim0; phi], D.un_lam bdry_fn)
+        T.BChk.run tac_tot (tp, Cubical.Cof.join [Cubical.Cof.eq r Cubical.Dim.Dim0; phi], D.un_lam bdry_fn)
       in
       let* tr = EM.quote_dim r in
       let+ t_pequiv =
@@ -654,7 +675,8 @@ struct
       EM.expected_connective `ElV tp
 
   let elim (tac_v : T.Syn.tac) : T.Syn.tac =
-    let* tm, tp = tac_v in
+    T.Syn.make @@
+    let* tm, tp = T.Syn.run tac_v in
     match tp with
     | D.ElUnstable (`V (r, pcode, code, pequiv)) ->
       let* tr = EM.quote_dim r in
@@ -677,6 +699,7 @@ end
 module ElHCom =
 struct
   let intro (tac_walls : T.BChk.tac) (tac_cap : T.BChk.tac) : T.BChk.tac =
+    T.BChk.make @@
     function
     | D.ElUnstable (`HCom (r, r', phi, bdy)), psi, psi_clo ->
       let* twalls =
@@ -695,7 +718,7 @@ struct
           TB.lam @@ fun _ -> (* [phi] *)
           TB.ap psi_clo [TB.prf]
         in
-        tac_walls (tp_walls, psi, D.un_lam bdry_fn)
+        T.BChk.run tac_walls (tp_walls, psi, D.un_lam bdry_fn)
       in
       let+ tcap =
         let* walls = EM.lift_ev @@ Sem.eval twalls in
@@ -720,7 +743,7 @@ struct
             [psi, TB.cap r r' phi bdy @@ TB.ap psi_clo [TB.prf];
              phi, TB.coe (TB.lam ~ident:(`Machine "i") @@ fun i -> TB.ap bdy [i; TB.prf]) r' r (TB.ap walls [TB.prf])]
         in
-        tac_cap (tp_cap, Cubical.Cof.join [phi; psi], D.un_lam bdry_fn)
+        T.BChk.run tac_cap (tp_cap, Cubical.Cof.join [phi; psi], D.un_lam bdry_fn)
       and+ tr = EM.quote_dim r
       and+ tr' = EM.quote_dim r'
       and+ tphi = EM.quote_cof phi in
@@ -730,7 +753,8 @@ struct
       EM.expected_connective `ElHCom tp
 
   let elim (tac_box : T.Syn.tac) : T.Syn.tac =
-    let* box, box_tp = tac_box in
+    T.Syn.make @@
+    let* box, box_tp = T.Syn.run tac_box in
     match box_tp with
     | D.ElUnstable (`HCom (r, r', phi, bdy)) ->
       let+ tr = EM.quote_dim r
@@ -754,6 +778,7 @@ struct
 
 
   let lookup_var id : T.Syn.tac =
+    T.Syn.make @@
     let* res = EM.resolve id in
     match res with
     | `Local ix ->
@@ -770,6 +795,7 @@ struct
     S.Var ix, tp
 
   let level lvl =
+    T.Syn.make @@
     let* env = EM.read in
     let ix = ElabEnv.size env - lvl - 1 in
     index ix
@@ -787,6 +813,7 @@ struct
         intros cells tac
     in
 
+    T.Chk.make @@
     fun tp ->
       let* env = EM.read in
       let* lvl =
@@ -807,7 +834,7 @@ struct
         in
         let* def =
           let prefix = ListUtil.take lvl cells_fwd in
-          let* tm = intros prefix tac global_tp in
+          let* tm = global_tp |> T.Chk.run @@ intros prefix tac in
           EM.lift_ev @@ Sem.eval tm
         in
         let* sym = EM.add_global `Anon global_tp @@ Some def in
@@ -817,9 +844,9 @@ struct
 
 
 
-  let let_ ?(ident = `Anon) tac_def (tac_bdy : T.var -> T.BChk.tac) : T.BChk.tac =
-    fun goal ->
-    let* tdef, tp_def = tac_def in
+  let let_ ?(ident = `Anon) (tac_def : T.Syn.tac) (tac_bdy : T.var -> T.BChk.tac) : T.BChk.tac =
+    T.BChk.make @@ fun goal ->
+    let* tdef, tp_def = T.Syn.run tac_def in
     let* vdef = EM.lift_ev @@ Sem.eval tdef in
     let* tbdy =
       let* const_vdef =
@@ -827,12 +854,13 @@ struct
         Splice.term @@ TB.lam @@ fun _ -> vdef
       in
       T.abstract ~ident (D.Sub (tp_def, Cubical.Cof.top, D.un_lam const_vdef)) @@ fun var ->
-      tac_bdy var goal
+      T.BChk.run (tac_bdy var) goal
     in
     EM.ret @@ S.Let (S.SubIn tdef, ident, tbdy)
 
-  let let_syn ?(ident = `Anon) tac_def (tac_bdy : T.var -> T.Syn.tac) : T.Syn.tac =
-    let* tdef, tp_def = tac_def in
+  let let_syn ?(ident = `Anon) (tac_def : T.Syn.tac) (tac_bdy : T.var -> T.Syn.tac) : T.Syn.tac =
+    T.Syn.make @@
+    let* tdef, tp_def = T.Syn.run tac_def in
     let* vdef = EM.lift_ev @@ Sem.eval tdef in
     let* tbdy, tbdytp =
       let* const_vdef =
@@ -840,7 +868,7 @@ struct
         Splice.term @@ TB.lam @@ fun _ -> vdef
       in
       T.abstract ~ident (D.Sub (tp_def, Cubical.Cof.top, D.un_lam const_vdef)) @@ fun var ->
-      let* tbdy, bdytp = tac_bdy var in
+      let* tbdy, bdytp = T.Syn.run @@ tac_bdy var in
       let* tbdytp = EM.quote_tp bdytp in
       EM.ret (tbdy, tbdytp)
     in
@@ -866,22 +894,24 @@ struct
     | n -> S.Suc (int_to_term (n - 1))
 
   let literal n : T.Chk.tac =
+    T.Chk.make @@
     fun tp ->
     let+ () = assert_nat tp in
     int_to_term n
 
   let suc tac : T.Chk.tac =
+    T.Chk.make @@
     fun tp ->
     let* () = assert_nat tp in
-    let+ t = tac tp in
+    let+ t = T.Chk.run tac tp in
     S.Suc t
 
-  let elim (tac_mot : T.Chk.tac) (tac_case_zero : T.Chk.tac) (tac_case_suc : T.Chk.tac) tac_scrut : T.Syn.tac =
+  let elim (tac_mot : T.Chk.tac) (tac_case_zero : T.Chk.tac) (tac_case_suc : T.Chk.tac) (tac_scrut : T.Syn.tac) : T.Syn.tac =
+    T.Syn.make @@
     EM.push_problem "elim" @@
-    let* tscrut, nattp = tac_scrut in
-    let* () = assert_nat nattp in
-    let* tmot =
-      tac_mot @<<
+    let* tscrut, nattp = T.Syn.run tac_scrut in
+    let* () = assert_nat nattp in let* tmot =
+      T.Chk.run tac_mot @<<
       EM.lift_cmp @@ Sem.splice_tp @@ Splice.term @@
       TB.pi TB.nat @@ fun _ -> TB.univ
     in
@@ -890,7 +920,7 @@ struct
     let* tcase_zero =
       let* code = EM.lift_cmp @@ Sem.do_ap vmot D.Zero in
       let* tp = EM.lift_cmp @@ Sem.do_el code in
-      tac_case_zero tp
+      T.Chk.run tac_case_zero tp
     in
 
     let* tcase_suc =
@@ -902,7 +932,7 @@ struct
         TB.pi (TB.el (TB.ap mot [x])) @@ fun _ih ->
         TB.el @@ TB.ap mot [TB.suc x]
       in
-      tac_case_suc suc_tp
+      T.Chk.run tac_case_suc suc_tp
     in
 
     let+ fib_scrut =
@@ -927,22 +957,23 @@ struct
     | tp -> EM.expected_connective `Circle tp
 
   let base =
-    fun tp ->
+    T.Chk.make @@ fun tp ->
     let+ () = assert_circle tp in
     S.Base
 
   let loop tac : T.Chk.tac =
-    fun tp ->
+    T.Chk.make @@ fun tp ->
     let* () = assert_circle tp in
-    let+ r = tac D.TpDim in
+    let+ r = T.Chk.run tac D.TpDim in
     S.Loop r
 
-  let elim (tac_mot : T.Chk.tac) (tac_case_base : T.Chk.tac) (tac_case_loop : T.Chk.tac) tac_scrut : T.Syn.tac =
+  let elim (tac_mot : T.Chk.tac) (tac_case_base : T.Chk.tac) (tac_case_loop : T.Chk.tac) (tac_scrut : T.Syn.tac) : T.Syn.tac =
+    T.Syn.make @@
     EM.push_problem "elim" @@
-    let* tscrut, circletp = tac_scrut in
+    let* tscrut, circletp = T.Syn.run tac_scrut in
     let* () = assert_circle circletp in
     let* tmot =
-      tac_mot @<<
+      T.Chk.run tac_mot @<<
       EM.lift_cmp @@ Sem.splice_tp @@ Splice.term @@
       TB.pi TB.circle @@ fun _ -> TB.univ
     in
@@ -951,7 +982,7 @@ struct
     let* tcase_base =
       let* code = EM.lift_cmp @@ Sem.do_ap vmot D.Base in
       let* tp = EM.lift_cmp @@ Sem.do_el code in
-      tac_case_base tp
+      T.Chk.run tac_case_base tp
     in
 
     let* tcase_loop =
@@ -962,7 +993,7 @@ struct
         TB.pi TB.tp_dim @@ fun x ->
         TB.el @@ TB.ap mot [TB.loop x]
       in
-      tac_case_loop loop_tp
+      T.Chk.run tac_case_loop loop_tp
     in
 
     let+ fib_scrut =
@@ -978,27 +1009,34 @@ end
 module Tactic =
 struct
   let match_goal tac =
+    T.Chk.make @@
     fun goal ->
       let* tac = tac goal in
-      tac goal
+      T.Chk.run tac goal
 
-  let bmatch_goal = match_goal
+  let bmatch_goal (tac : _ -> T.BChk.tac EM.m) : T.BChk.tac =
+    T.BChk.make @@
+    fun goal ->
+      let* tac = tac goal in
+      T.BChk.run tac goal
 
   let rec elim_implicit_connectives : T.Syn.tac -> T.Syn.tac =
     fun tac ->
-    let* tm, tp = T.Syn.whnf tac in
+    T.Syn.make @@
+    let* tm, tp = T.Syn.run @@ T.Syn.whnf tac in
     match tp with
     | D.Sub _ ->
-      elim_implicit_connectives @@ Sub.elim @@ EM.ret (tm, tp)
+      T.Syn.run @@ elim_implicit_connectives @@ Sub.elim @@ T.Syn.make @@ EM.ret (tm, tp)
+        (* The above code only makes sense because I know that the argument to Sub.elim will not be called under a further binder *)
     | D.ElStable _ ->
-      elim_implicit_connectives @@ El.elim @@ EM.ret (tm, tp)
+      T.Syn.run @@ elim_implicit_connectives @@ El.elim @@ T.Syn.make @@ EM.ret (tm, tp)
     | _ ->
       EM.ret (tm, tp)
 
   let rec intro_implicit_connectives : T.BChk.tac -> T.BChk.tac =
     fun tac ->
     T.BChk.whnf @@
-    match_goal @@ function
+    bmatch_goal @@ function
     | D.Sub _, _, _ ->
       EM.ret @@ Sub.intro @@ intro_implicit_connectives tac
     | D.ElStable _, _, _ ->
@@ -1026,8 +1064,9 @@ struct
         None
 
     let elim (mot : T.Chk.tac) (cases : case_tac list) (scrut : T.Syn.tac) : T.Syn.tac =
-      let* tscrut, ind_tp = scrut in
-      let scrut = EM.ret (tscrut, ind_tp) in
+      T.Syn.make @@
+      let* tscrut, ind_tp = T.Syn.run scrut in
+      let scrut = T.Syn.make @@ EM.ret (tscrut, ind_tp) (* only makes sense because because I know 'scrut' won't be used under some binder *) in
       match ind_tp, mot with
       | D.Nat, mot ->
         let* tac_zero : T.Chk.tac =
@@ -1045,7 +1084,7 @@ struct
           | Some _ -> EM.elab_err Err.MalformedCase
           | None -> EM.ret @@ Hole.unleash_hole (Some "suc") `Rigid
         in
-        Nat.elim mot tac_zero (T.Chk.bchk tac_suc) scrut
+        T.Syn.run @@ Nat.elim mot tac_zero (T.Chk.bchk tac_suc) scrut
       | D.Circle, mot ->
         let* tac_base : T.Chk.tac =
           match find_case "base" cases with
@@ -1060,7 +1099,7 @@ struct
           | Some _ -> EM.elab_err Err.MalformedCase
           | None -> EM.ret @@ Hole.unleash_hole (Some "loop") `Rigid
         in
-        Circle.elim mot tac_base (T.Chk.bchk tac_loop) scrut
+        T.Syn.run @@ Circle.elim mot tac_base (T.Chk.bchk tac_loop) scrut
       | _ ->
         EM.with_pp @@ fun ppenv ->
         let* tp = EM.quote_tp ind_tp in
@@ -1078,13 +1117,13 @@ struct
         EM.elab_err @@ Err.ExpectedSimpleInductive (ppenv, tp)
 
     let lam_elim cases : T.BChk.tac =
-      match_goal @@ fun (tp, _, _) ->
+      bmatch_goal @@ fun (tp, _, _) ->
       match tp with
       | D.Pi (_, _, fam) ->
         let mot_tac : T.Chk.tac =
           T.Chk.bchk @@
           Pi.intro @@ fun var -> (* of inductive type *)
-          T.BChk.chk @@ fun _goal ->
+          T.BChk.chk @@ T.Chk.make @@ fun _goal ->
           let* fib = EM.lift_cmp @@ Sem.inst_tp_clo fam @@ D.ElIn (T.Var.con var) in
           let* tfib = EM.quote_tp fib in
           match tfib with

--- a/src/lib/Refiner.ml
+++ b/src/lib/Refiner.ml
@@ -1015,7 +1015,7 @@ struct
   let rec elim_implicit_connectives : T.Syn.tac -> T.Syn.tac =
     fun tac ->
     T.Syn.rule @@
-    let* tm, tp = T.Syn.run @@ T.Syn.whnf tac in
+    let* tm, tp = T.Syn.run @@ T.Syn.whnf ~style:`UnfoldAll tac in
     match tp with
     | D.Sub _ ->
       T.Syn.run @@ elim_implicit_connectives @@ Sub.elim @@ T.Syn.rule @@ EM.ret (tm, tp)
@@ -1027,7 +1027,7 @@ struct
 
   let rec intro_implicit_connectives : T.Chk.tac -> T.Chk.tac =
     fun tac ->
-    T.Chk.whnf @@
+    T.Chk.whnf ~style:`UnfoldAll @@
     match_goal @@ function
     | D.Sub _, _, _ ->
       EM.ret @@ Sub.intro @@ intro_implicit_connectives tac

--- a/src/lib/Refiner.ml
+++ b/src/lib/Refiner.ml
@@ -1038,7 +1038,7 @@ struct
 
   let rec intro_subtypes : T.Chk.tac -> T.Chk.tac =
     fun tac ->
-    T.Chk.whnf @@
+    T.Chk.whnf ~style:`UnfoldNone @@
     match_goal @@ function
     | D.Sub _, _, _ ->
       EM.ret @@ Sub.intro @@ intro_subtypes tac

--- a/src/lib/Refiner.mli
+++ b/src/lib/Refiner.mli
@@ -125,13 +125,13 @@ module Structural : sig
 end
 
 module Tactic : sig
+  val intro_subtypes : Chk.tac -> Chk.tac
   val intro_implicit_connectives : Chk.tac -> Chk.tac
   val elim_implicit_connectives : Syn.tac -> Syn.tac
 
   val tac_nary_quantifier : ('a, 'b) quantifier -> (Ident.t * 'a) list -> 'b -> 'b
 
-  val match_goal : (D.tp -> Chk.tac EM.m) -> Chk.tac
-  val bmatch_goal : (D.tp * D.cof * D.tm_clo -> Chk.tac EM.m) -> Chk.tac
+  val match_goal : (D.tp * D.cof * D.tm_clo -> Chk.tac EM.m) -> Chk.tac
 
   module Elim : sig
     type case_tac = CS.pat * Chk.tac

--- a/src/lib/Refiner.mli
+++ b/src/lib/Refiner.mli
@@ -11,39 +11,39 @@ open Tactic
 type ('a, 'b) quantifier = 'a -> Ident.t * (var -> 'b) -> 'b
 
 module Hole : sig
-  val unleash_hole : string option -> [`Flex | `Rigid] -> BChk.tac
-  val unleash_tp_hole : string option -> [`Flex | `Rigid] -> tp_tac
+  val unleash_hole : string option -> [`Flex | `Rigid] -> Chk.tac
+  val unleash_tp_hole : string option -> [`Flex | `Rigid] -> Tp.tac
   val unleash_syn_hole : string option -> [`Flex | `Rigid] -> Syn.tac
 end
 
 module Goal : sig
-  val formation : string option -> tp_tac -> tp_tac
+  val formation : string option -> Tp.tac -> Tp.tac
 end
 
 module Dim : sig
-  val formation : tp_tac
+  val formation : Tp.tac
   val dim0 : Chk.tac
   val dim1 : Chk.tac
   val literal : int -> Chk.tac
 end
 
 module Cof : sig
-  val formation : tp_tac
+  val formation : Tp.tac
   val eq : Chk.tac -> Chk.tac -> Chk.tac
   val join : Chk.tac list -> Chk.tac
   val meet : Chk.tac list -> Chk.tac
   val boundary : Chk.tac -> Chk.tac
 
-  val split : (Chk.tac * (var -> BChk.tac)) list -> BChk.tac
+  val split : (Chk.tac * (var -> Chk.tac)) list -> Chk.tac
 end
 
 module Prf : sig
-  val formation : Chk.tac -> tp_tac
-  val intro : BChk.tac
+  val formation : Chk.tac -> Tp.tac
+  val intro : Chk.tac
 end
 
 module Univ : sig
-  val formation : tp_tac
+  val formation : Tp.tac
   val univ : Chk.tac
   val nat : Chk.tac
   val circle : Chk.tac
@@ -57,43 +57,43 @@ module Univ : sig
 end
 
 module El : sig
-  val formation : Chk.tac -> tp_tac
-  val intro : BChk.tac -> BChk.tac
+  val formation : Chk.tac -> Tp.tac
+  val intro : Chk.tac -> Chk.tac
   val elim : Syn.tac -> Syn.tac
 end
 
 module ElV : sig
-  val intro : BChk.tac -> BChk.tac -> BChk.tac
+  val intro : Chk.tac -> Chk.tac -> Chk.tac
   val elim : Syn.tac -> Syn.tac
 end
 
 module ElHCom : sig
-  val intro : BChk.tac -> BChk.tac -> BChk.tac
+  val intro : Chk.tac -> Chk.tac -> Chk.tac
   val elim : Syn.tac -> Syn.tac
 end
 
 module Pi : sig
-  val formation : (tp_tac, tp_tac) quantifier
-  val intro : ?ident:Ident.t -> (var -> BChk.tac) -> BChk.tac
+  val formation : (Tp.tac, Tp.tac) quantifier
+  val intro : ?ident:Ident.t -> (var -> Chk.tac) -> Chk.tac
   val apply : Syn.tac -> Chk.tac -> Syn.tac
 end
 
 module Sg : sig
-  val formation : (tp_tac, tp_tac) quantifier
-  val intro : BChk.tac -> BChk.tac -> BChk.tac
+  val formation : (Tp.tac, Tp.tac) quantifier
+  val intro : Chk.tac -> Chk.tac -> Chk.tac
 
   val pi1 : Syn.tac -> Syn.tac
   val pi2 : Syn.tac -> Syn.tac
 end
 
 module Sub : sig
-  val formation : tp_tac -> Chk.tac -> (var -> Chk.tac) -> tp_tac
-  val intro : BChk.tac -> BChk.tac
+  val formation : Tp.tac -> Chk.tac -> (var -> Chk.tac) -> Tp.tac
+  val intro : Chk.tac -> Chk.tac
   val elim : Syn.tac -> Syn.tac
 end
 
 module Nat : sig
-  val formation : tp_tac
+  val formation : Tp.tac
   val literal : int -> Chk.tac
   val suc : Chk.tac -> Chk.tac
   val elim
@@ -105,7 +105,7 @@ module Nat : sig
 end
 
 module Circle : sig
-  val formation : tp_tac
+  val formation : Tp.tac
   val base : Chk.tac
   val loop : Chk.tac -> Chk.tac
   val elim
@@ -117,7 +117,7 @@ module Circle : sig
 end
 
 module Structural : sig
-  val let_ : ?ident:Ident.t -> Syn.tac -> (var -> BChk.tac) -> BChk.tac
+  val let_ : ?ident:Ident.t -> Syn.tac -> (var -> Chk.tac) -> Chk.tac
   val let_syn : ?ident:Ident.t -> Syn.tac -> (var -> Syn.tac) -> Syn.tac
   val lookup_var : Ident.t -> Syn.tac
   val level : int -> Syn.tac
@@ -125,13 +125,13 @@ module Structural : sig
 end
 
 module Tactic : sig
-  val intro_implicit_connectives : BChk.tac -> BChk.tac
+  val intro_implicit_connectives : Chk.tac -> Chk.tac
   val elim_implicit_connectives : Syn.tac -> Syn.tac
 
   val tac_nary_quantifier : ('a, 'b) quantifier -> (Ident.t * 'a) list -> 'b -> 'b
 
   val match_goal : (D.tp -> Chk.tac EM.m) -> Chk.tac
-  val bmatch_goal : (D.tp * D.cof * D.tm_clo -> BChk.tac EM.m) -> BChk.tac
+  val bmatch_goal : (D.tp * D.cof * D.tm_clo -> Chk.tac EM.m) -> Chk.tac
 
   module Elim : sig
     type case_tac = CS.pat * Chk.tac
@@ -144,6 +144,6 @@ module Tactic : sig
 
     val lam_elim
       : case_tac list
-      -> BChk.tac
+      -> Chk.tac
   end
 end

--- a/src/lib/Semantics.mli
+++ b/src/lib/Semantics.mli
@@ -15,9 +15,9 @@ type 'a whnf = [`Done | `Reduce of 'a]
 val whnf_con : style:whnf_style -> D.con -> D.con whnf compute
 val whnf_cut : style:whnf_style -> D.cut -> D.con whnf compute
 val whnf_hd : style:whnf_style -> D.hd -> D.con whnf compute
-val whnf_tp : D.tp -> D.tp whnf compute
+val whnf_tp : style:whnf_style -> D.tp -> D.tp whnf compute
 
-val whnf_tp_ : D.tp -> D.tp compute
+val whnf_tp_ : style:whnf_style -> D.tp -> D.tp compute
 
 val normalize_cof : D.cof -> D.cof compute
 

--- a/src/lib/Syntax.ml
+++ b/src/lib/Syntax.ml
@@ -456,6 +456,8 @@ and pp_atomic env fmt tm =
   | Var _ | Global _ | Pair _ | CofSplit _ | Dim0 | Dim1 | Cof (Cof.Meet [] | Cof.Join []) | CodeNat | CodeCircle | CodeUniv
   | Zero | Base | Prf ->
     pp env fmt tm
+  | Suc _ as tm when Option.is_some (to_numeral tm) ->
+    pp env fmt tm
   | (SubIn tm | SubOut tm | GoalRet tm | GoalProj tm | ElIn tm | ElOut tm) when not debug_mode ->
     pp_atomic env fmt tm
   | _ ->

--- a/src/lib/Tactic.ml
+++ b/src/lib/Tactic.ml
@@ -141,7 +141,7 @@ struct
 
   let whnf tac =
     rule @@ fun tp ->
-    EM.lift_cmp @@ Sem.whnf_tp tp |>>
+    EM.lift_cmp @@ Sem.whnf_tp ~style:`UnfoldAll tp |>>
     function
     | `Done -> run tac tp
     | `Reduce tp -> run tac tp
@@ -170,7 +170,7 @@ struct
 
   let whnf tac =
     let* tm, tp = tac in
-    EM.lift_cmp @@ Sem.whnf_tp tp |>>
+    EM.lift_cmp @@ Sem.whnf_tp ~style:`UnfoldAll tp |>>
     function
     | `Done -> EM.ret (tm, tp)
     | `Reduce tp' -> EM.ret (tm, tp')

--- a/src/lib/Tactic.ml
+++ b/src/lib/Tactic.ml
@@ -12,7 +12,7 @@ module type Tactic =
 sig
   type tac
   val update_span : LexingUtil.span option -> tac -> tac
-  val whnf : ?style:Semantics.whnf_style -> tac -> tac
+  val whnf : style:Semantics.whnf_style -> tac -> tac
 end
 
 module Tp : sig
@@ -53,7 +53,7 @@ struct
   let update_span loc =
     map @@ EM.update_span loc
 
-  let whnf ?style:_ tac =
+  let whnf ~style:_ tac =
     tac
 end
 
@@ -135,7 +135,7 @@ struct
     let+ () = EM.equate_tp tp tp' in
     tm
 
-  let whnf ?(style = `UnfoldAll) tac =
+  let whnf ~style tac =
     brule @@ fun (tp, phi, clo) ->
     EM.lift_cmp @@ Sem.whnf_tp ~style tp |>>
     function
@@ -164,7 +164,7 @@ struct
     let+ tm = Chk.run tac_tm vtp in
     tm, vtp
 
-  let whnf ?(style = `UnfoldAll) tac =
+  let whnf ~style tac =
     let* tm, tp = tac in
     EM.lift_cmp @@ Sem.whnf_tp ~style tp |>>
     function

--- a/src/lib/Tactic.ml
+++ b/src/lib/Tactic.ml
@@ -140,8 +140,7 @@ struct
     tm
 
   let whnf tac =
-    rule @@
-    fun tp ->
+    rule @@ fun tp ->
     EM.lift_cmp @@ Sem.whnf_tp tp |>>
     function
     | `Done -> run tac tp

--- a/src/lib/Tactic.ml
+++ b/src/lib/Tactic.ml
@@ -75,11 +75,19 @@ let abstract : ?ident:Ident.t -> D.tp -> (Var.tac -> 'a EM.m) -> 'a EM.m =
 
 module rec Chk : sig
   include Tactic with type tac = D.tp -> S.t EM.m
+
+  val make : (D.tp -> S.t EM.m) -> tac
+  val run : tac -> D.tp -> S.t EM.m
+
   val bchk : BChk.tac -> tac
   val syn : Syn.tac -> tac
 end =
 struct
   type tac = D.tp -> S.t EM.m
+
+  let run tac = tac
+  let make tac = tac
+
   let update_span loc tac tp =
     EM.update_span loc @@ tac tp
 
@@ -104,11 +112,19 @@ end
 
 and BChk : sig
   include Tactic with type tac = D.tp * D.cof * D.tm_clo -> S.t EM.m
+
+  val make : (D.tp * D.cof * D.tm_clo -> S.t EM.m) -> tac
+  val run : tac -> D.tp * D.cof * D.tm_clo -> S.t EM.m
+
   val chk : Chk.tac -> tac
   val syn : Syn.tac -> tac
 end =
 struct
   type tac = D.tp * D.cof * D.tm_clo -> S.t EM.m
+
+  let run tac = tac
+  let make tac = tac
+
   let update_span loc tac goal =
     EM.update_span loc @@ tac goal
 
@@ -136,10 +152,16 @@ end
 
 and Syn : sig
   include Tactic with type tac = (S.t * D.tp) EM.m
+  val make : (S.t * D.tp) EM.m -> tac
+  val run : tac -> (S.t * D.tp) EM.m
   val ann : Chk.tac -> Tp.tac -> tac
 end =
 struct
   type tac = (S.t * D.tp) EM.m
+
+  let make tac = tac
+  let run tac = tac
+
   let update_span loc =
     EM.update_span loc
 

--- a/src/lib/Tactic.ml
+++ b/src/lib/Tactic.ml
@@ -12,7 +12,7 @@ module type Tactic =
 sig
   type tac
   val update_span : LexingUtil.span option -> tac -> tac
-  val whnf : tac -> tac
+  val whnf : ?style:Semantics.whnf_style -> tac -> tac
 end
 
 module Tp : sig
@@ -53,7 +53,8 @@ struct
   let update_span loc =
     map @@ EM.update_span loc
 
-  let whnf tac = tac
+  let whnf ?style:_ tac =
+    tac
 end
 
 module rec Var : sig
@@ -134,9 +135,9 @@ struct
     let+ () = EM.equate_tp tp tp' in
     tm
 
-  let whnf tac =
+  let whnf ?(style = `UnfoldAll) tac =
     brule @@ fun (tp, phi, clo) ->
-    EM.lift_cmp @@ Sem.whnf_tp ~style:`UnfoldAll tp |>>
+    EM.lift_cmp @@ Sem.whnf_tp ~style tp |>>
     function
     | `Done -> brun tac (tp, phi, clo)
     | `Reduce tp -> brun tac (tp, phi, clo)
@@ -163,9 +164,9 @@ struct
     let+ tm = Chk.run tac_tm vtp in
     tm, vtp
 
-  let whnf tac =
+  let whnf ?(style = `UnfoldAll) tac =
     let* tm, tp = tac in
-    EM.lift_cmp @@ Sem.whnf_tp ~style:`UnfoldAll tp |>>
+    EM.lift_cmp @@ Sem.whnf_tp ~style tp |>>
     function
     | `Done -> EM.ret (tm, tp)
     | `Reduce tp' -> EM.ret (tm, tp')

--- a/src/lib/Tactic.ml
+++ b/src/lib/Tactic.ml
@@ -119,7 +119,6 @@ struct
 
   let rule tac = Chk tac
   let brule tac = BChk tac
-  let make tac = Chk tac
 
   let update_span loc =
     function

--- a/src/lib/Tactic.ml
+++ b/src/lib/Tactic.ml
@@ -135,11 +135,11 @@ struct
     tm
 
   let whnf tac =
-    rule @@ fun tp ->
+    brule @@ fun (tp, phi, clo) ->
     EM.lift_cmp @@ Sem.whnf_tp ~style:`UnfoldAll tp |>>
     function
-    | `Done -> run tac tp
-    | `Reduce tp -> run tac tp
+    | `Done -> brun tac (tp, phi, clo)
+    | `Reduce tp -> brun tac (tp, phi, clo)
 end
 
 and Syn : sig

--- a/src/lib/Tactic.ml
+++ b/src/lib/Tactic.ml
@@ -88,7 +88,6 @@ and Chk : sig
   val run : tac -> D.tp -> S.t EM.m
   val brun : tac -> D.tp * D.cof * D.tm_clo -> S.t EM.m
 
-  val bchk : Chk.tac -> tac
   val syn : Syn.tac -> tac
 end =
 struct
@@ -128,10 +127,6 @@ struct
     | BChk tac ->
       brule @@ fun goal ->
       EM.update_span loc @@ tac goal
-
-  let bchk : Chk.tac -> tac =
-    fun btac ->
-    brule @@ Chk.brun btac
 
   let syn (tac : Syn.tac) : tac =
     rule @@ fun tp ->

--- a/src/lib/Tactic.mli
+++ b/src/lib/Tactic.mli
@@ -8,7 +8,7 @@ module type Tactic =
 sig
   type tac
   val update_span : LexingUtil.span option -> tac -> tac
-  val whnf : ?style:Semantics.whnf_style -> tac -> tac
+  val whnf : style:Semantics.whnf_style -> tac -> tac
 end
 
 

--- a/src/lib/Tactic.mli
+++ b/src/lib/Tactic.mli
@@ -8,7 +8,7 @@ module type Tactic =
 sig
   type tac
   val update_span : LexingUtil.span option -> tac -> tac
-  val whnf : tac -> tac
+  val whnf : ?style:Semantics.whnf_style -> tac -> tac
 end
 
 

--- a/src/lib/Tactic.mli
+++ b/src/lib/Tactic.mli
@@ -17,10 +17,10 @@ module Tp :
 sig
   include Tactic
 
-  val make : S.tp EM.m -> tac
+  val rule : S.tp EM.m -> tac
 
   (** A "virtual type" is one that is only permitted to appear as the domain of a pi type *)
-  val make_virtual : S.tp EM.m -> tac
+  val virtual_rule : S.tp EM.m -> tac
 
   (** Only succeeds for non-virtual types *)
   val run : tac -> S.tp EM.m
@@ -45,7 +45,7 @@ end
 and Syn :
 sig
   include Tactic
-  val make : (S.t * D.tp) EM.m -> tac
+  val rule : (S.t * D.tp) EM.m -> tac
   val run : tac -> (S.t * D.tp) EM.m
   val ann : Chk.tac -> Tp.tac -> tac
 end

--- a/src/lib/Tactic.mli
+++ b/src/lib/Tactic.mli
@@ -11,6 +11,7 @@ sig
   val whnf : tac -> tac
 end
 
+
 (* general types *)
 module Tp :
 sig
@@ -32,7 +33,10 @@ end
 
 module rec Chk :
 sig
-  include Tactic with type tac = D.tp -> S.t EM.m
+  include Tactic
+
+  val make : (D.tp -> S.t EM.m) -> tac
+  val run : tac -> D.tp -> S.t EM.m
 
   (** Converts a boundary-checking tactic to a checking tactic by change of base. *)
   val bchk : BChk.tac -> tac
@@ -40,7 +44,10 @@ sig
 end
 and BChk :
 sig
-  include Tactic with type tac = D.tp * D.cof * D.tm_clo -> S.t EM.m
+  include Tactic
+
+  val make : (D.tp * D.cof * D.tm_clo -> S.t EM.m) -> tac
+  val run : tac -> D.tp * D.cof * D.tm_clo -> S.t EM.m
 
   (** Converts a checking tactic to a boundary-checking tactic by a synchronous check. *)
   val chk : Chk.tac -> tac
@@ -48,7 +55,9 @@ sig
 end
 and Syn :
 sig
-  include Tactic with type tac = (S.t * D.tp) EM.m
+  include Tactic
+  val make : (S.t * D.tp) EM.m -> tac
+  val run : tac -> (S.t * D.tp) EM.m
   val ann : Chk.tac -> Tp.tac -> tac
 end
 

--- a/src/lib/Tactic.mli
+++ b/src/lib/Tactic.mli
@@ -35,22 +35,11 @@ module rec Chk :
 sig
   include Tactic
 
-  val make : (D.tp -> S.t EM.m) -> tac
+  val rule : (D.tp -> S.t EM.m) -> tac
+  val brule : (D.tp * D.cof * D.tm_clo -> S.t EM.m) -> tac
   val run : tac -> D.tp -> S.t EM.m
+  val brun : tac -> D.tp * D.cof * D.tm_clo -> S.t EM.m
 
-  (** Converts a boundary-checking tactic to a checking tactic by change of base. *)
-  val bchk : BChk.tac -> tac
-  val syn : Syn.tac -> tac
-end
-and BChk :
-sig
-  include Tactic
-
-  val make : (D.tp * D.cof * D.tm_clo -> S.t EM.m) -> tac
-  val run : tac -> D.tp * D.cof * D.tm_clo -> S.t EM.m
-
-  (** Converts a checking tactic to a boundary-checking tactic by a synchronous check. *)
-  val chk : Chk.tac -> tac
   val syn : Syn.tac -> tac
 end
 and Syn :
@@ -71,7 +60,6 @@ sig
   val syn : tac -> Syn.tac
 end
 
-type tp_tac = Tp.tac
 type var = Var.tac
 
 val abstract : ?ident:Ident.t -> D.tp -> (var -> 'a EM.m) -> 'a EM.m

--- a/test/hcom-type.cooltt
+++ b/test/hcom-type.cooltt
@@ -14,6 +14,6 @@ def hcom-type (i : 𝕀) : type =
   hcom type 0 1 {∂ i} {j _ => [j=0 => v-test i nat | ∂ i => nat]}
 
 def hcom-box (i : 𝕀) : hcom-type i =
-  [_ => ?asdf, ?]
+  [_ => ?asdf, [?,?]]
 
 


### PR DESCRIPTION
Previously chk/bchk were two different kinds of tactics; I have abstracted the representation of tactics, and now can make these into a single type with the section-retraction pair between them mediated dynamically. This makes the code much simpler! It also gets rid of spurious loss-of-information (when a bchk-tactic is spuriously transformed into chk-tac and then into bchk-tac again).