### PR TITLE
📽️  Update Projection Grammar

### DIFF
--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -276,6 +276,8 @@ plain_term_except_cof_case:
     { ap_or_atomic (List.concat [List.map term_of_name @@ Option.value ~default:[] spine; [arg1]; args2]) }
   | spine = nonempty_list_left_recursive(name)
     { ap_or_atomic (List.map term_of_name spine) }
+  | t = term; PROJ; lbl = path; spine = list_left_recursive(atomic_term)
+    { ap_or_atomic ({ node = Proj(t, lbl); info = None } :: spine) }
   | UNLOCK; t = term; IN; body = term;
     { Unlock (t, body) }
   | UNFOLD; names = nonempty_list(plain_name); IN; body = term;
@@ -306,8 +308,6 @@ plain_term_except_cof_case:
     { Signature tele }
   | STRUCT; tele = list(field);
     { Struct tele }
-  | t = term; PROJ; lbl = path; spine = list_left_recursive(atomic_term)
-    { ap_or_atomic ({ node = Proj(t, lbl); info = None } :: spine) }
   | dom = term; RIGHT_ARROW; cod = term
     { Pi ([Cell {names = [`Anon]; tp = dom}], cod) }
   | dom = term; TIMES; cod = term

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -306,8 +306,8 @@ plain_term_except_cof_case:
     { Signature tele }
   | STRUCT; tele = list(field);
     { Struct tele }
-  | t = term; PROJ; lbl = path
-    { Proj (t, lbl) }
+  | t = term; PROJ; lbl = path; spine = list_left_recursive(atomic_term)
+    { ap_or_atomic ({ node = Proj(t, lbl); info = None } :: spine) }
   | dom = term; RIGHT_ARROW; cod = term
     { Pi ([Cell {names = [`Anon]; tp = dom}], cod) }
   | dom = term; TIMES; cod = term

--- a/test/hlevel.cooltt
+++ b/test/hlevel.cooltt
@@ -1,5 +1,4 @@
-def path (A : type) (a b : A) : type :=
-  ext i => A with [i=0 => a | i=1 => b]
+import prelude
 
 def is-contr (C : type) : type :=
   (c : C) × {(c' : C) → path C c c'}
@@ -32,26 +31,6 @@ def hGroupoid : type := hLevel 3
 
 print hProp
 normalize hProp
-
-def symm/filler (A : type) (p : 𝕀 → A) (i : 𝕀) : 𝕀 → A :=
-  hfill A 0 {∂ i} {j _ =>
-    [ j=0 ∨ i=1 => p 0
-    | i=0 => p j
-    ]
-  }
-
-def symm (A : type) (p : 𝕀 → A) : path A {p 1} {p 0} :=
-  i => symm/filler A p i 1
-
-def trans/filler (A : type) (p : 𝕀 → A) (q : (i : 𝕀) → sub A {i=0} {p 1}) (j : 𝕀) (i : 𝕀) : A :=
-  hcom A 0 j {∂ i} {j _ =>
-    [ j=0 ∨ i=0 => p i
-    | i=1 => q j
-    ]
-  }
-
-def trans (A : type) (p : 𝕀 → A) (q : (i : 𝕀) → sub A {i=0} {p 1}) : path A {p 0} {q 1} :=
-  trans/filler A p q 1
 
 def contr-prop (A : type) (A/contr : is-contr A) : is-prop A :=
   a a' => trans A {symm A {{snd A/contr} a}} {{snd A/contr} a'}

--- a/test/record.cooltt
+++ b/test/record.cooltt
@@ -6,11 +6,13 @@ def basic : type :=
     (foo.x : nat)
     (bar : nat → nat)
 
-def basic.inhabit : basic := struct (foo.x : 1) (bar : x => x)
+def basic.inhabit : basic := struct (foo.x : 1) (bar : x => suc x)
 
 print basic
 print basic.inhabit
 normalize basic.inhabit
+normalize basic.inhabit@foo.x
+normalize basic.inhabit@bar 1
 
 def basic/ext
   (b0 : basic) (b1 : basic)
@@ -37,6 +39,7 @@ def depend/ext
   (q : path-p {i => p i → p i} {d0 @ fun} {d1 @ fun}) : path depend d0 d1
 :=
 i => struct (tp : p i) (fun : q i)
+
 
 -- Can we inhabit first class sigs?
 def sig/inhabit :

--- a/test/test.expected
+++ b/test/test.expected
@@ -534,12 +534,12 @@ hcom-type.cooltt:17.18-17.19 [Info]:
 
 
 --------------------[hlevel.cooltt]--------------------
-hlevel.cooltt:33.6-33.11 [Info]:
+hlevel.cooltt:32.6-32.11 [Info]:
   hProp
   : type
   = hLevel 1
 
-hlevel.cooltt:34.10-34.15 [Info]:
+hlevel.cooltt:33.10-33.15 [Info]:
   Computed normal form of hProp as
    (A : type) × (c : A) → (c' : A) → ext {i => A} {i => i = 0 ∨ i = 1} {
                                      i _x => [ i = 0 => c | i = 1 => c' ]}
@@ -712,13 +712,19 @@ record.cooltt:11.6-11.11 [Info]:
 record.cooltt:12.6-12.19 [Info]:
   basic.inhabit
   : basic
-  = struct (foo.x : 1) (bar : {x => x}) 
+  = struct (foo.x : 1) (bar : {x => suc x}) 
 
 record.cooltt:13.10-13.23 [Info]:
   Computed normal form of basic.inhabit as
-   struct (foo.x : 1) (bar : {x => x}) 
+   struct (foo.x : 1) (bar : {x => suc x}) 
 
-record.cooltt:30.6-30.12 [Info]:
+record.cooltt:14.10-14.29 [Info]:
+  Computed normal form of basic.inhabit @ foo.x as 1
+
+record.cooltt:15.10-15.29 [Info]:
+  Computed normal form of {basic.inhabit @ bar} 1 as 2
+
+record.cooltt:32.6-32.12 [Info]:
   depend
   : type
   = sig (tp : type) (fun : (_x : tp) → tp) 


### PR DESCRIPTION
## Patch Description

This PR updates the grammar for projections to allow for the following syntax:
```
normalize basic.inhabit@bar 1
```
Prior to this change, brackets were required, like so:
```
normalize {basic.inhabit@bar} 1
```