### PR TITLE
⚡ Optimize PP.Env

### DIFF
--- a/src/basis/Pp.ml
+++ b/src/basis/Pp.ml
@@ -28,24 +28,12 @@ struct
      When the name we are trying to freshen already has a numeric suffix, (For instance: x4)
      we split the name into it's "base" and the suffix, and begin the search at the suffix
      rather than 0. *)
-  let char_num (c : char) : int option =
-    (* 48 is the ASCII code for 0. *)
-    let n = Char.code c - 48 in
-    if n < 0 || n > 9 then None else Some n
 
-  (* Split a name into a base and a numerical suffix. *)
+
+  (** Split a name into a base and a numerical suffix. *)
   let split_name (nm : string) : string * (int option) =
-    let buf = Buffer.create 16 in
-    let handle_char sfx c =
-      match char_num c with
-      | Some n -> Some (Option.fold ~none:n ~some:(fun x -> (x * 10) + n) sfx)
-      | None ->
-         let _ = Option.iter (fun n -> Buffer.add_string buf @@ Int.to_string n) sfx in
-         let _ = Buffer.add_char buf c in
-         None
-    in
-    let sfx = CCString.fold handle_char None nm in
-    (Buffer.contents buf, sfx)
+    let (pfx, sfx) = StringUtil.rpartition StringUtil.is_digit nm in
+    (pfx, int_of_string_opt sfx)
 
   (** Compute the largest name still in use for a name. *)
   let lower_bound x env =

--- a/src/basis/Pp.ml
+++ b/src/basis/Pp.ml
@@ -1,13 +1,19 @@
 type 'a printer = Format.formatter -> 'a -> unit
 
-open Bwd
-open BwdNotation
+module StringSet = Set.Make(String)
 
 module Env =
 struct
-  type t = string bwd
+  (* [NOTE: Pretty Printer Environments]
+     After some profiling, it turns out that we were spending
+     a /huge/ amount of time generating fresh names + looking
+     up DeBruijin indexed names. To avoid any sneaky O(n^2)
+     behaviour, we use a sort of bump-allocator. *)
+  type t = { names : string CCVector.vector;
+             bound : int;
+             used : StringSet.t }
 
-  let emp = Emp
+  let emp : t = { names = CCVector.create (); bound = 0; used = StringSet.empty }
 
   let nat_to_suffix n =
     let formatted = string_of_int n in
@@ -16,32 +22,53 @@ struct
     List.init (String.length formatted) @@
     fun n -> lookup (Char.code (String.get formatted n) - Char.code '0')
 
-  let rec rename xs x i =
-    let suffix = nat_to_suffix i in
-    let new_x = x ^ suffix in
-    if Bwd.mem new_x xs then (rename [@tailcall]) xs x (i + 1) else new_x
+  let suffix_name nm i =
+    if i == 0 then nm
+    else nm ^ (nat_to_suffix i)
 
-  let choose_name (env : t) (x : string) =
-    if Bwd.mem x env then rename env x 1 else x
+  (* [NOTE: Fresh Names]
+     To find the "best" fresh name possible, we perform a sort of binary search.
+     We start by checking 'x1, x2, x4, x8...' until we find some name that isn't
+     in use yet. Once we have found this, we do a binary search between 'x_{n/2}' and 'x_{n}'
+     to find the smallest name not yet in use. *)
+  let upper_bound x env =
+    let rec go i =
+      if StringSet.mem (suffix_name x i) env.used then go (i * 2)
+      else i
+    in if StringSet.mem x env.used then go 1 else 0
 
-  let var i env =
-    if i < Bwd.length env then
-      Bwd.nth env i
+  let rec binary_search x lo hi env =
+    let mid = lo + (hi - lo)/2 in
+    let xmid = suffix_name x mid in
+    if hi <= lo then xmid
+    else if (StringSet.mem xmid env.used) then binary_search x (mid + 1) hi env
+    else binary_search x lo mid env
+
+  let rename x env =
+    let u = upper_bound x env in
+    binary_search x (u / 2) u env
+
+  let var i (env : t) =
+    if i < env.bound then
+      (* As these are DeBrujin /indicies/, we need perform our look up from
+         the back end of the bound section of the names. *)
+      CCVector.get env.names (env.bound - i - 1)
     else
       failwith "Pp printer: tried to resolve bound variable out of range"
 
-  let proj xs =
-    match xs with
-    | Emp -> failwith "ppenv/proj"
-    | Snoc (xs, _) -> xs
+  let proj (env : t) : t =
+    let nm = var (env.bound - 1) env in
+    { env with bound = env.bound - 1; used = StringSet.remove nm env.used }
 
-  let bind (env : t) (nm : string option) : string * t =
-    let x =
-      match nm with
-      | None -> choose_name env "_x"
-      | Some x -> choose_name env x
+  let bind (env : t) (onm : string option) : string * t =
+    let nm = Option.value ~default:"_x" onm in
+    let rnm = rename nm env in
+    let _ =
+      if CCVector.length env.names <= env.bound
+      then CCVector.push env.names rnm
+      else CCVector.set env.names env.bound rnm
     in
-    x, env #< x
+    rnm, { env with bound = env.bound + 1; used = StringSet.add rnm env.used }
 
   let rec bindn (env : t) (nms : string option list) : string list * t =
     match nms with
@@ -53,7 +80,7 @@ struct
       (x :: xs), env''
 
   let names (env : t) : string list =
-    env <>> []
+    CCSeq.to_list @@ CCSeq.take env.bound @@ CCVector.to_seq env.names
 end
 
 let pp_sep_list ?(sep = ", ") pp_elem fmt xs =

--- a/src/basis/StringUtil.ml
+++ b/src/basis/StringUtil.ml
@@ -1,0 +1,9 @@
+let is_digit =
+  function
+  | '0' .. '9' -> true
+  | _ -> false
+
+let rpartition p s =
+  let i = ref (String.length s-1) in
+  while !i >= 0 && p (String.unsafe_get s !i) do decr i done;
+  (CCString.take (!i+1) s, CCString.drop (!i+1) s)

--- a/src/basis/StringUtil.mli
+++ b/src/basis/StringUtil.mli
@@ -1,0 +1,2 @@
+val is_digit : char -> bool
+val rpartition : (char -> bool) -> string -> (string * string)

--- a/test/pp.cooltt
+++ b/test/pp.cooltt
@@ -1,0 +1,18 @@
+def test-freshen (_x : nat) : nat → nat → nat → nat :=
+  _x _x _x => _x
+
+print test-freshen
+
+def test-freshen/0 (x : nat) (x0 : nat) : nat := x0
+
+print test-freshen/0
+
+def test-freshen/split (x : nat) : {nat → nat} × {nat → nat} :=
+  [ x => x, x => x ]
+
+print test-freshen/split
+
+def test-freshen/suffix (x : nat) (x2 : nat) : nat → nat → nat → nat :=
+  x x x => x
+
+print test-freshen/suffix 

--- a/test/test.expected
+++ b/test/test.expected
@@ -4,435 +4,435 @@ circle.cooltt:20.10-20.20 [Info]:
   Computed normal form of loopn 45 as
    i =>
    hcom circle 0 1 {i = 0 ∨ i = 1}
-     {_x _x₁ =>
+     {_x _x1 =>
       [ _x = 0 =>
         hcom circle 0 1 {i = 0 ∨ i = 1}
-          {_x₃ _x₄ =>
-           [ _x₃ = 0 =>
+          {_x3 _x4 =>
+           [ _x3 = 0 =>
              hcom circle 0 1 {i = 0 ∨ i = 1}
-               {_x₆ _x₇ =>
-                [ _x₆ = 0 =>
+               {_x6 _x7 =>
+                [ _x6 = 0 =>
                   hcom circle 0 1 {i = 0 ∨ i = 1}
-                    {_x₉ _x₁₀ =>
-                     [ _x₉ = 0 =>
+                    {_x9 _x10 =>
+                     [ _x9 = 0 =>
                        hcom circle 0 1 {i = 0 ∨ i = 1}
-                         {_x₁₂ _x₁₃ =>
-                          [ _x₁₂ = 0 =>
+                         {_x12 _x13 =>
+                          [ _x12 = 0 =>
                             hcom circle 0 1 {i = 0 ∨ i = 1}
-                              {_x₁₅ _x₁₆ =>
-                               [ _x₁₅ = 0 =>
+                              {_x15 _x16 =>
+                               [ _x15 = 0 =>
                                  hcom circle 0 1 {i = 0 ∨ i = 1}
-                                   {_x₁₈ _x₁₉ =>
-                                    [ _x₁₈ = 0 =>
+                                   {_x18 _x19 =>
+                                    [ _x18 = 0 =>
                                       hcom circle 0 1 {i = 0 ∨ i = 1}
-                                        {_x₂₁ _x₂₂ =>
-                                         [ _x₂₁ = 0 =>
+                                        {_x21 _x22 =>
+                                         [ _x21 = 0 =>
                                            hcom circle 0 1 {i = 0 ∨ i = 1}
-                                             {_x₂₄ _x₂₅ =>
-                                              [ _x₂₄ = 0 =>
+                                             {_x24 _x25 =>
+                                              [ _x24 = 0 =>
                                                 hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                  {_x₂₇ _x₂₈ =>
-                                                   [ _x₂₇ = 0 =>
+                                                  {_x27 _x28 =>
+                                                   [ _x27 = 0 =>
                                                      hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                       {_x₃₀ _x₃₁ =>
-                                                        [ _x₃₀ = 0 =>
+                                                       {_x30 _x31 =>
+                                                        [ _x30 = 0 =>
                                                           hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                            {_x₃₃ _x₃₄ =>
-                                                             [ _x₃₃ = 0 =>
+                                                            {_x33 _x34 =>
+                                                             [ _x33 = 0 =>
                                                                hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                 {_x₃₆ _x₃₇ =>
-                                                                  [ _x₃₆ = 0 =>
+                                                                 {_x36 _x37 =>
+                                                                  [ _x36 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₃₉ _x₄₀ =>
+                                                                    {_x39 _x40 =>
                                                                     [ 
-                                                                    _x₃₉ = 0 =>
+                                                                    _x39 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₄₂ _x₄₃ =>
+                                                                    {_x42 _x43 =>
                                                                     [ 
-                                                                    _x₄₂ = 0 =>
+                                                                    _x42 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₄₅ _x₄₆ =>
+                                                                    {_x45 _x46 =>
                                                                     [ 
-                                                                    _x₄₅ = 0 =>
+                                                                    _x45 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₄₈ _x₄₉ =>
+                                                                    {_x48 _x49 =>
                                                                     [ 
-                                                                    _x₄₈ = 0 =>
+                                                                    _x48 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₅₁ _x₅₂ =>
+                                                                    {_x51 _x52 =>
                                                                     [ 
-                                                                    _x₅₁ = 0 =>
+                                                                    _x51 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₅₄ _x₅₅ =>
+                                                                    {_x54 _x55 =>
                                                                     [ 
-                                                                    _x₅₄ = 0 =>
+                                                                    _x54 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₅₇ _x₅₈ =>
+                                                                    {_x57 _x58 =>
                                                                     [ 
-                                                                    _x₅₇ = 0 =>
+                                                                    _x57 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₆₀ _x₆₁ =>
+                                                                    {_x60 _x61 =>
                                                                     [ 
-                                                                    _x₆₀ = 0 =>
+                                                                    _x60 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₆₃ _x₆₄ =>
+                                                                    {_x63 _x64 =>
                                                                     [ 
-                                                                    _x₆₃ = 0 =>
+                                                                    _x63 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₆₆ _x₆₇ =>
+                                                                    {_x66 _x67 =>
                                                                     [ 
-                                                                    _x₆₆ = 0 =>
+                                                                    _x66 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₆₉ _x₇₀ =>
+                                                                    {_x69 _x70 =>
                                                                     [ 
-                                                                    _x₆₉ = 0 =>
+                                                                    _x69 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₇₂ _x₇₃ =>
+                                                                    {_x72 _x73 =>
                                                                     [ 
-                                                                    _x₇₂ = 0 =>
+                                                                    _x72 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₇₅ _x₇₆ =>
+                                                                    {_x75 _x76 =>
                                                                     [ 
-                                                                    _x₇₅ = 0 =>
+                                                                    _x75 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₇₈ _x₇₉ =>
+                                                                    {_x78 _x79 =>
                                                                     [ 
-                                                                    _x₇₈ = 0 =>
+                                                                    _x78 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₈₁ _x₈₂ =>
+                                                                    {_x81 _x82 =>
                                                                     [ 
-                                                                    _x₈₁ = 0 =>
+                                                                    _x81 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₈₄ _x₈₅ =>
+                                                                    {_x84 _x85 =>
                                                                     [ 
-                                                                    _x₈₄ = 0 =>
+                                                                    _x84 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₈₇ _x₈₈ =>
+                                                                    {_x87 _x88 =>
                                                                     [ 
-                                                                    _x₈₇ = 0 =>
+                                                                    _x87 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₉₀ _x₉₁ =>
+                                                                    {_x90 _x91 =>
                                                                     [ 
-                                                                    _x₉₀ = 0 =>
+                                                                    _x90 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₉₃ _x₉₄ =>
+                                                                    {_x93 _x94 =>
                                                                     [ 
-                                                                    _x₉₃ = 0 =>
+                                                                    _x93 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₉₆ _x₉₇ =>
+                                                                    {_x96 _x97 =>
                                                                     [ 
-                                                                    _x₉₆ = 0 =>
+                                                                    _x96 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₉₉ _x₁₀₀ =>
+                                                                    {_x99 _x100 =>
                                                                     [ 
-                                                                    _x₉₉ = 0 =>
+                                                                    _x99 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₀₂ _x₁₀₃ =>
+                                                                    {_x102 _x103 =>
                                                                     [ 
-                                                                    _x₁₀₂ = 0 =>
+                                                                    _x102 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₀₅ _x₁₀₆ =>
+                                                                    {_x105 _x106 =>
                                                                     [ 
-                                                                    _x₁₀₅ = 0 =>
+                                                                    _x105 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₀₈ _x₁₀₉ =>
+                                                                    {_x108 _x109 =>
                                                                     [ 
-                                                                    _x₁₀₈ = 0 =>
+                                                                    _x108 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₁₁ _x₁₁₂ =>
+                                                                    {_x111 _x112 =>
                                                                     [ 
-                                                                    _x₁₁₁ = 0 =>
+                                                                    _x111 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₁₄ _x₁₁₅ =>
+                                                                    {_x114 _x115 =>
                                                                     [ 
-                                                                    _x₁₁₄ = 0 =>
+                                                                    _x114 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₁₇ _x₁₁₈ =>
+                                                                    {_x117 _x118 =>
                                                                     [ 
-                                                                    _x₁₁₇ = 0 =>
+                                                                    _x117 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₂₀ _x₁₂₁ =>
+                                                                    {_x120 _x121 =>
                                                                     [ 
-                                                                    _x₁₂₀ = 0 =>
+                                                                    _x120 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₂₃ _x₁₂₄ =>
+                                                                    {_x123 _x124 =>
                                                                     [ 
-                                                                    _x₁₂₃ = 0 =>
+                                                                    _x123 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₂₆ _x₁₂₇ =>
+                                                                    {_x126 _x127 =>
                                                                     [ 
-                                                                    _x₁₂₆ = 0 =>
+                                                                    _x126 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₂₉ _x₁₃₀ =>
+                                                                    {_x129 _x130 =>
                                                                     [ 
-                                                                    _x₁₂₉ = 0 =>
+                                                                    _x129 = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₃₂ _x₁₃₃ =>
+                                                                    {_x132 _x133 =>
                                                                     [ 
-                                                                    _x₁₃₂ = 0 =>
+                                                                    _x132 = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₃₂
+                                                                    loop _x132
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₂₉
+                                                                    loop _x129
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₂₆
+                                                                    loop _x126
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₂₃
+                                                                    loop _x123
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₂₀
+                                                                    loop _x120
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₁₇
+                                                                    loop _x117
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₁₄
+                                                                    loop _x114
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₁₁
+                                                                    loop _x111
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₀₈
+                                                                    loop _x108
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₀₅
+                                                                    loop _x105
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₀₂
+                                                                    loop _x102
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₉₉
+                                                                    loop _x99
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₉₆
+                                                                    loop _x96
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₉₃
+                                                                    loop _x93
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₉₀
+                                                                    loop _x90
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₈₇
+                                                                    loop _x87
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₈₄
+                                                                    loop _x84
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₈₁
+                                                                    loop _x81
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₇₈
+                                                                    loop _x78
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₇₅
+                                                                    loop _x75
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₇₂
+                                                                    loop _x72
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₆₉
+                                                                    loop _x69
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₆₆
+                                                                    loop _x66
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₆₃
+                                                                    loop _x63
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₆₀
+                                                                    loop _x60
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₅₇
+                                                                    loop _x57
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₅₄
+                                                                    loop _x54
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₅₁
+                                                                    loop _x51
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₄₈
+                                                                    loop _x48
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₄₅
+                                                                    loop _x45
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₄₂
+                                                                    loop _x42
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₃₉
+                                                                    loop _x39
                                                                     ]}
                                                                   | i = 0 =>
                                                                     base
                                                                   | i = 1 =>
-                                                                    loop _x₃₆
+                                                                    loop _x36
                                                                   ]}
                                                              | i = 0 => base
                                                              | i = 1 =>
-                                                               loop _x₃₃
+                                                               loop _x33
                                                              ]}
                                                         | i = 0 => base
-                                                        | i = 1 => loop _x₃₀
+                                                        | i = 1 => loop _x30
                                                         ]}
                                                    | i = 0 => base
-                                                   | i = 1 => loop _x₂₇
+                                                   | i = 1 => loop _x27
                                                    ]}
                                               | i = 0 => base
-                                              | i = 1 => loop _x₂₄
+                                              | i = 1 => loop _x24
                                               ]}
                                          | i = 0 => base
-                                         | i = 1 => loop _x₂₁
+                                         | i = 1 => loop _x21
                                          ]}
                                     | i = 0 => base
-                                    | i = 1 => loop _x₁₈
+                                    | i = 1 => loop _x18
                                     ]}
                                | i = 0 => base
-                               | i = 1 => loop _x₁₅
+                               | i = 1 => loop _x15
                                ]}
                           | i = 0 => base
-                          | i = 1 => loop _x₁₂
+                          | i = 1 => loop _x12
                           ]}
                      | i = 0 => base
-                     | i = 1 => loop _x₉
+                     | i = 1 => loop _x9
                      ]}
                 | i = 0 => base
-                | i = 1 => loop _x₆
+                | i = 1 => loop _x6
                 ]}
            | i = 0 => base
-           | i = 1 => loop _x₃
+           | i = 1 => loop _x3
            ]}
       | i = 0 => base
       | i = 1 => loop _x
@@ -442,39 +442,39 @@ circle.cooltt:20.10-20.20 [Info]:
 com.cooltt:21.10-21.19 [Info]:
   Computed normal form of mycom/fun as
    A B com/A com/B r φ p i x =>
-   com/B r φ {j _x => p j * {com/A i #f {_x₁ _x₂ => x} j}} i
+   com/B r φ {j _x => p j * {com/A i #f {_x1 _x2 => x} j}} i
 
 com.cooltt:34.10-34.16 [Info]:
   Computed normal form of coe/pi as
    A B r r' f _x =>
-   coe {_x₁ => B _x₁ {coe {_x₂ => A _x₂} r' _x₁ _x}} r r'
-     {f {coe {_x₁ => A _x₁} r' r _x}}
+   coe {_x1 => B _x1 {coe {_x2 => A _x2} r' _x1 _x}} r r'
+     {f {coe {_x1 => A _x1} r' r _x}}
 
 com.cooltt:44.10-44.19 [Info]:
   Computed normal form of coe/sigma as
    A B r r' p =>
    [ coe {_x => A _x} r r' {fst p}
-   , coe {_x => B _x {coe {_x₁ => A _x₁} r _x {fst p}}} r r' {snd p}
+   , coe {_x => B _x {coe {_x1 => A _x1} r _x {fst p}}} r r' {snd p}
    ]
 
 com.cooltt:64.10-64.19 [Info]:
   Computed normal form of coe/pathd as
    A r r' a b m _x =>
    hcom {A r' _x} r r' {_x = 0 ∨ _x = 1}
-     {_x₁ _x₂ =>
-      coe {_x₃ => A _x₃ _x} _x₁ r'
-        [ _x = 0 ∨ _x = 1 => [ _x = 0 => a _x₁ | _x = 1 => b _x₁ ]
-        | _x₁ = r => m _x
+     {_x1 _x2 =>
+      coe {_x3 => A _x3 _x} _x1 r'
+        [ _x = 0 ∨ _x = 1 => [ _x = 0 => a _x1 | _x = 1 => b _x1 ]
+        | _x1 = r => m _x
         ]}
 
 com.cooltt:80.10-80.18 [Info]:
   Computed normal form of hcom/fun as
-   A B r r' φ p _x => hcom B r r' φ {_x₁ _x₂ => p _x₁ _x₂ _x}
+   A B r r' φ p _x => hcom B r r' φ {_x1 _x2 => p _x1 _x2 _x}
 
 com.cooltt:89.10-89.19 [Info]:
   Computed normal form of com/intro as
    A r r' φ p =>
-   hcom {A r'} r r' φ {_x _x₁ => coe {_x₂ => A _x₂} _x r' {p _x _x₁}}
+   hcom {A r'} r r' φ {_x _x1 => coe {_x2 => A _x2} _x r' {p _x _x1}}
 
 --------------------[elab.cooltt]--------------------
 elab.cooltt:7.10-7.23 [Info]:
@@ -499,7 +499,7 @@ elab.cooltt:35.9-35.16 [Info]:
   Emitted hole:
     y : nat
     z : nat
-    |- ?tmhole : (z₁ : nat) → ?tyhole y z z₁
+    |- ?tmhole : (z1 : nat) → ?tyhole y z z1
 
 
 elab.cooltt:42.6-42.12 [Info]:
@@ -590,41 +590,41 @@ nat-path.cooltt:15.10-15.11 [Info]:
    coe {i =>
         C {_x =>
            hcom A 0 _x {i = 0 ∨ i = 1}
-             {k _x₁ => [ k = 0 ∨ i = 0 => p 0 | i = 1 => p k ]}}} 0 1
+             {k _x1 => [ k = 0 ∨ i = 0 => p 0 | i = 1 => p k ]}}} 0 1
      d
 
 nat-path.cooltt:56.10-56.17 [Info]:
   Computed normal form of +-assoc as
    _x =>
-   elim _x @ {_x₁ =>
+   elim _x @ {_x1 =>
               (y : nat) → (z : nat) → ext {i => nat} {i => i = 0 ∨ i = 1} {
-                                      i _x₂ =>
+                                      i _x2 =>
                                       [ i = 0 =>
-                                        elim {elim _x₁ @ {_x₄ =>
-                                                          (_x₅ : nat) → nat}
+                                        elim {elim _x1 @ {_x4 =>
+                                                          (_x5 : nat) → nat}
                                                 [ zero => n => n
-                                                | suc => _x₄ ih n =>
+                                                | suc => _x4 ih n =>
                                                          suc {ih n}
-                                                ] y} @ {_x₄ =>
-                                                        (_x₅ : nat) → nat}
+                                                ] y} @ {_x4 =>
+                                                        (_x5 : nat) → nat}
                                           [ zero => n => n
-                                          | suc => _x₄ ih n => suc {ih n}
+                                          | suc => _x4 ih n => suc {ih n}
                                           ] z
                                       | i = 1 =>
-                                        elim _x₁ @ {_x₄ => (_x₅ : nat) → nat}
+                                        elim _x1 @ {_x4 => (_x5 : nat) → nat}
                                           [ zero => n => n
-                                          | suc => _x₄ ih n => suc {ih n}
-                                          ] {elim y @ {_x₄ =>
-                                                       (_x₅ : nat) → nat}
+                                          | suc => _x4 ih n => suc {ih n}
+                                          ] {elim y @ {_x4 =>
+                                                       (_x5 : nat) → nat}
                                                [ zero => n => n
-                                               | suc => _x₄ ih n =>
+                                               | suc => _x4 ih n =>
                                                         suc {ih n}
                                                ] z}
                                       ]}}
      [ zero => y z i =>
-               elim y @ {_x₁ => (_x₂ : nat) → nat}
+               elim y @ {_x1 => (_x2 : nat) → nat}
                  [ zero => n => n
-                 | suc => _x₁ ih n => suc {ih n}
+                 | suc => _x1 ih n => suc {ih n}
                  ] z
      | suc => x ih y z i => suc {ih y z i}
      ]
@@ -638,21 +638,21 @@ nat-path.cooltt:58.10-58.25 [Info]:
       | i = 1 => p j
       | k = 0 =>
         hcom A 0 1 {i = 0 ∨ i = 1 ∨ j = 0 ∨ j = 1}
-          {l _x₂ =>
+          {l _x2 =>
            [ l = 0 ∨ i = 0 ∨ j = 1 =>
              hcom A 0 i {l = 0 ∨ l = 1}
-               {j₁ _x₄ => [ j₁ = 0 ∨ l = 0 => p 0 | l = 1 => p j₁ ]}
+               {j1 _x4 => [ j1 = 0 ∨ l = 0 => p 0 | l = 1 => p j1 ]}
            | i = 1 ∨ j = 0 =>
              hcom A 0 j {l = 0 ∨ l = 1}
-               {j₁ _x₄ => [ j₁ = 0 ∨ l = 0 => p 0 | l = 1 => p j₁ ]}
+               {j1 _x4 => [ j1 = 0 ∨ l = 0 => p 0 | l = 1 => p j1 ]}
            ]}
       ]}
 
 nat-path.cooltt:59.10-59.26 [Info]:
   Computed normal form of trans-right-unit as
-   A p _x _x₁ =>
-   hcom A 0 _x {_x₁ = 0 ∨ _x₁ = 1}
-     {j _x₂ => [ j = 0 ∨ _x₁ = 0 => p _x₁ | _x₁ = 1 => p 1 ]}
+   A p _x _x1 =>
+   hcom A 0 _x {_x1 = 0 ∨ _x1 = 1}
+     {j _x2 => [ j = 0 ∨ _x1 = 0 => p _x1 | _x1 = 1 => p 1 ]}
 
 nat-path.cooltt:60.10-60.25 [Info]:
   Computed normal form of trans-symm-refl as
@@ -660,20 +660,20 @@ nat-path.cooltt:60.10-60.25 [Info]:
    hcom A 0 1 {k = 0 ∨ i = 0 ∨ i = 1}
      {j _x =>
       hcom A 0 i {j = 0 ∨ j = 1}
-        {j₁ _x₁ => [ j₁ = 0 ∨ j = 1 => p 0 | j = 0 => p j₁ ]}}
+        {j1 _x1 => [ j1 = 0 ∨ j = 1 => p 0 | j = 0 => p j1 ]}}
 
 nat-path.cooltt:82.10-82.14 [Info]:
   Computed normal form of test as
    p i =>
    hcom nat 0 1 {i = 0 ∨ i = 1}
-     {_x _x₁ =>
+     {_x _x1 =>
       [ _x = 0 ∨ i = 1 =>
-        elim {p 0} @ {_x₃ => nat} [ zero => 0
-                                  | suc => _x₃ _x₄ => 0
+        elim {p 0} @ {_x3 => nat} [ zero => 0
+                                  | suc => _x3 _x4 => 0
                                   ]
       | i = 0 =>
-        elim {p _x} @ {_x₃ => nat} [ zero => 0
-                                   | suc => _x₃ _x₄ => 0
+        elim {p _x} @ {_x3 => nat} [ zero => 0
+                                   | suc => _x3 _x4 => 0
                                    ]
       ]}
 
@@ -681,7 +681,7 @@ nat-path.cooltt:84.10-84.15 [Info]:
   Computed normal form of test2 as
    i =>
    hcom nat 0 1 {i = 0 ∨ i = 1}
-     {_x _x₁ => [ _x = 0 ∨ i = 1 => 0 | i = 0 => 0 ]}
+     {_x _x1 => [ _x = 0 ∨ i = 1 => 0 | i = 0 => 0 ]}
 
 --------------------[nat.cooltt]--------------------
 nat.cooltt:9.10-9.15 [Info]:
@@ -701,6 +701,27 @@ path-types.cooltt:32.10-32.16 [Info]:
 
 path-types.cooltt:55.10-55.17 [Info]:
   Computed normal form of pairext as A B p q h i => [ fst h i , snd h i ]
+
+--------------------[pp.cooltt]--------------------
+pp.cooltt:4.6-4.18 [Info]:
+  test-freshen
+  : (_x : nat) → (_x1 : nat) → (_x2 : nat) → (_x3 : nat) → nat
+  = _x _x1 _x2 _x3 => _x3
+
+pp.cooltt:8.6-8.20 [Info]:
+  test-freshen/0
+  : (x : nat) → (x0 : nat) → nat
+  = x x0 => x0
+
+pp.cooltt:13.6-13.24 [Info]:
+  test-freshen/split
+  : (x : nat) → (_x : (_x : nat) → nat) × (_x1 : nat) → nat
+  = x => [ x1 => x1 , x1 => x1 ]
+
+pp.cooltt:18.6-18.25 [Info]:
+  test-freshen/suffix
+  : (x : nat) → (x2 : nat) → (_x : nat) → (_x1 : nat) → (_x2 : nat) → nat
+  = x x2 x1 x3 x4 => x4
 
 --------------------[prelude.cooltt]--------------------
 --------------------[record.cooltt]--------------------
@@ -726,7 +747,7 @@ record.cooltt:30.6-30.12 [Info]:
 --------------------[selfification.cooltt]--------------------
 selfification.cooltt:8.10-8.17 [Info]:
   Computed normal form of testing as
-   _x _x₁ _x₂ p _x₃ => [ fst {p _x₃} , snd {p _x₃} ]
+   _x _x1 _x2 p _x3 => [ fst {p _x3} , snd {p _x3} ]
 
 --------------------[v.cooltt]--------------------
 v.cooltt:13.10-13.16 [Info]:
@@ -735,14 +756,14 @@ v.cooltt:13.10-13.16 [Info]:
    V r {_x => A} A {_x =>
                     [ x => x
                     , x =>
-                      [ [ x , _x₁ => x ]
+                      [ [ x , _x1 => x ]
                       , p i =>
                         [ hcom A 1 0 {i = 0 ∨ i = 1}
-                            {k _x₁ =>
+                            {k _x1 =>
                              [ k = 1 => x | i = 1 => snd p k | i = 0 => x ]}
-                        , _x₁ =>
-                          hcom A 1 _x₁ {i = 0 ∨ i = 1}
-                            {k _x₂ =>
+                        , _x1 =>
+                          hcom A 1 _x1 {i = 0 ∨ i = 1}
+                            {k _x2 =>
                              [ k = 1 => x | i = 1 => snd p k | i = 0 => x ]}
                         ]
                       ]
@@ -755,11 +776,11 @@ v.cooltt:22.10-22.15 [Info]:
   Computed normal form of cool2 as
    A a i =>
    hcom A 0 1 {i = 0}
-     {_x _x₁ =>
-      [ _x = 0 => coe {_x₃ => A} i 0 a
+     {_x _x1 =>
+      [ _x = 0 => coe {_x3 => A} i 0 a
       | i = 0 =>
         hcom A 1 0 {_x = 0 ∨ _x = 1}
-          {k _x₃ => [ k = 1 => a | _x = 1 => a | _x = 0 => a ]}
+          {k _x3 => [ k = 1 => a | _x = 1 => a | _x = 0 => a ]}
       ]}
 
 v.cooltt:28.10-28.15 [Info]:


### PR DESCRIPTION
## Patch Description
Out of curiosity, I profiled `cooltt` to see exactly what was preventing us from normalizing really big terms like `loopn 1000`. To my surprise, I found that most of cooltt is super fast, with the exception of the pretty printer environment. In fact, for terms with large amounts of anonymous variables, we were spending like 99% of our time generating fresh names + looking up DeBruijin Indexed names.

To fix this, I've replaced the `string bwd` we used for our env previously with the following data structure:
```ocaml
  type t = { names : string CCVector.vector;
             bound : int;
             used : StringSet.t }
```

This behaves somewhat like a bump-allocator, where we keep track of the current number of bound names, possibly rewriting over previously bound ones in the mutable vector. We also keep track of a set of names currently in use, and then perform a binary search suggested by @favonia to pick out fresh names.

## Results
With these optimizations in place, we can now do `loopn 10000` in under 3 seconds!