### PR TITLE
🌳 Refactor the search of the project root.

### DIFF
--- a/src/frontend/Driver.mli
+++ b/src/frontend/Driver.mli
@@ -1,6 +1,4 @@
 (* This is the top-level driver for the proof assistant. *)
 
-val find_project_root : [`Stdin | `File of string] -> string
-
-val load_file : string -> [`Stdin | `File of string] -> (unit, unit) result
-val do_repl : string -> (unit, unit) result
+val load_file : as_file:string option -> [`Stdin | `File of string] -> (unit, unit) result
+val do_repl : as_file:string option -> (unit, unit) result

--- a/test/Test.ml
+++ b/test/Test.ml
@@ -6,7 +6,7 @@ let header fname =
 let execute_file fname =
   if String.equal (Filename.extension fname) ".cooltt" then
     let _ = print_string (header fname) in
-    ignore @@ Driver.load_file "." (`File fname)
+    ignore @@ Driver.load_file ~as_file:None (`File fname)
 
 let () =
   let cooltt_files = Sys.readdir "." in

--- a/vim/ftplugin/cooltt.vim
+++ b/vim/ftplugin/cooltt.vim
@@ -45,7 +45,7 @@ function! CheckBuffer(...)
   execute 'sign unplace * file=' . l:current
 
   let s:job = job_start(g:cooltt_path .
-    \' - -w ' . s:EditWidth() . ' -p ' . expand('%:p'), {
+    \' - -w ' . s:EditWidth() . ' --as-file ' . expand('%:p'), {
     \'in_io': 'buffer', 'in_buf': bufnr('%'),
     \'in_bot': exists('a:1') ? a:1 : line('$'),
     \'out_cb': 'ParseMessages',


### PR DESCRIPTION
1. Use `--as-file` instead of `--project-root`.
2. The interactive mode will search for the root by default instead of using the current working directory.
3. Architectural changes: no fancy logic in `main.ml` other than option parsing.

PS: I *did not* test the Vim mode or the interactive mode!