### PR TITLE
🔘 Minor updates to name modifiers

### DIFF
--- a/src/core/Namespace.ml
+++ b/src/core/Namespace.ml
@@ -29,7 +29,7 @@ let nest pp_a modifier imported ns =
   | Ok transformed_imported ->
     Trie.union report_duplicate ns transformed_imported
   | Error (`BindingNotFound path) ->
-    failwith @@ "No identifier at " ^ Ident.to_string (`User path)
+    failwith @@ "No identifiers with the prefix " ^ Ident.to_string (`User path)
 
 let find (ident : Ident.t) ns =
   match ident with

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -159,8 +159,8 @@ plain_bracketed_modifier:
     { ModUnion list }
 
 plain_modifier:
-  | m = plain_bracketed_modifier
-    { m }
+  | DOT
+    { ModAny }
   | path = path DOT m = bracketed_modifier
     { ModInSubtree (path, m) }
   | RIGHT_ARROW
@@ -179,6 +179,8 @@ plain_modifier:
     { ModExcept path }
   | name = HOLE_NAME
     { ModPrint name }
+  | m = plain_bracketed_modifier
+    { m }
 
 plain_atomic_in_cof_except_term:
   | BOUNDARY t = atomic_term


### PR DESCRIPTION
1. Allow the standalone dot pattern `.`.
2. Slightly better error messages.