### PR TITLE
Dimension probe invariants

### DIFF
--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -40,8 +40,7 @@ let dim_to_con =
   | Dim.DimVar lvl ->
     Cut {tp = TpDim; cut = Var lvl, []}
   | Dim.DimSym sym ->
-    (* hmmm *)
-    Cut {tp = TpDim; cut = Global sym, []}
+    DimSym sym
 
 let rec cof_to_con =
   function
@@ -145,6 +144,8 @@ and pp_con : con Pp.printer =
     Format.fprintf fmt "meet[%a]" (Format.pp_print_list ~pp_sep:(fun fmt () -> Uuseg_string.pp_utf_8 fmt ",") pp_con) phis
   | Cof (Cof.Eq (r, s)) ->
     Format.fprintf fmt "eq[%a,%a]" pp_con r pp_con s
+  | DimSym x ->
+    Format.fprintf fmt "probe[%a]" Symbol.pp x
   | Lam (_, clo) ->
     Format.fprintf fmt "lam[%a]" pp_clo clo
   | Dim0 ->

--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -39,8 +39,8 @@ let dim_to_con =
   | Dim.Dim1 -> Dim1
   | Dim.DimVar lvl ->
     Cut {tp = TpDim; cut = Var lvl, []}
-  | Dim.DimSym sym ->
-    DimSym sym
+  | Dim.DimProbe sym ->
+    DimProbe sym
   | Dim.DimGlobal sym ->
     Cut {tp = TpDim; cut = Global sym, []}
 
@@ -146,7 +146,7 @@ and pp_con : con Pp.printer =
     Format.fprintf fmt "meet[%a]" (Format.pp_print_list ~pp_sep:(fun fmt () -> Uuseg_string.pp_utf_8 fmt ",") pp_con) phis
   | Cof (Cof.Eq (r, s)) ->
     Format.fprintf fmt "eq[%a,%a]" pp_con r pp_con s
-  | DimSym x ->
+  | DimProbe x ->
     Format.fprintf fmt "probe[%a]" Symbol.pp x
   | Lam (_, clo) ->
     Format.fprintf fmt "lam[%a]" pp_clo clo

--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -41,6 +41,8 @@ let dim_to_con =
     Cut {tp = TpDim; cut = Var lvl, []}
   | Dim.DimSym sym ->
     DimSym sym
+  | Dim.DimGlobal sym ->
+    Cut {tp = TpDim; cut = Global sym, []}
 
 let rec cof_to_con =
   function

--- a/src/core/DomainData.ml
+++ b/src/core/DomainData.ml
@@ -68,6 +68,7 @@ and con =
 
   | Dim0
   | Dim1
+  | DimSym of Symbol.t
 
   | Cof of (con, con) Cof.cof_f
   (** A mixin of the language of cofibrations (as described in {!module:Cubical.Cof}), with dimensions and indeterminates in {!type:con}. *)

--- a/src/core/DomainData.ml
+++ b/src/core/DomainData.ml
@@ -68,7 +68,7 @@ and con =
 
   | Dim0
   | Dim1
-  | DimSym of Symbol.t
+  | DimProbe of Symbol.t
 
   | Cof of (con, con) Cof.cof_f
   (** A mixin of the language of cofibrations (as described in {!module:Cubical.Cof}), with dimensions and indeterminates in {!type:con}. *)

--- a/src/core/Semantics.ml
+++ b/src/core/Semantics.ml
@@ -160,8 +160,8 @@ and con_to_dim =
     function
     | D.Dim0 -> ret Dim.Dim0
     | D.Dim1 -> ret Dim.Dim1
+    | D.DimSym x -> ret @@ Dim.DimSym x
     | D.Cut {cut = Var l, []; _} -> ret @@ Dim.DimVar l
-    | D.Cut {cut = Global sym, []; _} -> ret @@ Dim.DimSym sym
     | con ->
       Format.eprintf "bad: %a@." D.pp_con con;
       throw @@ NbeFailed "con_to_dim"
@@ -251,7 +251,7 @@ and push_subst_con : D.dim -> Symbol.t -> D.con -> D.con CM.m =
     and+ pivot = subst_con r x pivot
     and+ base = subst_con r x base in
     D.VIn (s, equiv, pivot, base)
-  | D.Cut {tp = _; cut = (D.Global y, [])} as con ->
+  | D.DimSym y as con ->
     begin
       test_sequent [] (Cof.eq (Dim.DimSym x) (Dim.DimSym y)) |>>
       function
@@ -763,7 +763,7 @@ and whnf_con ~style : D.con -> D.con whnf CM.m =
   let open CM in
   function
   | D.Lam _ | D.BindSym _ | D.Zero | D.Suc _ | D.Base | D.Pair _ | D.SubIn _ | D.ElIn _ | D.LockedPrfIn _
-  | D.Cof _ | D.Dim0 | D.Dim1 | D.Prf | D.StableCode _ ->
+  | D.Cof _ | D.Dim0 | D.Dim1 | D.Prf | D.StableCode _ | D.DimSym _ ->
     ret `Done
   | D.LetSym (r, x, con) ->
     reduce_to ~style @<< push_subst_con r x con

--- a/src/core/Semantics.ml
+++ b/src/core/Semantics.ml
@@ -162,6 +162,7 @@ and con_to_dim =
     | D.Dim1 -> ret Dim.Dim1
     | D.DimSym x -> ret @@ Dim.DimSym x
     | D.Cut {cut = Var l, []; _} -> ret @@ Dim.DimVar l
+    | D.Cut {cut = Global x, []; _} -> ret @@ Dim.DimGlobal x
     | con ->
       Format.eprintf "bad: %a@." D.pp_con con;
       throw @@ NbeFailed "con_to_dim"

--- a/src/cubical/Dim.ml
+++ b/src/cubical/Dim.ml
@@ -5,4 +5,4 @@ type dim =
   | Dim1
   | DimVar of int
   | DimSym of Symbol.t
-
+  | DimGlobal of Symbol.t

--- a/src/cubical/Dim.ml
+++ b/src/cubical/Dim.ml
@@ -4,5 +4,5 @@ type dim =
   | Dim0
   | Dim1
   | DimVar of int
-  | DimSym of Symbol.t
+  | DimProbe of Symbol.t
   | DimGlobal of Symbol.t

--- a/src/cubical/Dim.mli
+++ b/src/cubical/Dim.mli
@@ -13,3 +13,6 @@ type dim =
   | DimSym of Symbol.t
     (** Some dimension variables must be generated in a globally fresh way ({i e.g.} when computing under a binder). *)
 
+  | DimGlobal of Symbol.t
+    (** For dimensions that are defined in the signature *)
+

--- a/src/cubical/Dim.mli
+++ b/src/cubical/Dim.mli
@@ -10,9 +10,9 @@ type dim =
   | DimVar of int
     (** In [cooltt], most dimension variables are represented as natural numbers (pointers into the context). *)
 
-  | DimSym of Symbol.t
-    (** Some dimension variables must be generated in a globally fresh way ({i e.g.} when computing under a binder). *)
+  | DimProbe of Symbol.t
+    (** Some dimension variables must be generated to probe underneath a binder. Subject to substitution. *)
 
   | DimGlobal of Symbol.t
-    (** For dimensions that are defined in the signature *)
+    (** For dimensions that are defined in the signature. Not subject to substitution. *)
 

--- a/test/axiom.cooltt
+++ b/test/axiom.cooltt
@@ -1,18 +1,25 @@
 axiom φ/path : 𝔽
 axiom u/path : locked φ/path
-axiom path (A : type) (x : A) (y : A) 
+axiom path (A : type) (x : A) (y : A)
   : sub type φ/path {ext i => A with [i=0 => x | i=1 => y]}
 
-normalize path 
+normalize path
 
-def test : path nat 3 3 := 
+def test : path nat 3 3 :=
   unlock u/path in
   i => 3
 
 normalize test
 
-def test2 : unlock u/path in path {path nat 3 3} test {_ => 3} := 
-  unlock u/path in 
+def test2 : unlock u/path in path {path nat 3 3} test {_ => 3} :=
+  unlock u/path in
   _ _ => 3
 
 print test2
+
+
+def bar : 𝕀 := 0
+axiom foo : 𝕀
+
+def test : sub nat {foo=0} 34 :=
+  34


### PR DESCRIPTION
Per our discussion, I tried to switch the "fresh dimension" variables over to use their own constructor `DimSym` in the domain, because these are not treated like global variables (they are not in the top-level signature).

However, I realized that we actually need both! Because it is possible for a user to write something like:

```
axiom foo : II
```

or 

```
def bar : II := 0
```

So let me work that out too. 