### PR TITLE
Add compilation-mode regexes for emacs mode

### DIFF
--- a/emacs/cooltt.el
+++ b/emacs/cooltt.el
@@ -162,6 +162,11 @@
   ;; Bind mode-specific commands to keys
   (define-key cooltt-mode-map (kbd "C-c C-l") 'cooltt-compile-buffer)
 
+  (add-to-list 'compilation-error-regexp-alist 'cooltt)
+  (add-to-list 'compilation-error-regexp-alist-alist
+               '(cooltt "^\\([^ \n]+\\):\\([0-9]+\\)\\.\\([0-9]+\\)-\\([0-9]+\\).\\([0-9]+\\) \\[Error\\]:$"
+                        1 (2 . 4) (3 . 5) nil))
+
   (set (make-local-variable 'completion-at-point-functions)
        '(cooltt-completion-at-point)))
 

--- a/emacs/cooltt.el
+++ b/emacs/cooltt.el
@@ -43,6 +43,7 @@
 
 
 (require 'cl-lib)
+(require 'compile)
 
 (defgroup cooltt nil "cooltt" :prefix 'cooltt :group 'languages)
 
@@ -124,6 +125,23 @@
     (,(regexp-opt cooltt-expression-symbols 'nil) 0 'cooltt-expression-symbol-face)
     ))
 
+
+(defconst cooltt-compilation-error-regexp-alist
+  `((,(concat
+       "^\\([^ \n]+\\):"             ;; Filename
+       "\\([0-9]+\\)\\.\\([0-9]+\\)" ;; Starting Line/Column
+       "-"
+       "\\([0-9]+\\)\\.\\([0-9]+\\)" ;; Ending Line/Column
+       " \\(\\[Info\\]\\)?")         ;; Match forward if we see [Info]
+     1 (2 . 4) (3 . 5) (nil . 6)))
+  "Regexps used for matching cooltt compilation messages.
+See `compilation-error-regexp-alist' for semantics.")
+
+(define-compilation-mode cooltt-compilation-mode "Cooltt"
+  "Cooltt specific `compilation-mode' derivative."
+  (setq-local compilation-error-regexp-alist
+              cooltt-compilation-error-regexp-alist))
+
 (defconst cooltt--compilation-buffer-name
   "*cooltt*"
   "The name to use for cooltt compilation buffers.")
@@ -147,7 +165,7 @@
                  (compilation-buffer-name-function
                   'cooltt--compilation-buffer-name-function)
                  (default-directory dir))
-            (compile command)))
+            (compilation-start command 'cooltt-compilation-mode nil t)))
       (error "Buffer has no file name"))))
 
 ;;;###autoload
@@ -161,11 +179,6 @@
 
   ;; Bind mode-specific commands to keys
   (define-key cooltt-mode-map (kbd "C-c C-l") 'cooltt-compile-buffer)
-
-  (add-to-list 'compilation-error-regexp-alist 'cooltt)
-  (add-to-list 'compilation-error-regexp-alist-alist
-               '(cooltt "^\\([^ \n]+\\):\\([0-9]+\\)\\.\\([0-9]+\\)-\\([0-9]+\\).\\([0-9]+\\) \\[Error\\]:$"
-                        1 (2 . 4) (3 . 5) nil))
 
   (set (make-local-variable 'completion-at-point-functions)
        '(cooltt-completion-at-point)))


### PR DESCRIPTION
## Patch Description

This PR adds some regexes to highlight errors in the `cooltt` compilation output in emacs. This also makes it nice and easy to jump to/between the errors using `next-error`