### PR TITLE
🏃 Stop path compression in union-and-find

### DIFF
--- a/src/basis/DisjointSet.ml
+++ b/src/basis/DisjointSet.ml
@@ -18,38 +18,29 @@ struct
   type key = O.t
   type t =
     {rank : int T.t;
-     mutable parent : key T.t}
+     parent : key T.t}
 
   let empty =
     {rank = T.empty;
      parent = T.empty}
 
 
-  let rec find_aux (x : key) (f : key T.t) =
-    try
-      let fx = T.get x f in
-      if fx == x then
-        f, x
-      else
-        let f, y = find_aux fx f in
-        let f = T.set x y f in
-        f, y
-    with
-    | _ ->
-      let f = T.set x x f in
-      f, x
-
-  let find (x : key) (h : t) : key =
-    let f, cx = find_aux x h.parent in
-    h.parent <- f;
-    cx
+  let find (x : key) (h : t) =
+    let rec loop x p =
+      match
+        T.get_opt x p
+      with
+      | Some x -> loop x p
+      | None -> x
+    in
+    loop x h.parent
 
   let get_rank cx h =
-    try
-      T.get cx h.rank
+    match
+      T.get_opt cx h.rank
     with
-    | _ ->
-      0
+    | Some r -> r
+    | _ -> 0
 
   let test (x : key) (y : key) (h : t) =
     x = y ||

--- a/src/basis/PersistentTable.ml
+++ b/src/basis/PersistentTable.ml
@@ -6,6 +6,7 @@ sig
   val empty : 'a t
   val size : 'a t -> int
   val get : key -> 'a t -> 'a
+  val get_opt : key -> 'a t -> 'a option
   val set : key -> 'a -> 'a t -> 'a t
   val mem : key -> 'a t -> bool
   val remove : key -> 'a t -> 'a t
@@ -37,6 +38,8 @@ struct
   let size t = M.cardinal t
 
   let get k t = M.find k t
+
+  let get_opt k t = M.find_opt k t
 
   let mem k t = M.mem k t
 

--- a/src/basis/PersistentTable.mli
+++ b/src/basis/PersistentTable.mli
@@ -1,6 +1,4 @@
-(* Due to Conchon & Filliatre *)
-
-(* Redone using Map.Make *)
+(* Originally due to Conchon & Filliatre, but then redone using Map.Make *)
 
 module type S =
 sig
@@ -10,6 +8,7 @@ sig
   val empty : 'a t
   val size : 'a t -> int
   val get : key -> 'a t -> 'a
+  val get_opt : key -> 'a t -> 'a option
   val set : key -> 'a -> 'a t -> 'a t
   val mem : key -> 'a t -> bool
   val remove : key -> 'a t -> 'a t


### PR DESCRIPTION
Path compression is totally useless. Could one of you benchmark the test suite to confirm that this is the case not just on my machines? @jonsterling @TOTBWF My theory is that a data structure even more stupid than this PR would actually work better.