### PR TITLE
🪡  Record Patches

### DIFF
--- a/src/core/Refiner.ml
+++ b/src/core/Refiner.ml
@@ -542,21 +542,20 @@ struct
       | Done -> RM.ret @@ S.Signature (Bwd.to_list tele)
     in T.Tp.rule ~name:"Signature.formation" @@ form_fields Emp tacs
 
-  let rec find_field_tac (lbl : string list) (fields : (string list * T.Chk.tac) list) : T.Chk.tac option =
+  let rec find_field_tac (fields : (string list * T.Chk.tac) list) (lbl : string list) : T.Chk.tac option =
     match fields with
     | (lbl', tac) :: _ when equal_path (lbl : string list) lbl'  ->
       Some tac
     | _ :: fields ->
-      find_field_tac lbl fields
+      find_field_tac fields lbl
     | [] ->
       None
 
 
-  let rec intro_fields phi phi_clo (sign : D.sign) (tacs : (string list * T.Chk.tac) list) : (string list * S.t) list m =
+  let rec intro_fields phi phi_clo (sign : D.sign) (tacs : string list -> T.Chk.tac option) : (string list * S.t) list m =
     match sign with
     | D.Field (lbl, tp, sign_clo) ->
-      let tac =
-        match find_field_tac lbl tacs with
+      let tac = match tacs lbl with
         | Some tac -> tac
         | None -> Hole.unleash_hole (hole_name_of_path lbl)
       in
@@ -568,7 +567,7 @@ struct
     | D.Empty ->
       RM.ret []
 
-  let intro (tacs : (string list * T.Chk.tac) list) : T.Chk.tac =
+  let intro (tacs : string list -> T.Chk.tac option) : T.Chk.tac =
     T.Chk.brule ~name:"Signature.intro" @@
     function
     | (D.Signature sign, phi, phi_clo) ->

--- a/src/core/Refiner.mli
+++ b/src/core/Refiner.mli
@@ -102,8 +102,10 @@ end
 
 module Signature : sig
   val formation : Tp.tac telescope -> Tp.tac
-  val intro : (string list * Chk.tac) list -> Chk.tac
+  val intro : (string list -> Chk.tac option) -> Chk.tac
   val proj : Syn.tac -> string list -> Syn.tac
+
+  val find_field_tac : (string list * Chk.tac) list -> string list -> Chk.tac option
 end
 
 module Sub : sig

--- a/src/core/Refiner.mli
+++ b/src/core/Refiner.mli
@@ -62,6 +62,7 @@ module Univ : sig
   val pi : Chk.tac -> Chk.tac -> Chk.tac
   val sg : Chk.tac -> Chk.tac -> Chk.tac
   val signature : (string list * Chk.tac) list -> Chk.tac
+  val patch : Chk.tac -> (string list * Chk.tac) list -> Chk.tac
   val ext : int -> Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac
   val code_v : Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac
   val coe : Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac -> Syn.tac

--- a/src/core/Semantics.ml
+++ b/src/core/Semantics.ml
@@ -993,6 +993,13 @@ and whnf_tp_ ~style tp =
   | `Done -> ret tp
   | `Reduce tp -> ret tp
 
+and whnf_con_ ~style con =
+  let open CM in
+  whnf_con ~style con |>>
+  function
+  | `Done -> ret con
+  | `Reduce con -> ret con
+
 and do_nat_elim (mot : D.con) zero (suc : D.con) : D.con -> D.con CM.m =
   let open CM in
 

--- a/src/core/Semantics.mli
+++ b/src/core/Semantics.mli
@@ -19,6 +19,7 @@ val whnf_hd : style:whnf_style -> D.hd -> D.con whnf compute
 val whnf_tp : style:whnf_style -> D.tp -> D.tp whnf compute
 
 val whnf_tp_ : style:whnf_style -> D.tp -> D.tp compute
+val whnf_con_ : style:whnf_style -> D.con -> D.con compute
 
 val normalize_cof : D.cof -> D.cof compute
 

--- a/src/core/TermBuilder.ml
+++ b/src/core/TermBuilder.ml
@@ -95,6 +95,13 @@ let lam ?(ident = `Anon) mbdy : _ m =
   let+ bdy = mbdy var in
   S.Lam (ident, bdy)
 
+let lams idents mbdy : _ m =
+  let rec go vars =
+    function
+    | [] -> mbdy (Bwd.to_list vars)
+    | (ident :: idents) -> lam ~ident @@ fun var -> go (Snoc (vars, var)) idents
+  in go Emp idents
+
 let rec ap m0 ms : _ m =
   match ms with
   | [] -> m0
@@ -278,7 +285,7 @@ let code_ext n mfam mcof mbdry =
 let code_pis (margs : S.t m list) (mfam : S.t m list -> S.t m) : S.t m =
   let rec go margs vars =
     match margs with
-    | (marg ::  margs) -> code_pi marg @@ lam @@ fun var -> go margs (vars @ [var])
+    | (marg ::  margs) -> code_pi (ap marg vars) @@ lam @@ fun var -> go margs (vars @ [var])
     | [] -> mfam vars
   in go margs []
 

--- a/src/core/TermBuilder.ml
+++ b/src/core/TermBuilder.ml
@@ -269,6 +269,19 @@ let code_v mr mpcode mcode mpequiv : _ m=
   and+ pequiv = mpequiv in
   S.CodeV (r, pcode, code, pequiv)
 
+let code_ext n mfam mcof mbdry =
+  let+ fam = mfam
+  and+ cof = mcof
+  and+ bdry = mbdry in
+  S.CodeExt (n, fam, `Global cof, bdry)
+
+let code_pis (margs : S.t m list) (mfam : S.t m list -> S.t m) : S.t m =
+  let rec go margs vars =
+    match margs with
+    | (marg ::  margs) -> code_pi marg @@ lam @@ fun var -> go margs (vars @ [var])
+    | [] -> mfam vars
+  in go margs []
+
 let sub mbase mphi mbdry =
   let+ base = mbase
   and+ phi = mphi
@@ -306,6 +319,12 @@ let join mphis =
 let meet mphis =
   let+ phis = MU.commute_list mphis in
   S.Cof (Cof.Meet phis)
+
+let top =
+  meet []
+
+let bot =
+  join []
 
 let forall mphi =
   let+ phi = scope mphi in

--- a/src/core/TermBuilder.mli
+++ b/src/core/TermBuilder.mli
@@ -28,6 +28,8 @@ val pair : t m -> t m -> t m
 val fst : t m -> t m
 val snd : t m -> t m
 
+val lams : Ident.t list -> (t m list -> t m) -> t m
+
 val struct_ : (string list * t m) list -> t m
 val proj : t m -> string list -> t m
 

--- a/src/core/TermBuilder.mli
+++ b/src/core/TermBuilder.mli
@@ -81,13 +81,18 @@ val code_pi : t m -> t m -> t m
 val code_sg : t m -> t m -> t m
 val code_path : t m -> t m -> t m
 val code_v : t m -> t m -> t m -> t m -> t m
+val code_ext : int -> t m -> t m -> t m -> t m
 val vproj : t m -> t m -> t m -> t m -> t m -> t m
+
+val code_pis : t m list -> (t m list -> t m) -> t m
 
 val dim0 : t m
 val dim1 : t m
 val eq : t m -> t m -> t m
 val join : t m list -> t m
 val meet : t m list -> t m
+val top : t m
+val bot : t m
 val boundary : t m -> t m
 val forall : t b -> t m
 

--- a/src/frontend/ConcreteSyntaxData.ml
+++ b/src/frontend/ConcreteSyntaxData.ml
@@ -37,6 +37,7 @@ and con_ =
   | Signature of field list
   | Struct of field list
   | Proj of con * string list
+  | Patch of con * Ident.t * field list
   | Sub of con * con * con
   | Pair of con * con
   | Fst of con

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -347,6 +347,9 @@ and chk_tm : CS.con -> T.Chk.tac =
         RM.ret @@ R.Pi.intro @@ fun _ -> chk_tm @@ CS.{node = CS.Ap (con, [CS.{node = DeBruijnLevel lvl; info = None}]); info = None}
       | D.Sg _ ->
         RM.ret @@ R.Sg.intro (chk_tm @@ CS.{node = CS.Fst con; info = None}) (chk_tm @@ CS.{node = CS.Snd con; info = None})
+      | D.Signature _ ->
+        let field_tac lbl = Option.some @@ chk_tm @@ CS.{node = CS.Proj (con, lbl); info = None} in
+        RM.ret @@ R.Signature.intro field_tac
       | _ ->
         RM.ret @@ T.Chk.syn @@ syn_tm con
 

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -263,7 +263,7 @@ and chk_tm : CS.con -> T.Chk.tac =
 
     | CS.Struct fields ->
       let tacs = List.map (fun (CS.Field field) -> (field.lbl, chk_tm field.tp)) fields in
-      R.Signature.intro tacs
+      R.Signature.intro @@ R.Signature.find_field_tac tacs
 
     | CS.Suc c ->
       R.Nat.suc (chk_tm c)

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -303,8 +303,8 @@ and chk_tm : CS.con -> T.Chk.tac =
       R.Univ.signature tacs
 
     | CS.Patch (tp, _ident, patches) ->
-       let tacs = List.map (fun (CS.Field field) -> field.lbl, chk_tm field.tp) patches in
-       R.Univ.patch (chk_tm tp) tacs
+      let tacs = List.map (fun (CS.Field field) -> field.lbl, chk_tm field.tp) patches in
+      R.Univ.patch (chk_tm tp) tacs
 
     | CS.V (r, pcode, code, pequiv) ->
       R.Univ.code_v (chk_tm r) (chk_tm pcode) (chk_tm code) (chk_tm pequiv)

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -302,6 +302,10 @@ and chk_tm : CS.con -> T.Chk.tac =
       let tacs = bind_sig_tacs @@ List.map (fun (CS.Field field) -> field.lbl, chk_tm field.tp) fields in
       R.Univ.signature tacs
 
+    | CS.Patch (tp, _ident, patches) ->
+       let tacs = List.map (fun (CS.Field field) -> field.lbl, chk_tm field.tp) patches in
+       R.Univ.patch (chk_tm tp) tacs
+
     | CS.V (r, pcode, code, pequiv) ->
       R.Univ.code_v (chk_tm r) (chk_tm pcode) (chk_tm code) (chk_tm pequiv)
 

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -31,7 +31,7 @@
 %token <string> ATOM
 %token <string option> HOLE_NAME
 %token LOCKED UNLOCK
-%token BANG COLON COLON_EQUALS PIPE COMMA DOT SEMI RIGHT_ARROW RRIGHT_ARROW UNDERSCORE DIM COF BOUNDARY
+%token BANG COLON COLON_EQUALS PIPE COMMA DOT DOT_EQUALS SEMI RIGHT_ARROW RRIGHT_ARROW UNDERSCORE DIM COF BOUNDARY
 %token LPR RPR LBR RBR LSQ RSQ LBANG RBANG
 %token EQUALS JOIN MEET
 %token TYPE
@@ -39,7 +39,7 @@
 %token LET IN SUB
 %token SUC NAT ZERO UNFOLD GENERALIZE WITH
 %token CIRCLE BASE LOOP
-%token SIG STRUCT PROJ
+%token SIG STRUCT PROJ AS
 %token EXT
 %token COE COM HCOM HFILL
 %token QUIT NORMALIZE PRINT DEF AXIOM
@@ -49,7 +49,7 @@
 %token TOPC BOTC
 %token V VPROJ CAP
 
-%nonassoc IN RRIGHT_ARROW SEMI
+%nonassoc IN AS RRIGHT_ARROW SEMI
 %nonassoc COLON
 %left PROJ
 %right RIGHT_ARROW TIMES
@@ -313,6 +313,11 @@ plain_term_except_cof_case:
     { Pi ([Cell {names = [`Anon]; tp = dom}], cod) }
   | dom = term; TIMES; cod = term
     { Sg ([Cell {names = [`Anon]; tp = dom}], cod) }
+  /* So the issue is when we have a cofibration split case, we will have a bunch of pipe separated things
+   We need to ensure that any patches occur in brackets...
+   */
+  | tp = term; AS; n = plain_name; ps = patches
+    { Patch (tp, n, ps) }
   | SUB; tp = atomic_term; phi = atomic_term; tm = atomic_term
     { Sub (tp, phi, tm) }
   | FST; t = atomic_term
@@ -327,10 +332,8 @@ plain_term_except_cof_case:
     { Cap t }
   | name = HOLE_NAME; SEMI; t = term
     { Hole (name, Some t) }
-
   | EXT; names = list(plain_name); RRIGHT_ARROW; fam = term; WITH; LSQ; ioption(PIPE) cases = separated_list(PIPE, cof_case); RSQ;
     { Ext (names, fam, cases) }
-
   | COE; fam = atomic_term; src = atomic_term; trg = atomic_term; body = atomic_term
     { Coe (fam, src, trg, body) }
   | HCOM; tp = atomic_term; src = atomic_term; trg = atomic_term; phi = atomic_term; body = atomic_term
@@ -353,6 +356,7 @@ cof_case:
     { let name, body = t in term_of_name name, body }
   | phi = located(plain_cof_or_atomic_term_except_name) RRIGHT_ARROW t = term
     { phi, t }
+
 
 pat_lbl:
   | ZERO
@@ -380,6 +384,14 @@ pat_arg:
 field:
   | LPR lbl = path; COLON tp = term; RPR
     { Field {lbl; tp} }
+
+patch:
+  | lbl = path; DOT_EQUALS; tp = term
+    { Field {lbl; tp} }
+
+patches:
+  | LSQ ioption(PIPE) patches = separated_list(PIPE, patch) RSQ
+  { patches }
 
 tele_cell:
   | LPR names = nonempty_list(plain_name); COLON tp = term; RPR

--- a/src/frontend/Lex.mll
+++ b/src/frontend/Lex.mll
@@ -29,6 +29,7 @@ let keywords =
     ("circle", CIRCLE);
     ("sig", SIG);
     ("struct", STRUCT);
+    ("as", AS);
     ("🍪", CIRCLE);
     ("let", LET);
     ("in", IN);
@@ -144,6 +145,8 @@ and real_token = parse
     { EQUALS }
   | "≔" | ":="
     { COLON_EQUALS }
+  | ".="
+     { DOT_EQUALS }
   | "→" | "->"
     { RIGHT_ARROW }
   | "⇒" | "=>"

--- a/test/patch.cooltt
+++ b/test/patch.cooltt
@@ -1,0 +1,2 @@
+def el : type := sig (A : type) (a : A)
+def el-patch : type := el as x [ A .= _ => nat | a .= _ => 4 ]

--- a/test/patch.cooltt
+++ b/test/patch.cooltt
@@ -1,2 +1,8 @@
 def el : type := sig (A : type) (a : A)
-def el-patch : type := el as x [ A .= _ => nat | a .= _ => 4 ]
+def el-patch : type := el as x [ A .= nat | a .= 4 ]
+
+def patch/inhabit : el-patch := struct (A : nat) (a : 4)
+def patch/inhabit/hole : el-patch := struct (A : ?) (a : ?)
+
+print el-patch
+print patch/inhabit

--- a/test/patch.cooltt
+++ b/test/patch.cooltt
@@ -6,3 +6,8 @@ def patch/inhabit/hole : el-patch := struct (A : ?) (a : ?)
 
 print el-patch
 print patch/inhabit
+
+def testing (A Z : type) (B : A → type) (p : Z → sig (x : A) (bx : B x)) (z : Z) : sig (x : A) (bx : B x) as _ [ x .= p z @ x | bx .= p z @ bx ] :=
+  p z
+
+print testing

--- a/test/test.expected
+++ b/test/test.expected
@@ -780,6 +780,27 @@ nat-path.cooltt:84.10-84.15 [Info]:
 nat.cooltt:9.10-9.15 [Info]:
   Computed normal form of + 2 3 as 5
 
+--------------------[patch.cooltt]--------------------
+patch.cooltt:5.49-5.50 [Info]:
+  Emitted hole:
+    |- ? : ext type #t {_x => nat}
+
+
+patch.cooltt:5.57-5.58 [Info]:
+  Emitted hole:
+    |- ? : ext nat #t {_x => 4}
+
+
+patch.cooltt:7.6-7.14 [Info]:
+  el-patch
+  : type
+  = sig (A : ext type #t {_x => nat}) (a : ext nat #t {_x => 4}) 
+
+patch.cooltt:8.6-8.19 [Info]:
+  patch/inhabit
+  : el-patch
+  = struct (A : nat) (a : 4) 
+
 --------------------[path-types.cooltt]--------------------
 path-types.cooltt:8.10-8.19 [Info]:
   Computed normal form of formation as

--- a/test/test.expected
+++ b/test/test.expected
@@ -809,6 +809,15 @@ patch.cooltt:8.6-8.19 [Info]:
   : el-patch
   = struct (A : nat) (a : 4) 
 
+patch.cooltt:13.6-13.13 [Info]:
+  testing
+  : (A : type) → (Z : type) → (B : (_x : A) → type) → (p : (_x : Z) → 
+  sig (x : A) (bx : B x) ) → (z : Z) → sig (x : ext A #t {_x => p z @ x}) 
+                                       (bx : ext {B {p z @ x}} #t {_x =>
+                                                                   p z @ bx})
+                                       
+  = A Z B p z => struct (x : p z @ x) (bx : p z @ bx) 
+
 --------------------[path-types.cooltt]--------------------
 path-types.cooltt:8.10-8.19 [Info]:
   Computed normal form of formation as

--- a/test/test.expected
+++ b/test/test.expected
@@ -783,12 +783,20 @@ nat.cooltt:9.10-9.15 [Info]:
 --------------------[patch.cooltt]--------------------
 patch.cooltt:5.49-5.50 [Info]:
   Emitted hole:
-    |- ? : ext type #t {_x => nat}
+    |- ? : type
+    
+    Boundary:
+    #t
+    |- nat
 
 
 patch.cooltt:5.57-5.58 [Info]:
   Emitted hole:
-    |- ? : ext nat #t {_x => 4}
+    |- ? : nat
+    
+    Boundary:
+    #t
+    |- 4
 
 
 patch.cooltt:7.6-7.14 [Info]:


### PR DESCRIPTION
## Patch Description

This PR starts work on implementing record patches as described in #266.

## Notes
This _mostly_ works, but we run into some weird issues with conversion checking. For example, the following _ought_ to typecheck:
```
def testing (A Z : type) (B : A → type)
            (p : Z → sig (x : A) (bx : B x))
            (z : Z) : sig (x : A) (bx : B x) as x [ x .= {p z} @ x | bx .= {p z} @ bx ] := p z
```

However, we get the following error:
```
  Expected sig (x : el {ext el/out A #t {_x => el/out {el/out p z} @ x}})
           
           (bx : el {ext el/out {el/out Z {el/out {el/out B p} @ x}} #t {
                     _x => el/out {el/out B p} @ bx}})
           
            =
           sig (x : el el/out A)
           
           (bx : el el/out {el/out Z z})
```
