### PR TITLE
🇿 Auto-completion for zsh

### DIFF
--- a/zsh/README.md
+++ b/zsh/README.md
@@ -1,0 +1,6 @@
+Add the following lines to your `~/.zshrc`:
+
+```zsh
+fpath=(PATH-TO-COOLTT/zsh $fpath)
+compinit #if `compinit` would not be called by the end of your ~/.zshrc
+```

--- a/zsh/_cooltt
+++ b/zsh/_cooltt
@@ -1,0 +1,10 @@
+#compdef cooltt
+
+_arguments ':' \
+  '--as-file[pretend the input location]:file:_files' \
+  '(- :)--help=[get help]::format:(auto pager groff plain)' \
+  '(-i --interactive -m --mode)'{-i,--interactive}'[specify mode to "interactive"]' \
+  '(-i --interactive -m --mode)'{-m,--mode=}'[specify mode]:mode:(scripting interactve)' \
+  '(- :)--version[show version]' \
+  '(-w --width)'{-w,--width=}'[specify width for pretty printing]:width:' \
+  "1:CoolTT file:_files -g '*.cooltt'"


### PR DESCRIPTION
I removed the code that checks whether the input mode is a prefix of some recognized mode. Seriously, just press <kbd>Tab</kbd>.