### PR TITLE
🧶 Detangle Namespaces + Code Units

### DIFF
--- a/src/core/CodeUnit.ml
+++ b/src/core/CodeUnit.ml
@@ -42,12 +42,6 @@ struct
   type t =
     { (* The name of the code unit.  *)
       id : id;
-      (* The top-level namespace of this code unit. Import namespaces are stored separately. *)
-      namespace : Global.t Namespace.t;
-      (* The code unit names of all of this code unit's imports. *)
-      imports : id bwd;
-      (* The namespace of imports. *)
-      import_namespace : Global.t Namespace.t;
       (* All the top-level bindings for this code unit. *)
       symbol_table :  (Domain.tp * Domain.con option) Vector.vector }
 
@@ -55,31 +49,16 @@ struct
 
   let id code_unit = code_unit.id
 
-  let imports code_unit = Bwd.to_list code_unit.imports
-
   let create id =
     { id = id;
-      namespace = Namespace.empty;
-      imports = Emp;
-      import_namespace = Namespace.empty;
       symbol_table = Vector.create () }
 
   let add_global ident tp ocon code_unit =
     let index = Vector.length code_unit.symbol_table in
     let _ = Vector.push code_unit.symbol_table (tp, ocon) in
     let sym = { Global.origin = code_unit.id; index = index; name = Ident.to_string_opt ident } in
-    let code_unit' = { code_unit with namespace = Namespace.add ident sym code_unit.namespace } in
-    (sym, code_unit')
-
-  let resolve_global ident code_unit =
-    match Namespace.find ident code_unit.namespace with
-    | Some sym -> Some sym
-    | None -> Namespace.find ident code_unit.import_namespace
+    (sym, code_unit)
 
   let get_global (sym : Global.t) code_unit =
     Vector.get code_unit.symbol_table sym.index
-
-  let add_import modifier import code_unit =
-    { code_unit with import_namespace = Namespace.nest Global.pp modifier import.namespace code_unit.import_namespace;
-                     imports = Snoc (code_unit.imports, code_unit.id) }
 end

--- a/src/core/CodeUnit.ml
+++ b/src/core/CodeUnit.ml
@@ -1,7 +1,4 @@
 open ContainersLabels
-open Basis
-open Bwd
-
 module CodeUnitID =
 struct
   type t = string option

--- a/src/core/CodeUnit.mli
+++ b/src/core/CodeUnit.mli
@@ -26,21 +26,12 @@ module CodeUnit : sig
   (** The name of a given code unit *)
   val id : t -> id
 
-  (** All of the code unit this unit directly imports *)
-  val imports : t -> id list
-
   (** Create a code unit. *)
   val create : id -> t
 
   (** Add a binding to a given code unit. *)
   val add_global : Ident.t -> Domain.tp -> Domain.con option -> t -> (Global.t * t)
 
-  (** Attempt to resolve an identifier a given code unit. *)
-  val resolve_global : Ident.t -> t -> Global.t option
-
   (** Get the binding associated with a symbol. *)
   val get_global : Global.t -> t -> Domain.tp * Domain.con option
-
-  (** Add another code unit as an import. *)
-  val add_import : [< `Print of string option] Yuujinchou.Pattern.t -> t -> t -> t
 end

--- a/src/core/RefineMonad.ml
+++ b/src/core/RefineMonad.ml
@@ -75,8 +75,12 @@ let add_import modifier code_unit =
   modify (St.add_import current_unit_id modifier code_unit)
 
 let get_import path =
-  let* st = get in
-  ret @@ St.get_import path st
+  let+ st = get in
+  St.get_import path st
+
+let is_imported path =
+  let+ st = get in
+  St.is_imported path st
 
 let quote_con tp con =
   lift_qu @@ Qu.quote_con tp con

--- a/src/core/RefineMonad.mli
+++ b/src/core/RefineMonad.mli
@@ -26,7 +26,7 @@ val with_code_unit : Bantorra.Manager.library -> id -> 'a m -> 'a m
 val get_current_lib : Bantorra.Manager.library m
 val get_current_unit : CodeUnit.t m
 
-val add_import : [< `Print of string option] Yuujinchou.Pattern.t -> CodeUnit.t -> unit m
+val add_import : [< `Print of string option] Yuujinchou.Pattern.t -> id -> unit m
 val get_import : id -> (CodeUnit.t option) m
 
 val quote_con : D.tp -> D.con -> S.t m

--- a/src/core/RefineMonad.mli
+++ b/src/core/RefineMonad.mli
@@ -28,6 +28,7 @@ val get_current_unit : CodeUnit.t m
 
 val add_import : [< `Print of string option] Yuujinchou.Pattern.t -> id -> unit m
 val get_import : id -> (CodeUnit.t option) m
+val is_imported : id -> bool m
 
 val quote_con : D.tp -> D.con -> S.t m
 val quote_tp : D.tp -> S.tp m

--- a/src/core/RefineState.ml
+++ b/src/core/RefineState.ml
@@ -61,3 +61,6 @@ let init_unit id st =
 
 let get_import path st =
   IDMap.find_opt path st.code_units
+
+let is_imported path st =
+  IDMap.mem path st.code_units

--- a/src/core/RefineState.ml
+++ b/src/core/RefineState.ml
@@ -3,36 +3,61 @@ open CodeUnit
 module IDMap = Map.Make (CodeUnitID)
 module D = Domain
 
-type t = { code_units : CodeUnit.t IDMap.t }
+type t = { code_units : CodeUnit.t IDMap.t;
+           (** The binding namespace for each code unit. *)
+           namespaces : (Global.t Namespace.t) IDMap.t;
+           (** The import namespace for each code unit. *)
+           import_namespaces : (Global.t Namespace.t) IDMap.t }
 
-let init = { code_units = IDMap.empty }
+let init =
+  { code_units = IDMap.empty;
+    namespaces = IDMap.empty;
+    import_namespaces = IDMap.empty }
 
 let get_unit id st =
   IDMap.find id st.code_units
 
-let update_unit id f st = { code_units = IDMap.update id (Option.map f) st.code_units }
+let get_namespace id st =
+  IDMap.find id st.namespaces
 
-let set_unit id code_unit st = { code_units = IDMap.add id code_unit st.code_units }
+let get_imports id st =
+  IDMap.find id st.import_namespaces
+
+let update_unit id f st = { st with code_units = IDMap.update id (Option.map f) st.code_units }
+
+let update_namespace id f st = { st with namespaces = IDMap.update id (Option.map f) st.namespaces }
+
+let update_imports id f st = { st with import_namespaces = IDMap.update id (Option.map f) st.import_namespaces }
 
 let add_global id ident tp ocon st =
   let code_unit = get_unit id st in
+  let namespace = get_namespace id st in
   let (sym, code_unit') = CodeUnit.add_global ident tp ocon code_unit in
-  (sym, set_unit id code_unit' st)
+  let namespace' = Namespace.add ident sym namespace in
+  let st' =
+    { st with code_units = IDMap.add id code_unit' st.code_units;
+              namespaces = IDMap.add id namespace' st.namespaces }
+  in
+  (sym, st')
 
 let resolve_global id ident st =
-  let code_unit = get_unit id st in
-  CodeUnit.resolve_global ident code_unit
+  match Namespace.find ident (get_namespace id st) with
+  | Some sym -> Some sym
+  | None -> Namespace.find ident (get_imports id st)
 
 let get_global sym st =
   let unit_name = CodeUnit.origin sym in
-  let code_unit = IDMap.find unit_name st.code_units in
+  let code_unit = get_unit unit_name st in
   CodeUnit.get_global sym code_unit
 
-let add_import id modifier code_unit st =
-  update_unit id (CodeUnit.add_import modifier code_unit) st
+let add_import id modifier import_id st =
+  let import_ns = get_namespace import_id st in
+  update_imports id (Namespace.nest Global.pp modifier import_ns) st
 
 let init_unit id st =
-  { code_units = IDMap.add id (CodeUnit.create id) st.code_units }
+  { code_units = IDMap.add id (CodeUnit.create id) st.code_units;
+    namespaces = IDMap.add id Namespace.empty st.namespaces;
+    import_namespaces = IDMap.add id Namespace.empty st.import_namespaces }
 
 let get_import path st =
   IDMap.find_opt path st.code_units

--- a/src/core/RefineState.mli
+++ b/src/core/RefineState.mli
@@ -14,7 +14,7 @@ val resolve_global : id -> Ident.t -> t -> Global.t option
 val get_global : Global.t -> t -> D.tp * D.con option
 
 (** Add a code unit as an import. *)
-val add_import : id -> [< `Print of string option] Yuujinchou.Pattern.t -> CodeUnit.t -> t -> t
+val add_import : id -> [< `Print of string option] Yuujinchou.Pattern.t -> id -> t -> t
 
 (** Try to get a code unit from the imports. *)
 val get_import : id -> t -> CodeUnit.t option

--- a/src/core/RefineState.mli
+++ b/src/core/RefineState.mli
@@ -19,5 +19,7 @@ val add_import : id -> [< `Print of string option] Yuujinchou.Pattern.t -> id ->
 (** Try to get a code unit from the imports. *)
 val get_import : id -> t -> CodeUnit.t option
 
+val is_imported : id -> t -> bool
+
 (** Create and add a new code unit. *)
 val init_unit : id -> t -> t

--- a/src/frontend/Driver.ml
+++ b/src/frontend/Driver.ml
@@ -131,7 +131,7 @@ and import_code_unit path modifier : command =
       match unit_loaded with
       | Some import_unit -> RM.ret import_unit
       | None -> load_code_unit lib src in
-    let* _ = RM.add_import modifier import_unit in
+    let* _ = RM.add_import modifier (CodeUnitID.file src) in
     RM.ret @@ Continue Fun.id
 
 and execute_decl : CS.decl -> command =


### PR DESCRIPTION
## Patch Description

This PR removes namespaces from `CodeUnit`s, and pulls it into the `RefinerState` instead. This could be brought out of the core entirely, but would require yet another layer of `StateT`. If a wish is made then this shall be done.