### PR TITLE
n-ary split refinement rule

### DIFF
--- a/src/basis/Monad.ml
+++ b/src/basis/Monad.ml
@@ -61,6 +61,16 @@ struct
       and+ ys = map f xs in
       y :: ys
 
+  let rec filter_map f =
+    function
+    | [] -> M.ret []
+    | (x :: xs) ->
+      let+ oy = f x
+      and+ ys = filter_map f xs in
+      match oy with
+      | None -> ys
+      | Some y -> y :: ys
+
   let rec map_bwd f =
     function
     | Emp -> M.ret Emp

--- a/src/basis/Monad.mli
+++ b/src/basis/Monad.mli
@@ -26,6 +26,7 @@ module Notation (M : S) : Notation with type 'a m = 'a M.m
 module Util (M : S) : sig
   val commute_list : 'a M.m list -> 'a list M.m
   val map : ('a -> 'b M.m) -> 'a list -> 'b list M.m
+  val filter_map : ('a -> 'b option M.m) -> 'a list -> 'b list M.m
   val map_bwd : ('a -> 'b M.m) -> 'a bwd -> 'b bwd M.m
   val iter : ('a -> unit M.m) -> 'a list -> unit M.m
   val ignore : 'a M.m -> unit M.m

--- a/src/lib/Domain.ml
+++ b/src/lib/Domain.ml
@@ -7,6 +7,9 @@ module S = Syntax
 let const_tp_clo tp =
   Clo (S.TpVar 0, {tpenv = Snoc (Emp, tp); conenv = Emp})
 
+let const_tm_clo con =
+  Clo (S.Var 0, {tpenv = Emp; conenv = Snoc (Emp, con)})
+
 let push frm (hd, sp) =
   hd, sp @ [frm]
 

--- a/src/lib/Domain.mli
+++ b/src/lib/Domain.mli
@@ -11,6 +11,7 @@ val cof_to_con : cof -> con
 val mk_var : tp -> int -> con
 val push : frm -> cut -> cut
 
+val const_tm_clo : con -> tm_clo
 val const_tp_clo : tp -> tp_clo
 
 val un_lam : con -> tm_clo

--- a/src/lib/ElabBasics.ml
+++ b/src/lib/ElabBasics.ml
@@ -32,12 +32,6 @@ let add_global id tp con =
   let* () = set st' in
   ret sym
 
-let add_flex_global tp =
-  let* st = get in
-  let sym, st' = St.add_flex_global tp st in
-  let* () = set st' in
-  ret sym
-
 let get_global sym : (D.tp * D.con option) m =
   let* st = get in
   match St.get_global sym st with

--- a/src/lib/ElabBasics.mli
+++ b/src/lib/ElabBasics.mli
@@ -16,7 +16,6 @@ val update_span : LexingUtil.span option -> 'a m -> 'a m
 val abstract : Ident.t -> D.tp -> (D.con -> 'a m) -> 'a m
 
 val add_global : Ident.t -> D.tp -> D.con option -> Symbol.t m
-val add_flex_global : D.tp -> Symbol.t m
 
 val resolve : Ident.t -> [`Local of int | `Global of Symbol.t | `Unbound] m
 val get_global : Symbol.t -> (D.tp * D.con option) m

--- a/src/lib/ElabError.ml
+++ b/src/lib/ElabError.ml
@@ -81,6 +81,10 @@ let pp fmt =
       (S.pp ppenv) cof
   | VirtualType ->
     Fmt.fprintf fmt "Virtual type (dim, cof, etc.) cannot appear in this position"
+  | HoleNotPermitted (ppenv, tp) ->
+    Fmt.fprintf fmt
+      "Holes of type %a are not permitted"
+      (S.pp_tp ppenv) tp
 
 
 exception ElabError of t * LexingUtil.span option

--- a/src/lib/ElabErrorData.ml
+++ b/src/lib/ElabErrorData.ml
@@ -33,5 +33,6 @@ struct
     | ExpectedDimensionLiteral of int
     | ExpectedTrue of Pp.env * S.t
     | VirtualType
+    | HoleNotPermitted of Pp.env * S.tp
 
 end

--- a/src/lib/ElabState.ml
+++ b/src/lib/ElabState.ml
@@ -5,12 +5,10 @@ module StringMap = Map.Make (String)
 
 type t =
   {resolver : Symbol.t StringMap.t;
-   flexity : [`Flex | `Rigid] SymbolMap.t;
    globals : (D.tp * D.con option) SymbolMap.t}
 
 let init =
   {resolver = StringMap.empty;
-   flexity = SymbolMap.empty;
    globals = SymbolMap.empty}
 
 let add_global (ident : Ident.t) tp ocon st =
@@ -28,14 +26,12 @@ let add_global (ident : Ident.t) tp ocon st =
        | `User ident -> StringMap.add ident sym st.resolver
        | _ -> st.resolver
      end;
-   flexity = SymbolMap.add sym `Rigid st.flexity;
    globals = SymbolMap.add sym (tp, ocon) st.globals}
 
 let add_flex_global tp st =
   let sym = Symbol.fresh () in
   sym,
   {st with
-   flexity = SymbolMap.add sym `Flex st.flexity;
    globals = SymbolMap.add sym (tp, None) st.globals}
 
 let resolve_global ident st =
@@ -46,5 +42,3 @@ let resolve_global ident st =
 let get_global sym st =
   SymbolMap.find sym st.globals
 
-let get_flexity sym st =
-  SymbolMap.find sym st.flexity

--- a/src/lib/ElabState.mli
+++ b/src/lib/ElabState.mli
@@ -7,8 +7,6 @@ type t
 
 val init : t
 val add_global : Ident.t -> D.tp -> D.con option -> t -> Symbol.t * t
-val add_flex_global : D.tp -> t -> Symbol.t * t
 val resolve_global : Ident.t -> t -> Symbol.t option
 
 val get_global : Symbol.t -> t -> D.tp * D.con option
-val get_flexity : Symbol.t -> t -> [`Flex | `Rigid]

--- a/src/lib/Elaborator.ml
+++ b/src/lib/Elaborator.ml
@@ -164,7 +164,7 @@ and chk_tm : CS.con -> T.Chk.tac =
   R.Tactic.intro_subtypes @@
   match con.node with
   | CS.Hole name ->
-    R.Hole.unleash_hole name `Rigid
+    R.Hole.unleash_hole name
 
   | CS.Unfold (idents, c) ->
     (* TODO: move to a trusted rule *)
@@ -293,7 +293,7 @@ and syn_tm : CS.con -> T.Syn.tac =
     R.Tactic.elim_implicit_connectives @@
     match con.node with
     | CS.Hole name ->
-      R.Hole.unleash_syn_hole name `Rigid
+      R.Hole.unleash_syn_hole name
     | CS.Var id ->
       R.Structural.lookup_var id
     | CS.DeBruijnLevel lvl ->

--- a/src/lib/Elaborator.ml
+++ b/src/lib/Elaborator.ml
@@ -265,7 +265,7 @@ and chk_tm : CS.con -> T.Chk.tac =
       R.Cof.boundary (chk_tm c)
 
     | CS.CofSplit splits ->
-      let branch_tacs = splits |> List.map @@ fun (cphi, ctm) -> chk_tm cphi, fun _ -> chk_tm ctm in
+      let branch_tacs = splits |> List.map @@ fun (cphi, ctm) -> R.Cof.{cof = chk_tm cphi; bdy = fun _ -> chk_tm ctm} in
       R.Cof.split branch_tacs
 
     | CS.Ext (idents, tp, cases) ->

--- a/src/lib/Quote.ml
+++ b/src/lib/Quote.ml
@@ -39,14 +39,17 @@ let rec quote_con (tp : D.tp) con =
   let* con = contractum_or con <@> lift_cmp @@ Sem.whnf_con ~style:(`Veil veil) con in
   match tp, con with
   | _, D.Split branches ->
-    let branch_body (phi, clo) =
-      bind_var (D.TpPrf phi) @@ fun prf ->
-      let* body = lift_cmp @@ inst_tm_clo clo prf in
-      quote_con tp body
+    let quote_branch (phi, clo) =
+      let+ tphi = quote_cof phi
+      and+ tbdy =
+        bind_var (D.TpPrf phi) @@ fun prf ->
+        let* body = lift_cmp @@ inst_tm_clo clo prf in
+        quote_con tp body
+      in
+      tphi, tbdy
     in
-    let* tphis = MU.map (fun (phi , _) -> quote_cof phi) branches in
-    let* tms = MU.map branch_body branches in
-    ret @@ S.CofSplit (List.combine tphis tms)
+    let* tbranches = MU.map quote_branch branches in
+    ret @@ S.CofSplit tbranches
 
   | _, D.Cut {cut = (D.Var lvl, []); tp = TpDim} ->
     (* for dimension variables, check to see if we can prove them to be

--- a/src/lib/Refiner.ml
+++ b/src/lib/Refiner.ml
@@ -534,7 +534,7 @@ struct
     EM.lift_cmp @@
     Sem.splice_tp @@
     Splice.con r @@ fun src ->
-    Splice.cof phi @@ fun cof ->
+    Splice.con phi @@ fun cof ->
     Splice.tp tp @@ fun vtp ->
     Splice.term @@
     TB.pi TB.tp_dim @@ fun i ->
@@ -548,7 +548,7 @@ struct
     let* trg = T.Chk.run tac_trg D.TpDim in
     let* cof = T.Chk.run tac_cof D.TpCof in
     let* vsrc = EM.lift_ev @@ Sem.eval src in
-    let* vcof = EM.lift_ev @@ Sem.eval_cof cof in
+    let* vcof = EM.lift_ev @@ Sem.eval cof in
     let* vtp = EM.lift_ev @@ Sem.eval_tp @@ S.El code in
     (* (i : dim) -> (_ : [i=src \/ cof]) -> A *)
     let+ tm = T.Chk.run tac_tm @<< hcom_bdy_tp vtp vsrc vcof in
@@ -569,7 +569,7 @@ struct
     let* cof = T.Chk.run tac_cof D.TpCof in
     let* vfam = EM.lift_ev @@ Sem.eval fam in
     let* vsrc = EM.lift_ev @@ Sem.eval src in
-    let* vcof = EM.lift_ev @@ Sem.eval_cof cof in
+    let* vcof = EM.lift_ev @@ Sem.eval cof in
     (* (i : dim) -> (_ : [i=src \/ cof]) -> A i *)
     let+ tm =
       T.Chk.run tac_tm @<<
@@ -577,7 +577,7 @@ struct
       Sem.splice_tp @@
       Splice.con vfam @@ fun vfam ->
       Splice.con vsrc @@ fun src ->
-      Splice.cof vcof @@ fun cof ->
+      Splice.con vcof @@ fun cof ->
       Splice.term @@
       TB.pi TB.tp_dim @@ fun i ->
       TB.pi (TB.tp_prf (TB.join [TB.eq i src; cof])) @@ fun _ ->
@@ -758,7 +758,7 @@ struct
       and+ tr' = EM.quote_dim r'
       and+ tphi = EM.quote_cof phi
       and+ tbdy =
-        let* tp_bdy = Univ.hcom_bdy_tp D.Univ (D.dim_to_con r) phi in
+        let* tp_bdy = Univ.hcom_bdy_tp D.Univ (D.dim_to_con r) (D.cof_to_con phi) in
         EM.quote_con tp_bdy bdy
       and+ tp_cap =
         let* code_fib = EM.lift_cmp @@ Sem.do_ap2 bdy (D.dim_to_con r) D.Prf in

--- a/src/lib/Refiner.mli
+++ b/src/lib/Refiner.mli
@@ -34,7 +34,8 @@ module Cof : sig
   val meet : Chk.tac list -> Chk.tac
   val boundary : Chk.tac -> Chk.tac
 
-  val split : (Chk.tac * (var -> Chk.tac)) list -> Chk.tac
+  type branch_tac = {cof : Chk.tac; bdy : var -> Chk.tac}
+  val split : branch_tac list -> Chk.tac
 end
 
 module Prf : sig

--- a/src/lib/Refiner.mli
+++ b/src/lib/Refiner.mli
@@ -11,9 +11,9 @@ open Tactic
 type ('a, 'b) quantifier = 'a -> Ident.t * (var -> 'b) -> 'b
 
 module Hole : sig
-  val unleash_hole : string option -> [`Flex | `Rigid] -> Chk.tac
-  val unleash_tp_hole : string option -> [`Flex | `Rigid] -> Tp.tac
-  val unleash_syn_hole : string option -> [`Flex | `Rigid] -> Syn.tac
+  val unleash_hole : string option -> Chk.tac
+  val unleash_tp_hole : string option -> Tp.tac
+  val unleash_syn_hole : string option -> Syn.tac
 end
 
 module Goal : sig


### PR DESCRIPTION
Resolves #75 

In the past, the n-ary cofibration splits were elaborated as iterated binary splits; this was ugly and inefficient. I now implemented a general refinement rule for the n-ary split.