### PR TITLE
🌾 Serialization of Terms

### DIFF
--- a/cooltt.opam
+++ b/cooltt.opam
@@ -14,6 +14,7 @@ depends: [
   "ppx_deriving" {>= "4.4.1"}
   "cmdliner" {>= "1.0"}
   "containers" {>= "3.4"}
+  "ezjsonm" {>= "1.2.0"}
   "menhir" {>= "20180703"}
   "uuseg" {>= "12.0.0"}
   "uutf" {>= "1.0.2"}

--- a/src/basis/Symbol.ml
+++ b/src/basis/Symbol.ml
@@ -1,3 +1,5 @@
+module J = Ezjsonm
+
 module type S = sig
   type t
 
@@ -6,4 +8,7 @@ module type S = sig
 
   val pp : t Pp.printer
   val show : t -> string
+
+  val serialize : t -> J.value
+  val deserialize : J.value -> t
 end

--- a/src/basis/Symbol.mli
+++ b/src/basis/Symbol.mli
@@ -1,3 +1,5 @@
+module J = Ezjsonm
+
 module type S = sig
   type t
 
@@ -6,4 +8,7 @@ module type S = sig
 
   val pp : t Pp.printer
   val show : t -> string
+
+  val serialize : t -> J.value
+  val deserialize : J.value -> t
 end

--- a/src/basis/dune
+++ b/src/basis/dune
@@ -4,5 +4,5 @@
   (:standard -w -32-38 -warn-error -a+31))
  (preprocess
   (pps ppx_deriving.std))
- (libraries uuseg uuseg.string uutf containers)
+ (libraries ezjsonm uuseg uuseg.string uutf containers)
  (public_name cooltt.basis))

--- a/src/core/CodeUnit.ml
+++ b/src/core/CodeUnit.ml
@@ -1,4 +1,9 @@
 open ContainersLabels
+open Basis
+open Bwd
+
+module J = Ezjsonm
+
 module CodeUnitID =
 struct
   type t = string option
@@ -29,6 +34,19 @@ struct
       Format.fprintf fmt "%a" Uuseg_string.pp_utf_8 nm
     | None ->
       Format.fprintf fmt "#%i" sym.index
+
+  let serialize sym =
+    `O [("origin", J.option J.string @@ sym.origin);
+        ("index", `String (Int.to_string sym.index));
+        ("name", J.option J.string @@ sym.name) ]
+
+  let deserialize : J.value -> t =
+    function
+    | `O [("origin", j_origin); ("index", j_index); ("name", j_name)] ->
+      { origin = J.get_option J.get_string j_origin;
+        index = int_of_string @@ J.get_string j_index;
+        name = J.get_option J.get_string j_name }
+    | j -> J.parse_error j "Global.deserialize"
 end
 
 module Domain = Domain.Make (Global)

--- a/src/core/CodeUnit.ml
+++ b/src/core/CodeUnit.ml
@@ -1,6 +1,5 @@
 open ContainersLabels
 open Basis
-open Bwd
 
 module J = Ezjsonm
 

--- a/src/core/CodeUnit.mli
+++ b/src/core/CodeUnit.mli
@@ -1,5 +1,7 @@
 open Basis
 
+module J = Ezjsonm
+
 module CodeUnitID :
 sig
   type t
@@ -10,7 +12,12 @@ sig
 end
 type id = CodeUnitID.t
 
-module Global : Symbol.S
+module Global :
+sig
+  include Symbol.S
+  val serialize : t -> J.value
+  val deserialize : J.value -> t
+end
 
 module Domain : module type of Domain.Make(Global)
 module Syntax : module type of Syntax.Make(Global)

--- a/src/core/CodeUnit.mli
+++ b/src/core/CodeUnit.mli
@@ -15,8 +15,6 @@ type id = CodeUnitID.t
 module Global :
 sig
   include Symbol.S
-  val serialize : t -> J.value
-  val deserialize : J.value -> t
 end
 
 module Domain : module type of Domain.Make(Global)

--- a/src/core/Serialize.ml
+++ b/src/core/Serialize.ml
@@ -1,0 +1,419 @@
+open Cubical
+open CodeUnit
+
+module S = Syntax
+module J = Ezjsonm
+
+(* Basic JSON Helpers *)
+let json_of_pair x y = `A [x; y]
+
+let json_to_pair json_to_a json_to_b =
+  function
+  | `A [j_a; j_b] ->
+     let a = json_to_a j_a in
+     let b = json_to_b j_b in
+     (a,b)
+  | j -> J.parse_error j "json_to_pair"
+
+
+let json_of_int n = `String (Int.to_string n)
+
+let json_to_int : J.value -> int =
+  function
+  | `String n -> int_of_string n
+  | j -> J.parse_error j "json_to_int"
+
+let labeled lbl v = `A (`String lbl :: v)
+
+(* Identitifers *)
+
+let json_of_ident nm = `String (Ident.to_string nm)
+
+(* FIXME: Machine names? *)
+let json_to_ident : J.value -> Ident.t =
+  function
+  | `String "<anon>" -> `Anon
+  | `String nm -> `User (String.split_on_char '.' nm)
+  | j -> J.parse_error j "json_to_ident"
+
+let json_of_path path = `String (String.concat "." path)
+
+let json_to_path =
+  function
+  | `String path -> String.split_on_char '.' path
+  | j -> J.parse_error j "json_to_path"
+
+(* Terms/Types *)
+
+let rec json_of_tm =
+  function
+  | S.Var n -> labeled "var" [json_of_int n]
+  | S.Global sym -> labeled "global" [Global.serialize sym]
+  | S.Let (tm, nm, body) -> labeled "let" [json_of_tm tm; json_of_ident nm; json_of_tm body]
+  | S.Ann (tm, tp) -> labeled "ann" [json_of_tm tm; json_of_tp tp]
+  | S.Zero -> `String "zero"
+  | S.Suc tm -> labeled "suc" [json_of_tm tm]
+  | S.NatElim (mot, zero, suc, scrut) -> labeled "nat_elim" [json_of_tm mot; json_of_tm zero; json_of_tm suc; json_of_tm scrut]
+  | S.Base -> `String "base"
+  | S.Loop tm -> labeled "loop" [json_of_tm tm]
+  | S.CircleElim (mot, base, loop, scrut) -> labeled  "circle_elim" [json_of_tm mot; json_of_tm base; json_of_tm loop; json_of_tm scrut]
+  | S.Lam (nm, body) -> labeled "lam" [json_of_ident nm; json_of_tm body]
+  | S.Ap (tm0, tm1) -> labeled "ap" [json_of_tm tm0; json_of_tm tm1]
+  | S.Pair (tm0, tm1) -> labeled "pair" [json_of_tm tm0; json_of_tm tm1]
+  | S.Fst tm -> labeled "fst" [json_of_tm tm]
+  | S.Snd tm -> labeled "snd" [json_of_tm tm]
+  | S.Struct strct -> labeled "struct" [json_of_struct strct]
+  | S.Proj (tm, path) -> labeled "proj" [json_of_tm tm; json_of_path path]
+  | S.Coe (fam, src, trg, tm) -> labeled "coe" [json_of_tm fam; json_of_tm src; json_of_tm trg; json_of_tm tm]
+  | S.HCom (code, src, trg, cof, tm) -> labeled "hcom" [json_of_tm code; json_of_tm src; json_of_tm trg; json_of_tm cof; json_of_tm tm]
+  | S.Com (fam, src, trg, cof, tm) -> labeled "com" [json_of_tm fam; json_of_tm src; json_of_tm trg; json_of_tm cof; json_of_tm tm]
+  | S.SubIn tm -> labeled "sub_in" [json_of_tm tm]
+  | S.SubOut tm -> labeled "sub_out" [json_of_tm tm]
+  | S.Dim0 -> `String "dim0"
+  | S.Dim1 -> `String "dim1"
+  | S.Cof cof -> labeled "cof" [json_of_cof cof]
+  | S.ForallCof cof -> labeled "forall" [json_of_tm cof]
+  | S.CofSplit branches -> labeled "split" @@ List.map (fun (tphi, tm) -> json_of_pair (json_of_tm tphi) (json_of_tm tm)) branches
+  | S.Prf -> `String "prf"
+  | S.ElIn tm -> labeled "el_in" [json_of_tm tm]
+  | S.ElOut tm -> labeled "el_out" [json_of_tm tm]
+  | S.Box (r, s, phi, sides, cap) -> labeled "box" [json_of_tm r; json_of_tm s; json_of_tm phi; json_of_tm sides; json_of_tm cap]
+  | S.Cap (r, s, phi, code, box) -> labeled "cap" [json_of_tm r; json_of_tm s; json_of_tm phi; json_of_tm code; json_of_tm box]
+  | S.VIn (r, pequiv, pivot, base) -> labeled "v_in" [json_of_tm r; json_of_tm pequiv; json_of_tm pivot; json_of_tm base]
+  | S.VProj (r, pcode, code, pequiv, v) -> labeled "v_proj" [json_of_tm r; json_of_tm pcode; json_of_tm code; json_of_tm pequiv; json_of_tm v]
+  | S.CodeExt (n, fam, `Global phi, tbdry) -> labeled "code_ext" [json_of_int n; json_of_tm fam; json_of_tm phi; json_of_tm tbdry]
+  | S.CodePi (tbase, tfam) -> labeled "code_pi" [json_of_tm tbase; json_of_tm tfam]
+  | S.CodeSg (tbase, tfam) -> labeled "code_sg" [json_of_tm tbase; json_of_tm tfam]
+  | S.CodeSignature sign -> labeled "code_sign" [json_of_struct sign]
+  | S.CodeNat -> `String "code_nat"
+  | S.CodeUniv -> `String "code_univ"
+  | S.CodeV (r, pcode, code, pequiv) -> labeled "code_v" [json_of_tm r; json_of_tm pcode; json_of_tm code; json_of_tm pequiv]
+  | S.CodeCircle -> `String "code_circle"
+  | S.ESub (sb, tm) -> labeled "sub" [json_of_sub sb; json_of_tm tm]
+  | S.LockedPrfIn tm -> labeled "prf_in" [json_of_tm tm]
+  | S.LockedPrfUnlock {tp; cof; prf; bdy} -> labeled "prf_unlock" [json_of_tp tp; json_of_tm cof; json_of_tm prf; json_of_tm bdy]
+
+and json_of_struct strct : J.value =
+  `O (List.map (fun (path, tm) -> (String.concat "." path, json_of_tm tm)) strct)
+
+and json_of_cof : (S.t, S.t) Cof.cof_f -> J.value =
+  function
+  | Eq (tm0, tm1) -> labeled "eq" [json_of_tm tm0; json_of_tm tm1]
+  | Join tms -> labeled "join" @@ List.map json_of_tm tms
+  | Meet tms -> labeled "meet" @@ List.map json_of_tm tms
+
+and json_of_sub : S.sub -> J.value =
+  function
+  | S.SbI -> `String "id"
+  | S.SbC (sb0, sb1) -> labeled "comp" [json_of_sub sb0; json_of_sub sb1]
+  | S.Sb1 -> `String "1"
+  | S.SbE (sb, tm) -> labeled "extend" [ json_of_sub sb; json_of_tm tm ]
+  | S.SbP -> `String "proj"
+
+
+and json_of_tp : S.tp -> J.value =
+  function
+  | S.Univ -> `String "univ"
+  | S.El tm -> labeled "el" [json_of_tm tm]
+  | S.TpVar n -> labeled "var" [json_of_int n]
+  | S.TpDim -> `String "dim"
+  | S.TpCof -> `String "cof"
+  | S.TpPrf tm -> labeled "prf" [json_of_tm tm]
+  | S.TpCofSplit branches -> labeled "split" @@ List.map (fun (cof, tp) -> json_of_pair (json_of_tm cof) (json_of_tp tp)) branches
+  | S.Sub (tp, tphi, tm) -> labeled "sub" [json_of_tp tp; json_of_tm tphi; json_of_tm tm]
+  | S.Pi (base, nm, fib) -> labeled "pi" [json_of_tp base; json_of_ident nm; json_of_tp fib ]
+  | S.Sg (base, nm, fib) -> labeled "sg" [json_of_tp base; json_of_ident nm; json_of_tp fib ]
+  | S.Signature sign -> labeled "sign" [json_of_sign sign]
+  | S.Nat -> `String "nat"
+  | S.Circle -> `String "circle"
+  | S.TpESub (sub, tp) -> labeled "subst" [json_of_sub sub; json_of_tp tp ]
+  | S.TpLockedPrf tm -> labeled "locked" [json_of_tm tm]
+
+and json_of_sign (sign : S.sign) : J.value =
+  `O (List.map (fun (path, tp) -> (String.concat "." path, json_of_tp tp)) sign)
+
+let json_of_ctx ctx : J.value =
+  `O (List.map (fun (nm, tp) -> (Ident.to_string nm, json_of_tp tp)) ctx)
+
+let serialize_goal (ctx : (Ident.t * S.tp) list) (tp : S.tp) : J.t =
+  `O [ ("ctx", json_of_ctx ctx);
+       ("goal", json_of_tp tp) ]
+
+(* FIXME: None of this needs monadic context! *)
+let rec json_to_tm : J.value -> S.t =
+  function
+  | `A [`String "var"; j_n] -> S.Var (json_to_int j_n)
+  | `A [`String "global"; j_sym] ->
+     let sym = Global.deserialize j_sym in
+     S.Global sym
+  | `A [`String "let"; j_tm; j_nm; j_body] ->
+     let tm = json_to_tm j_tm in
+     let nm = json_to_ident j_nm in
+     let body = json_to_tm j_body in
+     S.Let (tm, nm, body)
+  | `A [`String "ann"; j_tm; j_tp] ->
+     let tm = json_to_tm j_tm in
+     let tp = json_to_tp j_tp in
+     S.Ann (tm, tp)
+  | `String "zero" -> S.Zero
+  | `A [`String "suc"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.Suc tm
+  | `A [`String "nat_elim"; j_mot; j_zero; j_suc; j_scrut] ->
+     let mot = json_to_tm j_mot in
+     let zero = json_to_tm j_zero in
+     let suc = json_to_tm j_suc in
+     let scrut = json_to_tm j_scrut in
+     S.NatElim (mot, zero, suc, scrut)
+  | `String "base" -> S.Base
+  | `A [`String "loop"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.Loop tm
+  | `A [`String "circle_elim"; j_mot; j_base; j_loop; j_scrut] ->
+     let mot = json_to_tm j_mot in
+     let base = json_to_tm j_base in
+     let loop = json_to_tm j_loop in
+     let scrut = json_to_tm j_scrut in
+     S.CircleElim (mot, base, loop, scrut)
+  | `A [`String "lam"; j_nm; j_body] ->
+     let nm = json_to_ident j_nm in
+     let body = json_to_tm j_body in
+     S.Lam (nm, body)
+  | `A [`String "ap"; j_tm0; j_tm1] ->
+     let tm0 = json_to_tm j_tm0 in
+     let tm1 = json_to_tm j_tm1 in
+     S.Ap (tm0, tm1)
+  | `A [`String "pair"; j_tm0; j_tm1] ->
+     let tm0 = json_to_tm j_tm0 in
+     let tm1 = json_to_tm j_tm1 in
+     S.Pair (tm0, tm1)
+  | `A [`String "fst"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.Fst tm
+  | `A [`String "snd"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.Snd tm
+  | `A [`String "struct"; j_strct] ->
+     let strct = json_to_struct j_strct in
+     S.Struct strct
+  | `A [`String "proj"; j_tm; j_path] ->
+     let tm = json_to_tm j_tm in
+     let path = json_to_path j_path in
+     S.Proj (tm, path)
+  | `A [`String "coe"; j_fam; j_src; j_trg; j_tm] ->
+     let fam = json_to_tm j_fam in
+     let src = json_to_tm j_src in
+     let trg = json_to_tm j_trg in
+     let tm = json_to_tm j_tm in
+     S.Coe (fam, src, trg, tm)
+  | `A [`String "hcom"; j_code; j_src; j_trg; j_cof; j_tm] ->
+     let code = json_to_tm j_code in
+     let src = json_to_tm j_src in
+     let trg = json_to_tm j_trg in
+     let cof = json_to_tm j_cof in
+     let tm = json_to_tm j_tm in
+     S.HCom (code, src, trg, cof, tm)
+  | `A [`String "com"; j_fam; j_src; j_trg; j_cof; j_tm] ->
+     let fam = json_to_tm j_fam in
+     let src = json_to_tm j_src in
+     let trg = json_to_tm j_trg in
+     let cof = json_to_tm j_cof in
+     let tm = json_to_tm j_tm in
+     S.Com (fam, src, trg, cof, tm)
+  | `A [`String "sub_in"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.SubIn tm
+  | `A [`String "sub_out"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.SubOut tm
+  | `String "dim0" -> S.Dim0
+  | `String "dim1" -> S.Dim1
+  | `A [`String "cof"; j_cof] ->
+     let cof = json_to_cof j_cof in
+     S.Cof cof
+  | `A [`String "forall"; j_cof] ->
+     let cof = json_to_tm j_cof in
+     S.ForallCof cof
+  | `A (`String "split" :: j_branches) ->
+     let branches = List.map (json_to_pair json_to_tm json_to_tm) j_branches in
+     S.CofSplit branches
+  | `String "prf" -> S.Prf
+  | `A [`String "el_in"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.ElIn tm
+  | `A [`String "el_out"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.ElOut tm
+  | `A [`String "box"; j_r; j_s; j_phi; j_sides; j_cap] ->
+     let r = json_to_tm j_r in
+     let s = json_to_tm j_s in
+     let phi = json_to_tm j_phi in
+     let sides = json_to_tm j_sides in
+     let cap = json_to_tm j_cap in
+     S.Box (r, s, phi, sides, cap)
+  | `A [`String "cap"; j_r; j_s; j_phi; j_code; j_box] ->
+     let r = json_to_tm j_r in
+     let s = json_to_tm j_s in
+     let phi = json_to_tm j_phi in
+     let code = json_to_tm j_code in
+     let box = json_to_tm j_box in
+     S.Cap (r, s, phi, code, box)
+  | `A [`String "v_in"; j_r; j_pequiv; j_pivot; j_base] ->
+     let r = json_to_tm j_r in
+     let pequiv = json_to_tm j_pequiv in
+     let pivot = json_to_tm j_pivot in
+     let base = json_to_tm j_base in
+     S.VIn (r, pequiv, pivot, base)
+  | `A [`String "v_proj"; j_r; j_pcode; j_code; j_pequiv; j_v] ->
+     let r = json_to_tm j_r in
+     let pcode = json_to_tm j_pcode in
+     let code = json_to_tm j_code in
+     let pequiv = json_to_tm j_pequiv in
+     let v = json_to_tm j_v in
+     S.VProj (r, pcode, code, pequiv, v)
+  | `A [`String "code_ext"; j_n; j_fam; j_phi; j_bdry] ->
+     let n = json_to_int j_n in
+     let fam = json_to_tm j_fam in
+     let phi = json_to_tm j_phi in
+     let brdy = json_to_tm j_bdry in
+     S.CodeExt (n, fam, `Global phi, brdy)
+  | `A [`String "code_pi"; j_base; j_fam] ->
+     let base = json_to_tm j_base in
+     let fam = json_to_tm j_fam in
+     S.CodePi (base, fam)
+  | `A [`String "code_sg"; j_base; j_fam] ->
+     let base = json_to_tm j_base in
+     let fam = json_to_tm j_fam in
+     S.CodeSg (base, fam)
+  | `A [`String "code_sign"; j_sign] ->
+     let sign = json_to_struct j_sign in
+     S.CodeSignature sign
+  | `String "code_nat" -> S.CodeNat
+  | `String "code_univ" -> S.CodeUniv
+  | `A [`String "code_v"; j_r; j_pcode; j_code; j_pequiv] ->
+     let r = json_to_tm j_r in
+     let pcode = json_to_tm j_pcode in
+     let code = json_to_tm j_code in
+     let pequiv = json_to_tm j_pequiv in
+     S.CodeV (r, pcode, code, pequiv)
+  | `String "code_circle" -> S.CodeCircle
+  | `A [`String "sub"; j_sb; j_tm] ->
+     let sub = json_to_sub j_sb in
+     let tm = json_to_tm j_tm in
+     S.ESub (sub, tm)
+  | `A [`String "prf_in"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.LockedPrfIn tm
+  | `A [`String "prf_unlock"; j_tp; j_cof; j_prf; j_body] ->
+     let tp = json_to_tp j_tp in
+     let cof = json_to_tm j_cof in
+     let prf = json_to_tm j_prf in
+     let bdy = json_to_tm j_body in
+     S.LockedPrfUnlock {tp; cof; prf; bdy}
+  | j -> J.parse_error j "json_to_tm"
+
+and json_to_struct : J.value -> (string list * S.t) list =
+  function
+  | `O j_strct -> j_strct |> List.map @@ fun (j_path, j_tm) ->
+    let path = String.split_on_char '.' j_path in
+    let tm = json_to_tm j_tm in
+    (path, tm)
+  | j -> J.parse_error j "json_to_struct"
+
+and json_to_cof : J.value -> (S.t, S.t) Cof.cof_f =
+  function
+  | `A [`String "eq"; j_tm0; j_tm1] ->
+     let tm0 = json_to_tm j_tm0 in
+     let tm1 = json_to_tm j_tm1 in
+     Cof.Eq (tm0, tm1)
+  | `A (`String "join" :: j_tms) ->
+     let tms = List.map json_to_tm j_tms in
+     Cof.Join tms
+  | `A (`String "meet" :: j_tms) ->
+     let tms = List.map json_to_tm j_tms in
+     Cof.Meet tms
+  | j -> J.parse_error j "json_to_cof"
+and json_to_sub : J.value -> S.sub =
+  function
+  | `String "id" -> S.SbI
+  | `A [`String "comp"; j_sb0; j_sb1] ->
+     let sb0 = json_to_sub j_sb0 in
+     let sb1 = json_to_sub j_sb1 in
+     S.SbC (sb0, sb1)
+  | `String "1" -> S.Sb1
+  | `A [`String "extend"; j_sb; j_tm] ->
+     let sb = json_to_sub j_sb in
+     let tm = json_to_tm j_tm in
+     S.SbE (sb, tm)
+  | `String "proj" -> S.SbP
+  | j -> J.parse_error j "json_to_sub"
+
+and json_to_tp : J.value -> S.tp =
+  function
+  | `String "univ" -> S.Univ
+  | `A [`String "el"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.El tm
+  | `A [`String "var"; j_n] ->
+     let n = json_to_int j_n in
+     S.TpVar n
+  | `String "dim" -> S.TpDim
+  | `String "cof" -> S.TpCof
+  | `A [`String "prf"; j_prf] ->
+     let prf = json_to_tm j_prf in
+     S.TpPrf prf
+  | `A (`String "split" :: j_branches) ->
+     let branches = List.map (json_to_pair json_to_tm json_to_tp) j_branches in
+     S.TpCofSplit branches
+  | `A [`String "sub"; j_tp; j_tphi; j_tm] ->
+     let tp = json_to_tp j_tp in
+     let phi = json_to_tm j_tphi in
+     let tm = json_to_tm j_tm in
+     S.Sub (tp, phi, tm)
+  | `A [`String "pi"; j_base; j_nm; j_fib] ->
+     let base = json_to_tp j_base in
+     let nm = json_to_ident j_nm in
+     let fib = json_to_tp j_fib in
+     S.Pi (base, nm, fib)
+  | `A [`String "sg"; j_base; j_nm; j_fib] ->
+     let base = json_to_tp j_base in
+     let nm = json_to_ident j_nm in
+     let fib = json_to_tp j_fib in
+     S.Pi (base, nm, fib)
+  | `A [`String "sign"; j_sign] ->
+     let sign = json_to_sign j_sign in
+     S.Signature sign
+  | `String "nat" -> S.Nat
+  | `String "circle" -> S.Nat
+  | `A [`String "subst"; j_sub; j_tp] ->
+     let sub = json_to_sub j_sub in
+     let tp = json_to_tp j_tp in
+     S.TpESub (sub, tp)
+  | `A [`String "locked"; j_tm] ->
+     let tm = json_to_tm j_tm in
+     S.TpLockedPrf tm
+  | j -> J.parse_error j "json_to_tp"
+
+and json_to_sign : J.value -> S.sign =
+  function
+  | `O j_sign -> j_sign |> List.map @@ fun (j_path, j_tp) ->
+    let path = String.split_on_char '.' j_path in
+    let tp = json_to_tp j_tp in
+    (path, tp)
+  | j -> J.parse_error j "json_to_sign"
+
+let json_to_ctx : J.value -> (Ident.t * S.tp) list =
+  function
+  | `O j_ctx -> j_ctx |> List.map @@ fun (nm_str, j_tp) ->
+    let nm = `User (String.split_on_char '.' nm_str) in
+    let tp = json_to_tp j_tp in
+    (nm, tp)
+  | j -> J.parse_error j "json_to_ctx"
+
+let deserialize_goal : J.t -> ((Ident.t * S.tp) list * S.tp) =
+  function
+  | `O [("ctx", j_ctx); ("goal", j_goal)] ->
+     let ctx = json_to_ctx j_ctx in
+     let goal = json_to_tp j_goal in
+     (ctx, goal)
+  | j -> J.parse_error (J.value j) "deserialize_goal"

--- a/src/core/Serialize.ml
+++ b/src/core/Serialize.ml
@@ -1,7 +1,10 @@
+open Basis
+open Bwd
 open Cubical
 open CodeUnit
 
 module S = Syntax
+module D = Domain
 module J = Ezjsonm
 
 (* Basic JSON Helpers *)
@@ -10,11 +13,10 @@ let json_of_pair x y = `A [x; y]
 let json_to_pair json_to_a json_to_b =
   function
   | `A [j_a; j_b] ->
-     let a = json_to_a j_a in
-     let b = json_to_b j_b in
-     (a,b)
+    let a = json_to_a j_a in
+    let b = json_to_b j_b in
+    (a,b)
   | j -> J.parse_error j "json_to_pair"
-
 
 let json_of_int n = `String (Int.to_string n)
 
@@ -22,6 +24,20 @@ let json_to_int : J.value -> int =
   function
   | `String n -> int_of_string n
   | j -> J.parse_error j "json_to_int"
+
+let json_of_alist json_of_a json_of_b xs : J.value list =
+  List.map (fun (a, b) -> json_of_pair (json_of_a a) (json_of_b b)) xs
+
+let json_to_alist json_to_a json_to_b j_alist : ('a * 'b) list =
+  List.map (json_to_pair json_to_a json_to_b) j_alist
+
+let json_of_bwd json_of_el bwd : J.value =
+  `A (Bwd.to_list @@ Bwd.map json_of_el bwd)
+
+let json_to_bwd json_to_el : J.value -> 'a bwd =
+  function
+  | `A xs -> Bwd.map json_to_el @@ Bwd.from_list xs
+  | j -> J.parse_error j "json_to_bwd"
 
 let labeled lbl v = `A (`String lbl :: v)
 
@@ -43,377 +59,504 @@ let json_to_path =
   | `String path -> String.split_on_char '.' path
   | j -> J.parse_error j "json_to_path"
 
+let json_of_labeled json_of_el els : J.value =
+  `O (List.map (fun (path, el) -> (String.concat "." path, json_of_el el)) els)
+
+let json_to_labeled json_to_el =
+  function
+  | `O j_els -> j_els |> List.map @@ fun (j_path, j_el) ->
+    let path = String.split_on_char '.' j_path in
+    let tm = json_to_el j_el in
+    (path, tm)
+  | j -> J.parse_error j "json_to_labeled"
+
+module Cof =
+struct
+  let json_of_cof_f (json_of_r : 'r -> J.value) (json_of_a : 'a -> J.value) : ('r, 'a) Cof.cof_f -> J.value =
+    function
+    | Eq (r0, r1) -> labeled "eq" [json_of_r r0; json_of_r r1]
+    | Join xs -> labeled "join" @@ List.map json_of_a xs
+    | Meet xs -> labeled "meet" @@ List.map json_of_a xs
+
+  let rec json_of_cof (json_of_r : 'r -> J.value) (json_of_v : 'v -> J.value) : ('r, 'v) Cof.cof -> J.value =
+    function
+    | Cof cof -> json_of_cof_f json_of_r (json_of_cof json_of_r json_of_v) cof
+    | Var v -> json_of_v v
+
+  let json_to_cof_f (json_to_r : J.value -> 'r) (json_to_a : J.value -> 'a) : J.value -> ('r, 'a) Cof.cof_f =
+    function
+    | `A [`String "eq"; r0; r1] -> Eq (json_to_r r0, json_to_r r1)
+    | `A (`String "join" :: xs) -> Join (List.map json_to_a xs)
+    | `A (`String "meet" :: xs) -> Meet (List.map json_to_a xs)
+    | j -> J.parse_error j "Cof.json_to_cof_f"
+end
+
 (* Terms/Types *)
+module Syntax =
+struct
 
-let rec json_of_tm =
-  function
-  | S.Var n -> labeled "var" [json_of_int n]
-  | S.Global sym -> labeled "global" [Global.serialize sym]
-  | S.Let (tm, nm, body) -> labeled "let" [json_of_tm tm; json_of_ident nm; json_of_tm body]
-  | S.Ann (tm, tp) -> labeled "ann" [json_of_tm tm; json_of_tp tp]
-  | S.Zero -> `String "zero"
-  | S.Suc tm -> labeled "suc" [json_of_tm tm]
-  | S.NatElim (mot, zero, suc, scrut) -> labeled "nat_elim" [json_of_tm mot; json_of_tm zero; json_of_tm suc; json_of_tm scrut]
-  | S.Base -> `String "base"
-  | S.Loop tm -> labeled "loop" [json_of_tm tm]
-  | S.CircleElim (mot, base, loop, scrut) -> labeled  "circle_elim" [json_of_tm mot; json_of_tm base; json_of_tm loop; json_of_tm scrut]
-  | S.Lam (nm, body) -> labeled "lam" [json_of_ident nm; json_of_tm body]
-  | S.Ap (tm0, tm1) -> labeled "ap" [json_of_tm tm0; json_of_tm tm1]
-  | S.Pair (tm0, tm1) -> labeled "pair" [json_of_tm tm0; json_of_tm tm1]
-  | S.Fst tm -> labeled "fst" [json_of_tm tm]
-  | S.Snd tm -> labeled "snd" [json_of_tm tm]
-  | S.Struct strct -> labeled "struct" [json_of_struct strct]
-  | S.Proj (tm, path) -> labeled "proj" [json_of_tm tm; json_of_path path]
-  | S.Coe (fam, src, trg, tm) -> labeled "coe" [json_of_tm fam; json_of_tm src; json_of_tm trg; json_of_tm tm]
-  | S.HCom (code, src, trg, cof, tm) -> labeled "hcom" [json_of_tm code; json_of_tm src; json_of_tm trg; json_of_tm cof; json_of_tm tm]
-  | S.Com (fam, src, trg, cof, tm) -> labeled "com" [json_of_tm fam; json_of_tm src; json_of_tm trg; json_of_tm cof; json_of_tm tm]
-  | S.SubIn tm -> labeled "sub_in" [json_of_tm tm]
-  | S.SubOut tm -> labeled "sub_out" [json_of_tm tm]
-  | S.Dim0 -> `String "dim0"
-  | S.Dim1 -> `String "dim1"
-  | S.Cof cof -> labeled "cof" [json_of_cof cof]
-  | S.ForallCof cof -> labeled "forall" [json_of_tm cof]
-  | S.CofSplit branches -> labeled "split" @@ List.map (fun (tphi, tm) -> json_of_pair (json_of_tm tphi) (json_of_tm tm)) branches
-  | S.Prf -> `String "prf"
-  | S.ElIn tm -> labeled "el_in" [json_of_tm tm]
-  | S.ElOut tm -> labeled "el_out" [json_of_tm tm]
-  | S.Box (r, s, phi, sides, cap) -> labeled "box" [json_of_tm r; json_of_tm s; json_of_tm phi; json_of_tm sides; json_of_tm cap]
-  | S.Cap (r, s, phi, code, box) -> labeled "cap" [json_of_tm r; json_of_tm s; json_of_tm phi; json_of_tm code; json_of_tm box]
-  | S.VIn (r, pequiv, pivot, base) -> labeled "v_in" [json_of_tm r; json_of_tm pequiv; json_of_tm pivot; json_of_tm base]
-  | S.VProj (r, pcode, code, pequiv, v) -> labeled "v_proj" [json_of_tm r; json_of_tm pcode; json_of_tm code; json_of_tm pequiv; json_of_tm v]
-  | S.CodeExt (n, fam, `Global phi, tbdry) -> labeled "code_ext" [json_of_int n; json_of_tm fam; json_of_tm phi; json_of_tm tbdry]
-  | S.CodePi (tbase, tfam) -> labeled "code_pi" [json_of_tm tbase; json_of_tm tfam]
-  | S.CodeSg (tbase, tfam) -> labeled "code_sg" [json_of_tm tbase; json_of_tm tfam]
-  | S.CodeSignature sign -> labeled "code_sign" [json_of_struct sign]
-  | S.CodeNat -> `String "code_nat"
-  | S.CodeUniv -> `String "code_univ"
-  | S.CodeV (r, pcode, code, pequiv) -> labeled "code_v" [json_of_tm r; json_of_tm pcode; json_of_tm code; json_of_tm pequiv]
-  | S.CodeCircle -> `String "code_circle"
-  | S.ESub (sb, tm) -> labeled "sub" [json_of_sub sb; json_of_tm tm]
-  | S.LockedPrfIn tm -> labeled "prf_in" [json_of_tm tm]
-  | S.LockedPrfUnlock {tp; cof; prf; bdy} -> labeled "prf_unlock" [json_of_tp tp; json_of_tm cof; json_of_tm prf; json_of_tm bdy]
+  let rec json_of_tm =
+    function
+    | S.Var n -> labeled "var" [json_of_int n]
+    | S.Global sym -> labeled "global" [Global.serialize sym]
+    | S.Let (tm, nm, body) -> labeled "let" [json_of_tm tm; json_of_ident nm; json_of_tm body]
+    | S.Ann (tm, tp) -> labeled "ann" [json_of_tm tm; json_of_tp tp]
+    | S.Zero -> `String "zero"
+    | S.Suc tm -> labeled "suc" [json_of_tm tm]
+    | S.NatElim (mot, zero, suc, scrut) -> labeled "nat_elim" [json_of_tm mot; json_of_tm zero; json_of_tm suc; json_of_tm scrut]
+    | S.Base -> `String "base"
+    | S.Loop tm -> labeled "loop" [json_of_tm tm]
+    | S.CircleElim (mot, base, loop, scrut) -> labeled  "circle_elim" [json_of_tm mot; json_of_tm base; json_of_tm loop; json_of_tm scrut]
+    | S.Lam (nm, body) -> labeled "lam" [json_of_ident nm; json_of_tm body]
+    | S.Ap (tm0, tm1) -> labeled "ap" [json_of_tm tm0; json_of_tm tm1]
+    | S.Pair (tm0, tm1) -> labeled "pair" [json_of_tm tm0; json_of_tm tm1]
+    | S.Fst tm -> labeled "fst" [json_of_tm tm]
+    | S.Snd tm -> labeled "snd" [json_of_tm tm]
+    | S.Struct strct -> labeled "struct" [json_of_labeled json_of_tm strct]
+    | S.Proj (tm, path) -> labeled "proj" [json_of_tm tm; json_of_path path]
+    | S.Coe (fam, src, trg, tm) -> labeled "coe" [json_of_tm fam; json_of_tm src; json_of_tm trg; json_of_tm tm]
+    | S.HCom (code, src, trg, cof, tm) -> labeled "hcom" [json_of_tm code; json_of_tm src; json_of_tm trg; json_of_tm cof; json_of_tm tm]
+    | S.Com (fam, src, trg, cof, tm) -> labeled "com" [json_of_tm fam; json_of_tm src; json_of_tm trg; json_of_tm cof; json_of_tm tm]
+    | S.SubIn tm -> labeled "sub_in" [json_of_tm tm]
+    | S.SubOut tm -> labeled "sub_out" [json_of_tm tm]
+    | S.Dim0 -> `String "dim0"
+    | S.Dim1 -> `String "dim1"
+    | S.Cof cof -> labeled "cof" [Cof.json_of_cof_f json_of_tm json_of_tm cof]
+    | S.ForallCof cof -> labeled "forall" [json_of_tm cof]
+    | S.CofSplit branches -> labeled "split" @@ List.map (fun (tphi, tm) -> json_of_pair (json_of_tm tphi) (json_of_tm tm)) branches
+    | S.Prf -> `String "prf"
+    | S.ElIn tm -> labeled "el_in" [json_of_tm tm]
+    | S.ElOut tm -> labeled "el_out" [json_of_tm tm]
+    | S.Box (r, s, phi, sides, cap) -> labeled "box" [json_of_tm r; json_of_tm s; json_of_tm phi; json_of_tm sides; json_of_tm cap]
+    | S.Cap (r, s, phi, code, box) -> labeled "cap" [json_of_tm r; json_of_tm s; json_of_tm phi; json_of_tm code; json_of_tm box]
+    | S.VIn (r, pequiv, pivot, base) -> labeled "v_in" [json_of_tm r; json_of_tm pequiv; json_of_tm pivot; json_of_tm base]
+    | S.VProj (r, pcode, code, pequiv, v) -> labeled "v_proj" [json_of_tm r; json_of_tm pcode; json_of_tm code; json_of_tm pequiv; json_of_tm v]
+    | S.CodeExt (n, fam, `Global phi, tbdry) -> labeled "code_ext" [json_of_int n; json_of_tm fam; json_of_tm phi; json_of_tm tbdry]
+    | S.CodePi (tbase, tfam) -> labeled "code_pi" [json_of_tm tbase; json_of_tm tfam]
+    | S.CodeSg (tbase, tfam) -> labeled "code_sg" [json_of_tm tbase; json_of_tm tfam]
+    | S.CodeSignature sign -> labeled "code_sign" [json_of_labeled json_of_tm sign]
+    | S.CodeNat -> `String "code_nat"
+    | S.CodeUniv -> `String "code_univ"
+    | S.CodeV (r, pcode, code, pequiv) -> labeled "code_v" [json_of_tm r; json_of_tm pcode; json_of_tm code; json_of_tm pequiv]
+    | S.CodeCircle -> `String "code_circle"
+    | S.ESub (sb, tm) -> labeled "sub" [json_of_sub sb; json_of_tm tm]
+    | S.LockedPrfIn tm -> labeled "prf_in" [json_of_tm tm]
+    | S.LockedPrfUnlock {tp; cof; prf; bdy} -> labeled "prf_unlock" [json_of_tp tp; json_of_tm cof; json_of_tm prf; json_of_tm bdy]
 
-and json_of_struct strct : J.value =
-  `O (List.map (fun (path, tm) -> (String.concat "." path, json_of_tm tm)) strct)
-
-and json_of_cof : (S.t, S.t) Cof.cof_f -> J.value =
-  function
-  | Eq (tm0, tm1) -> labeled "eq" [json_of_tm tm0; json_of_tm tm1]
-  | Join tms -> labeled "join" @@ List.map json_of_tm tms
-  | Meet tms -> labeled "meet" @@ List.map json_of_tm tms
-
-and json_of_sub : S.sub -> J.value =
-  function
-  | S.SbI -> `String "id"
-  | S.SbC (sb0, sb1) -> labeled "comp" [json_of_sub sb0; json_of_sub sb1]
-  | S.Sb1 -> `String "1"
-  | S.SbE (sb, tm) -> labeled "extend" [ json_of_sub sb; json_of_tm tm ]
-  | S.SbP -> `String "proj"
+  and json_of_sub : S.sub -> J.value =
+    function
+    | S.SbI -> `String "id"
+    | S.SbC (sb0, sb1) -> labeled "comp" [json_of_sub sb0; json_of_sub sb1]
+    | S.Sb1 -> `String "1"
+    | S.SbE (sb, tm) -> labeled "extend" [ json_of_sub sb; json_of_tm tm ]
+    | S.SbP -> `String "proj"
 
 
-and json_of_tp : S.tp -> J.value =
-  function
-  | S.Univ -> `String "univ"
-  | S.El tm -> labeled "el" [json_of_tm tm]
-  | S.TpVar n -> labeled "var" [json_of_int n]
-  | S.TpDim -> `String "dim"
-  | S.TpCof -> `String "cof"
-  | S.TpPrf tm -> labeled "prf" [json_of_tm tm]
-  | S.TpCofSplit branches -> labeled "split" @@ List.map (fun (cof, tp) -> json_of_pair (json_of_tm cof) (json_of_tp tp)) branches
-  | S.Sub (tp, tphi, tm) -> labeled "sub" [json_of_tp tp; json_of_tm tphi; json_of_tm tm]
-  | S.Pi (base, nm, fib) -> labeled "pi" [json_of_tp base; json_of_ident nm; json_of_tp fib ]
-  | S.Sg (base, nm, fib) -> labeled "sg" [json_of_tp base; json_of_ident nm; json_of_tp fib ]
-  | S.Signature sign -> labeled "sign" [json_of_sign sign]
-  | S.Nat -> `String "nat"
-  | S.Circle -> `String "circle"
-  | S.TpESub (sub, tp) -> labeled "subst" [json_of_sub sub; json_of_tp tp ]
-  | S.TpLockedPrf tm -> labeled "locked" [json_of_tm tm]
+  and json_of_tp : S.tp -> J.value =
+    function
+    | S.Univ -> `String "univ"
+    | S.El tm -> labeled "el" [json_of_tm tm]
+    | S.TpVar n -> labeled "var" [json_of_int n]
+    | S.TpDim -> `String "dim"
+    | S.TpCof -> `String "cof"
+    | S.TpPrf tm -> labeled "prf" [json_of_tm tm]
+    | S.TpCofSplit branches -> labeled "split" @@ List.map (fun (cof, tp) -> json_of_pair (json_of_tm cof) (json_of_tp tp)) branches
+    | S.Sub (tp, tphi, tm) -> labeled "sub" [json_of_tp tp; json_of_tm tphi; json_of_tm tm]
+    | S.Pi (base, nm, fib) -> labeled "pi" [json_of_tp base; json_of_ident nm; json_of_tp fib ]
+    | S.Sg (base, nm, fib) -> labeled "sg" [json_of_tp base; json_of_ident nm; json_of_tp fib ]
+    | S.Signature sign -> labeled "sign" [json_of_sign sign]
+    | S.Nat -> `String "nat"
+    | S.Circle -> `String "circle"
+    | S.TpESub (sub, tp) -> labeled "subst" [json_of_sub sub; json_of_tp tp ]
+    | S.TpLockedPrf tm -> labeled "locked" [json_of_tm tm]
 
-and json_of_sign (sign : S.sign) : J.value =
-  `O (List.map (fun (path, tp) -> (String.concat "." path, json_of_tp tp)) sign)
+  and json_of_sign : S.sign -> J.value =
+    fun sign -> json_of_labeled json_of_tp sign
 
-let json_of_ctx ctx : J.value =
-  `O (List.map (fun (nm, tp) -> (Ident.to_string nm, json_of_tp tp)) ctx)
+  let json_of_ctx ctx : J.value =
+    `O (List.map (fun (nm, tp) -> (Ident.to_string nm, json_of_tp tp)) ctx)
+
+  let rec json_to_tm : J.value -> S.t =
+    function
+    | `A [`String "var"; j_n] -> S.Var (json_to_int j_n)
+    | `A [`String "global"; j_sym] ->
+      let sym = Global.deserialize j_sym in
+      S.Global sym
+    | `A [`String "let"; j_tm; j_nm; j_body] ->
+      let tm = json_to_tm j_tm in
+      let nm = json_to_ident j_nm in
+      let body = json_to_tm j_body in
+      S.Let (tm, nm, body)
+    | `A [`String "ann"; j_tm; j_tp] ->
+      let tm = json_to_tm j_tm in
+      let tp = json_to_tp j_tp in
+      S.Ann (tm, tp)
+    | `String "zero" -> S.Zero
+    | `A [`String "suc"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.Suc tm
+    | `A [`String "nat_elim"; j_mot; j_zero; j_suc; j_scrut] ->
+      let mot = json_to_tm j_mot in
+      let zero = json_to_tm j_zero in
+      let suc = json_to_tm j_suc in
+      let scrut = json_to_tm j_scrut in
+      S.NatElim (mot, zero, suc, scrut)
+    | `String "base" -> S.Base
+    | `A [`String "loop"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.Loop tm
+    | `A [`String "circle_elim"; j_mot; j_base; j_loop; j_scrut] ->
+      let mot = json_to_tm j_mot in
+      let base = json_to_tm j_base in
+      let loop = json_to_tm j_loop in
+      let scrut = json_to_tm j_scrut in
+      S.CircleElim (mot, base, loop, scrut)
+    | `A [`String "lam"; j_nm; j_body] ->
+      let nm = json_to_ident j_nm in
+      let body = json_to_tm j_body in
+      S.Lam (nm, body)
+    | `A [`String "ap"; j_tm0; j_tm1] ->
+      let tm0 = json_to_tm j_tm0 in
+      let tm1 = json_to_tm j_tm1 in
+      S.Ap (tm0, tm1)
+    | `A [`String "pair"; j_tm0; j_tm1] ->
+      let tm0 = json_to_tm j_tm0 in
+      let tm1 = json_to_tm j_tm1 in
+      S.Pair (tm0, tm1)
+    | `A [`String "fst"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.Fst tm
+    | `A [`String "snd"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.Snd tm
+    | `A [`String "struct"; j_strct] ->
+      let strct = json_to_labeled json_to_tm j_strct in
+      S.Struct strct
+    | `A [`String "proj"; j_tm; j_path] ->
+      let tm = json_to_tm j_tm in
+      let path = json_to_path j_path in
+      S.Proj (tm, path)
+    | `A [`String "coe"; j_fam; j_src; j_trg; j_tm] ->
+      let fam = json_to_tm j_fam in
+      let src = json_to_tm j_src in
+      let trg = json_to_tm j_trg in
+      let tm = json_to_tm j_tm in
+      S.Coe (fam, src, trg, tm)
+    | `A [`String "hcom"; j_code; j_src; j_trg; j_cof; j_tm] ->
+      let code = json_to_tm j_code in
+      let src = json_to_tm j_src in
+      let trg = json_to_tm j_trg in
+      let cof = json_to_tm j_cof in
+      let tm = json_to_tm j_tm in
+      S.HCom (code, src, trg, cof, tm)
+    | `A [`String "com"; j_fam; j_src; j_trg; j_cof; j_tm] ->
+      let fam = json_to_tm j_fam in
+      let src = json_to_tm j_src in
+      let trg = json_to_tm j_trg in
+      let cof = json_to_tm j_cof in
+      let tm = json_to_tm j_tm in
+      S.Com (fam, src, trg, cof, tm)
+    | `A [`String "sub_in"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.SubIn tm
+    | `A [`String "sub_out"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.SubOut tm
+    | `String "dim0" -> S.Dim0
+    | `String "dim1" -> S.Dim1
+    | `A [`String "cof"; j_cof] ->
+      let cof = Cof.json_to_cof_f json_to_tm json_to_tm j_cof in
+      S.Cof cof
+    | `A [`String "forall"; j_cof] ->
+      let cof = json_to_tm j_cof in
+      S.ForallCof cof
+    | `A (`String "split" :: j_branches) ->
+      let branches = List.map (json_to_pair json_to_tm json_to_tm) j_branches in
+      S.CofSplit branches
+    | `String "prf" -> S.Prf
+    | `A [`String "el_in"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.ElIn tm
+    | `A [`String "el_out"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.ElOut tm
+    | `A [`String "box"; j_r; j_s; j_phi; j_sides; j_cap] ->
+      let r = json_to_tm j_r in
+      let s = json_to_tm j_s in
+      let phi = json_to_tm j_phi in
+      let sides = json_to_tm j_sides in
+      let cap = json_to_tm j_cap in
+      S.Box (r, s, phi, sides, cap)
+    | `A [`String "cap"; j_r; j_s; j_phi; j_code; j_box] ->
+      let r = json_to_tm j_r in
+      let s = json_to_tm j_s in
+      let phi = json_to_tm j_phi in
+      let code = json_to_tm j_code in
+      let box = json_to_tm j_box in
+      S.Cap (r, s, phi, code, box)
+    | `A [`String "v_in"; j_r; j_pequiv; j_pivot; j_base] ->
+      let r = json_to_tm j_r in
+      let pequiv = json_to_tm j_pequiv in
+      let pivot = json_to_tm j_pivot in
+      let base = json_to_tm j_base in
+      S.VIn (r, pequiv, pivot, base)
+    | `A [`String "v_proj"; j_r; j_pcode; j_code; j_pequiv; j_v] ->
+      let r = json_to_tm j_r in
+      let pcode = json_to_tm j_pcode in
+      let code = json_to_tm j_code in
+      let pequiv = json_to_tm j_pequiv in
+      let v = json_to_tm j_v in
+      S.VProj (r, pcode, code, pequiv, v)
+    | `A [`String "code_ext"; j_n; j_fam; j_phi; j_bdry] ->
+      let n = json_to_int j_n in
+      let fam = json_to_tm j_fam in
+      let phi = json_to_tm j_phi in
+      let brdy = json_to_tm j_bdry in
+      S.CodeExt (n, fam, `Global phi, brdy)
+    | `A [`String "code_pi"; j_base; j_fam] ->
+      let base = json_to_tm j_base in
+      let fam = json_to_tm j_fam in
+      S.CodePi (base, fam)
+    | `A [`String "code_sg"; j_base; j_fam] ->
+      let base = json_to_tm j_base in
+      let fam = json_to_tm j_fam in
+      S.CodeSg (base, fam)
+    | `A [`String "code_sign"; j_sign] ->
+      let sign = json_to_labeled json_to_tm j_sign in
+      S.CodeSignature sign
+    | `String "code_nat" -> S.CodeNat
+    | `String "code_univ" -> S.CodeUniv
+    | `A [`String "code_v"; j_r; j_pcode; j_code; j_pequiv] ->
+      let r = json_to_tm j_r in
+      let pcode = json_to_tm j_pcode in
+      let code = json_to_tm j_code in
+      let pequiv = json_to_tm j_pequiv in
+      S.CodeV (r, pcode, code, pequiv)
+    | `String "code_circle" -> S.CodeCircle
+    | `A [`String "sub"; j_sb; j_tm] ->
+      let sub = json_to_sub j_sb in
+      let tm = json_to_tm j_tm in
+      S.ESub (sub, tm)
+    | `A [`String "prf_in"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.LockedPrfIn tm
+    | `A [`String "prf_unlock"; j_tp; j_cof; j_prf; j_body] ->
+      let tp = json_to_tp j_tp in
+      let cof = json_to_tm j_cof in
+      let prf = json_to_tm j_prf in
+      let bdy = json_to_tm j_body in
+      S.LockedPrfUnlock {tp; cof; prf; bdy}
+    | j -> J.parse_error j "json_to_tm"
+
+  and json_to_sub : J.value -> S.sub =
+    function
+    | `String "id" -> S.SbI
+    | `A [`String "comp"; j_sb0; j_sb1] ->
+      let sb0 = json_to_sub j_sb0 in
+      let sb1 = json_to_sub j_sb1 in
+      S.SbC (sb0, sb1)
+    | `String "1" -> S.Sb1
+    | `A [`String "extend"; j_sb; j_tm] ->
+      let sb = json_to_sub j_sb in
+      let tm = json_to_tm j_tm in
+      S.SbE (sb, tm)
+    | `String "proj" -> S.SbP
+    | j -> J.parse_error j "json_to_sub"
+
+  and json_to_tp : J.value -> S.tp =
+    function
+    | `String "univ" -> S.Univ
+    | `A [`String "el"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.El tm
+    | `A [`String "var"; j_n] ->
+      let n = json_to_int j_n in
+      S.TpVar n
+    | `String "dim" -> S.TpDim
+    | `String "cof" -> S.TpCof
+    | `A [`String "prf"; j_prf] ->
+      let prf = json_to_tm j_prf in
+      S.TpPrf prf
+    | `A (`String "split" :: j_branches) ->
+      let branches = List.map (json_to_pair json_to_tm json_to_tp) j_branches in
+      S.TpCofSplit branches
+    | `A [`String "sub"; j_tp; j_tphi; j_tm] ->
+      let tp = json_to_tp j_tp in
+      let phi = json_to_tm j_tphi in
+      let tm = json_to_tm j_tm in
+      S.Sub (tp, phi, tm)
+    | `A [`String "pi"; j_base; j_nm; j_fib] ->
+      let base = json_to_tp j_base in
+      let nm = json_to_ident j_nm in
+      let fib = json_to_tp j_fib in
+      S.Pi (base, nm, fib)
+    | `A [`String "sg"; j_base; j_nm; j_fib] ->
+      let base = json_to_tp j_base in
+      let nm = json_to_ident j_nm in
+      let fib = json_to_tp j_fib in
+      S.Pi (base, nm, fib)
+    | `A [`String "sign"; j_sign] ->
+      let sign = json_to_labeled json_to_tp j_sign in
+      S.Signature sign
+    | `String "nat" -> S.Nat
+    | `String "circle" -> S.Nat
+    | `A [`String "subst"; j_sub; j_tp] ->
+      let sub = json_to_sub j_sub in
+      let tp = json_to_tp j_tp in
+      S.TpESub (sub, tp)
+    | `A [`String "locked"; j_tm] ->
+      let tm = json_to_tm j_tm in
+      S.TpLockedPrf tm
+    | j -> J.parse_error j "json_to_tp"
+
+  let json_to_ctx : J.value -> (Ident.t * S.tp) list =
+    function
+    | `O j_ctx -> j_ctx |> List.map @@ fun (nm_str, j_tp) ->
+      let nm = `User (String.split_on_char '.' nm_str) in
+      let tp = json_to_tp j_tp in
+      (nm, tp)
+    | j -> J.parse_error j "json_to_ctx"
+
+end
+
+module Domain =
+struct
+
+  let rec json_of_con : D.con -> J.value =
+    function
+    | Lam (ident, clo) -> labeled "lam" [json_of_tm_clo clo]
+    | BindSym (dim_probe, con) -> labeled "bind_sym" [DimProbe.serialize dim_probe; json_of_con con]
+    | LetSym (dim, dim_probe, con) -> labeled "let_sym" [json_of_dim dim; DimProbe.serialize dim_probe; json_of_con con]
+    | Cut {tp; cut} -> labeled "cut" [json_of_tp tp; json_of_cut cut]
+    | Zero -> `String "zero"
+    | Suc con -> labeled "suc" [json_of_con con]
+    | Base -> `String "base"
+    | Loop dim -> labeled "loop" [json_of_dim dim]
+    | Pair (con0, con1) -> labeled "pair" [json_of_con con0; json_of_con con1]
+    | Struct fields -> labeled "struct" [json_of_labeled json_of_con fields]
+    | SubIn con -> labeled "sub_in" [json_of_con con]
+    | ElIn con -> labeled "el_in" [json_of_con con]
+    | Dim0 -> `String "dim0"
+    | Dim1 -> `String "dim1"
+    | DimProbe dim_probe -> labeled "dim_probe" [DimProbe.serialize dim_probe]
+    | Cof cof -> labeled "cof" [Cof.json_of_cof_f json_of_con json_of_con cof]
+    | Prf -> `String "prf"
+    | FHCom (tag, src, trg, cof, con) -> labeled "fhcom" [json_of_fhcom_tag tag; json_of_dim src; json_of_dim trg; json_of_cof cof; json_of_con con]
+    | StableCode code -> labeled "stable_code" [json_of_stable_code code]
+    | UnstableCode code -> labeled "unstable_code" [json_of_unstable_code code]
+    | Box (src, trg, cof, sides, cap) -> labeled "box" [json_of_dim src; json_of_dim trg; json_of_cof cof; json_of_con sides; json_of_con cap]
+    | VIn (s, eq, pivot, base) -> labeled "v_in" [json_of_dim s; json_of_con eq; json_of_con pivot; json_of_con base]
+    | Split branches -> labeled "split" (json_of_alist json_of_cof json_of_tm_clo branches)
+    | LockedPrfIn con -> labeled "locked_prf_in" [json_of_con con]
+
+
+  and json_of_tm_clo : D.tm_clo -> J.value =
+    function
+    | Clo (tm, env) -> labeled "clo" [Syntax.json_of_tm tm; json_of_env env]
+
+  and json_of_tp_clo : D.tp_clo -> J.value =
+    function
+    | Clo (tp, env) -> labeled "clo" [Syntax.json_of_tp tp; json_of_env env]
+
+  and json_of_sign_clo : S.sign D.clo -> J.value =
+    function
+    | Clo (sign, env) -> labeled "clo" [Syntax.json_of_sign sign; json_of_env env]
+
+  and json_of_cof (cof : D.cof) : J.value =
+    Cof.json_of_cof json_of_dim json_of_int cof
+
+  and json_of_env {tpenv; conenv} : J.value =
+    `O [("tpenv", json_of_bwd json_of_tp tpenv); ("conenv", json_of_bwd json_of_con conenv)]
+
+  (* FIXME: Should this be in the cubical part? *)
+  and json_of_dim : D.dim -> J.value =
+    function
+    | Dim0 -> `String "dim0"
+    | Dim1 -> `String "dim1"
+    | DimVar n -> labeled "dim_var" [json_of_int n]
+    | DimProbe dim_probe -> labeled "dim_probe" [DimProbe.serialize dim_probe]
+
+  and json_of_tp : D.tp -> J.value =
+    function
+    | Sub (tp, cof, clo) -> labeled "sub" [json_of_tp tp; json_of_cof cof; json_of_tm_clo clo]
+    | Univ -> `String "univ"
+    | ElCut cut -> labeled "el_cut" [json_of_cut cut]
+    | ElStable code -> labeled "el_stable" [json_of_stable_code code]
+    | ElUnstable code -> labeled "el_unstable" [json_of_unstable_code code]
+    | TpDim -> `String "tp_dim"
+    | TpCof -> `String "tp_cof"
+    | TpPrf cof -> labeled "tp_prf" [json_of_cof cof]
+    | TpSplit branches -> labeled "tp_split" (json_of_alist json_of_cof json_of_tp_clo branches)
+    | Pi (tp, ident, clo) -> labeled "pi" [json_of_tp tp; json_of_ident ident; json_of_tp_clo clo]
+    | Sg (tp, ident, clo) -> labeled "sg" [json_of_tp tp; json_of_ident ident; json_of_tp_clo clo]
+    | Signature sign -> labeled "signature" [json_of_sign sign]
+    | Nat -> `String "nat"
+    | Circle -> `String "circle"
+    | TpLockedPrf cof -> labeled "tp_locked_prf" [json_of_cof cof]
+
+  and json_of_sign : D.sign -> J.value =
+    function
+    | D.Empty -> `String "empty"
+    | D.Field (lbl, tp, clo) -> labeled "field" [json_of_path lbl; json_of_tp tp; json_of_sign_clo clo]
+
+  and json_of_hd : D.hd -> J.value =
+    function
+    | D.Global sym -> labeled "global" [Global.serialize sym]
+    | D.Var v -> labeled "var" [json_of_int v]
+    | D.Coe (code, src, trg, con) -> labeled "coe" [json_of_con code; json_of_dim src; json_of_dim trg; json_of_con con]
+    | D.UnstableCut (cut, frm) -> labeled "unstable_cut" [json_of_cut cut; json_of_unstable_frm frm]
+
+  and json_of_frm : D.frm -> J.value =
+    function
+    | D.KAp (tp, con) -> labeled "k_ap" [json_of_tp tp; json_of_con con]
+    | D.KFst -> `String "k_fst"
+    | D.KSnd -> `String "k_snd"
+    | D.KProj lbl -> labeled "k_proj" [json_of_path lbl]
+    | D.KNatElim (mot, z, s) -> labeled "k_nat_elim" [json_of_con mot; json_of_con z; json_of_con s]
+    | D.KCircleElim (mot, b, l) -> labeled "k_circle_elim" [json_of_con mot; json_of_con b; json_of_con l]
+    | D.KElOut -> `String "k_el_out"
+
+  and json_of_unstable_frm : D.unstable_frm -> J.value =
+    function
+    | D.KHCom (src, trg, cof, con) -> labeled "k_hcom" [json_of_dim src; json_of_dim trg; json_of_cof cof; json_of_con con]
+    | D.KCap (src, trg, cof, con) -> labeled "k_cap" [json_of_dim src; json_of_dim trg; json_of_cof cof; json_of_con con]
+    | D.KVProj (r, pcode, code, pequiv) -> labeled "k_vproj" [json_of_dim r; json_of_con pcode; json_of_con code; json_of_con pequiv]
+    | D.KSubOut (cof, clo) -> labeled "k_sub_out" [json_of_cof cof; json_of_tm_clo clo]
+    | D.KLockedPrfUnlock (tp, cof, con) -> labeled "k_locked_prf_unlock" [json_of_tp tp; json_of_cof cof; json_of_con con]
+
+  and json_of_cut : D.cut -> J.value =
+    fun (hd, frm) -> labeled "cut" (json_of_hd hd :: List.map json_of_frm frm)
+
+  and json_of_stable_code : D.con D.stable_code -> J.value =
+    function
+    | `Pi (base, fam) -> labeled "pi" [json_of_con base; json_of_con fam]
+    | `Sg (base, fam) -> labeled "sg" [json_of_con base; json_of_con fam]
+    | `Signature sign -> labeled "signature" [json_of_labeled json_of_con sign]
+    | `Ext (n, code, `Global phi, fam) -> labeled "ext" [json_of_int n; json_of_con code; json_of_con phi; json_of_con fam]
+    | `Nat -> `String "nat"
+    | `Circle -> `String "circle"
+    | `Univ -> `String "univ"
+
+  and json_of_unstable_code : D.con D.unstable_code -> J.value =
+    function
+    | `HCom (src, trg, cof, con) -> labeled "hcom" [json_of_dim src; json_of_dim trg; json_of_cof cof; json_of_con con]
+    | `V (r, pcode, code, pequiv) -> labeled "v" [json_of_dim r; json_of_con pcode; json_of_con code; json_of_con pequiv]
+
+  and json_of_fhcom_tag : [`Nat | `Circle] -> J.value =
+    function
+    | `Nat -> `String "nat"
+    | `Circle -> `String "circle"
+end
+
 
 let serialize_goal (ctx : (Ident.t * S.tp) list) (tp : S.tp) : J.t =
-  `O [ ("ctx", json_of_ctx ctx);
-       ("goal", json_of_tp tp) ]
-
-(* FIXME: None of this needs monadic context! *)
-let rec json_to_tm : J.value -> S.t =
-  function
-  | `A [`String "var"; j_n] -> S.Var (json_to_int j_n)
-  | `A [`String "global"; j_sym] ->
-     let sym = Global.deserialize j_sym in
-     S.Global sym
-  | `A [`String "let"; j_tm; j_nm; j_body] ->
-     let tm = json_to_tm j_tm in
-     let nm = json_to_ident j_nm in
-     let body = json_to_tm j_body in
-     S.Let (tm, nm, body)
-  | `A [`String "ann"; j_tm; j_tp] ->
-     let tm = json_to_tm j_tm in
-     let tp = json_to_tp j_tp in
-     S.Ann (tm, tp)
-  | `String "zero" -> S.Zero
-  | `A [`String "suc"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.Suc tm
-  | `A [`String "nat_elim"; j_mot; j_zero; j_suc; j_scrut] ->
-     let mot = json_to_tm j_mot in
-     let zero = json_to_tm j_zero in
-     let suc = json_to_tm j_suc in
-     let scrut = json_to_tm j_scrut in
-     S.NatElim (mot, zero, suc, scrut)
-  | `String "base" -> S.Base
-  | `A [`String "loop"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.Loop tm
-  | `A [`String "circle_elim"; j_mot; j_base; j_loop; j_scrut] ->
-     let mot = json_to_tm j_mot in
-     let base = json_to_tm j_base in
-     let loop = json_to_tm j_loop in
-     let scrut = json_to_tm j_scrut in
-     S.CircleElim (mot, base, loop, scrut)
-  | `A [`String "lam"; j_nm; j_body] ->
-     let nm = json_to_ident j_nm in
-     let body = json_to_tm j_body in
-     S.Lam (nm, body)
-  | `A [`String "ap"; j_tm0; j_tm1] ->
-     let tm0 = json_to_tm j_tm0 in
-     let tm1 = json_to_tm j_tm1 in
-     S.Ap (tm0, tm1)
-  | `A [`String "pair"; j_tm0; j_tm1] ->
-     let tm0 = json_to_tm j_tm0 in
-     let tm1 = json_to_tm j_tm1 in
-     S.Pair (tm0, tm1)
-  | `A [`String "fst"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.Fst tm
-  | `A [`String "snd"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.Snd tm
-  | `A [`String "struct"; j_strct] ->
-     let strct = json_to_struct j_strct in
-     S.Struct strct
-  | `A [`String "proj"; j_tm; j_path] ->
-     let tm = json_to_tm j_tm in
-     let path = json_to_path j_path in
-     S.Proj (tm, path)
-  | `A [`String "coe"; j_fam; j_src; j_trg; j_tm] ->
-     let fam = json_to_tm j_fam in
-     let src = json_to_tm j_src in
-     let trg = json_to_tm j_trg in
-     let tm = json_to_tm j_tm in
-     S.Coe (fam, src, trg, tm)
-  | `A [`String "hcom"; j_code; j_src; j_trg; j_cof; j_tm] ->
-     let code = json_to_tm j_code in
-     let src = json_to_tm j_src in
-     let trg = json_to_tm j_trg in
-     let cof = json_to_tm j_cof in
-     let tm = json_to_tm j_tm in
-     S.HCom (code, src, trg, cof, tm)
-  | `A [`String "com"; j_fam; j_src; j_trg; j_cof; j_tm] ->
-     let fam = json_to_tm j_fam in
-     let src = json_to_tm j_src in
-     let trg = json_to_tm j_trg in
-     let cof = json_to_tm j_cof in
-     let tm = json_to_tm j_tm in
-     S.Com (fam, src, trg, cof, tm)
-  | `A [`String "sub_in"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.SubIn tm
-  | `A [`String "sub_out"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.SubOut tm
-  | `String "dim0" -> S.Dim0
-  | `String "dim1" -> S.Dim1
-  | `A [`String "cof"; j_cof] ->
-     let cof = json_to_cof j_cof in
-     S.Cof cof
-  | `A [`String "forall"; j_cof] ->
-     let cof = json_to_tm j_cof in
-     S.ForallCof cof
-  | `A (`String "split" :: j_branches) ->
-     let branches = List.map (json_to_pair json_to_tm json_to_tm) j_branches in
-     S.CofSplit branches
-  | `String "prf" -> S.Prf
-  | `A [`String "el_in"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.ElIn tm
-  | `A [`String "el_out"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.ElOut tm
-  | `A [`String "box"; j_r; j_s; j_phi; j_sides; j_cap] ->
-     let r = json_to_tm j_r in
-     let s = json_to_tm j_s in
-     let phi = json_to_tm j_phi in
-     let sides = json_to_tm j_sides in
-     let cap = json_to_tm j_cap in
-     S.Box (r, s, phi, sides, cap)
-  | `A [`String "cap"; j_r; j_s; j_phi; j_code; j_box] ->
-     let r = json_to_tm j_r in
-     let s = json_to_tm j_s in
-     let phi = json_to_tm j_phi in
-     let code = json_to_tm j_code in
-     let box = json_to_tm j_box in
-     S.Cap (r, s, phi, code, box)
-  | `A [`String "v_in"; j_r; j_pequiv; j_pivot; j_base] ->
-     let r = json_to_tm j_r in
-     let pequiv = json_to_tm j_pequiv in
-     let pivot = json_to_tm j_pivot in
-     let base = json_to_tm j_base in
-     S.VIn (r, pequiv, pivot, base)
-  | `A [`String "v_proj"; j_r; j_pcode; j_code; j_pequiv; j_v] ->
-     let r = json_to_tm j_r in
-     let pcode = json_to_tm j_pcode in
-     let code = json_to_tm j_code in
-     let pequiv = json_to_tm j_pequiv in
-     let v = json_to_tm j_v in
-     S.VProj (r, pcode, code, pequiv, v)
-  | `A [`String "code_ext"; j_n; j_fam; j_phi; j_bdry] ->
-     let n = json_to_int j_n in
-     let fam = json_to_tm j_fam in
-     let phi = json_to_tm j_phi in
-     let brdy = json_to_tm j_bdry in
-     S.CodeExt (n, fam, `Global phi, brdy)
-  | `A [`String "code_pi"; j_base; j_fam] ->
-     let base = json_to_tm j_base in
-     let fam = json_to_tm j_fam in
-     S.CodePi (base, fam)
-  | `A [`String "code_sg"; j_base; j_fam] ->
-     let base = json_to_tm j_base in
-     let fam = json_to_tm j_fam in
-     S.CodeSg (base, fam)
-  | `A [`String "code_sign"; j_sign] ->
-     let sign = json_to_struct j_sign in
-     S.CodeSignature sign
-  | `String "code_nat" -> S.CodeNat
-  | `String "code_univ" -> S.CodeUniv
-  | `A [`String "code_v"; j_r; j_pcode; j_code; j_pequiv] ->
-     let r = json_to_tm j_r in
-     let pcode = json_to_tm j_pcode in
-     let code = json_to_tm j_code in
-     let pequiv = json_to_tm j_pequiv in
-     S.CodeV (r, pcode, code, pequiv)
-  | `String "code_circle" -> S.CodeCircle
-  | `A [`String "sub"; j_sb; j_tm] ->
-     let sub = json_to_sub j_sb in
-     let tm = json_to_tm j_tm in
-     S.ESub (sub, tm)
-  | `A [`String "prf_in"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.LockedPrfIn tm
-  | `A [`String "prf_unlock"; j_tp; j_cof; j_prf; j_body] ->
-     let tp = json_to_tp j_tp in
-     let cof = json_to_tm j_cof in
-     let prf = json_to_tm j_prf in
-     let bdy = json_to_tm j_body in
-     S.LockedPrfUnlock {tp; cof; prf; bdy}
-  | j -> J.parse_error j "json_to_tm"
-
-and json_to_struct : J.value -> (string list * S.t) list =
-  function
-  | `O j_strct -> j_strct |> List.map @@ fun (j_path, j_tm) ->
-    let path = String.split_on_char '.' j_path in
-    let tm = json_to_tm j_tm in
-    (path, tm)
-  | j -> J.parse_error j "json_to_struct"
-
-and json_to_cof : J.value -> (S.t, S.t) Cof.cof_f =
-  function
-  | `A [`String "eq"; j_tm0; j_tm1] ->
-     let tm0 = json_to_tm j_tm0 in
-     let tm1 = json_to_tm j_tm1 in
-     Cof.Eq (tm0, tm1)
-  | `A (`String "join" :: j_tms) ->
-     let tms = List.map json_to_tm j_tms in
-     Cof.Join tms
-  | `A (`String "meet" :: j_tms) ->
-     let tms = List.map json_to_tm j_tms in
-     Cof.Meet tms
-  | j -> J.parse_error j "json_to_cof"
-and json_to_sub : J.value -> S.sub =
-  function
-  | `String "id" -> S.SbI
-  | `A [`String "comp"; j_sb0; j_sb1] ->
-     let sb0 = json_to_sub j_sb0 in
-     let sb1 = json_to_sub j_sb1 in
-     S.SbC (sb0, sb1)
-  | `String "1" -> S.Sb1
-  | `A [`String "extend"; j_sb; j_tm] ->
-     let sb = json_to_sub j_sb in
-     let tm = json_to_tm j_tm in
-     S.SbE (sb, tm)
-  | `String "proj" -> S.SbP
-  | j -> J.parse_error j "json_to_sub"
-
-and json_to_tp : J.value -> S.tp =
-  function
-  | `String "univ" -> S.Univ
-  | `A [`String "el"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.El tm
-  | `A [`String "var"; j_n] ->
-     let n = json_to_int j_n in
-     S.TpVar n
-  | `String "dim" -> S.TpDim
-  | `String "cof" -> S.TpCof
-  | `A [`String "prf"; j_prf] ->
-     let prf = json_to_tm j_prf in
-     S.TpPrf prf
-  | `A (`String "split" :: j_branches) ->
-     let branches = List.map (json_to_pair json_to_tm json_to_tp) j_branches in
-     S.TpCofSplit branches
-  | `A [`String "sub"; j_tp; j_tphi; j_tm] ->
-     let tp = json_to_tp j_tp in
-     let phi = json_to_tm j_tphi in
-     let tm = json_to_tm j_tm in
-     S.Sub (tp, phi, tm)
-  | `A [`String "pi"; j_base; j_nm; j_fib] ->
-     let base = json_to_tp j_base in
-     let nm = json_to_ident j_nm in
-     let fib = json_to_tp j_fib in
-     S.Pi (base, nm, fib)
-  | `A [`String "sg"; j_base; j_nm; j_fib] ->
-     let base = json_to_tp j_base in
-     let nm = json_to_ident j_nm in
-     let fib = json_to_tp j_fib in
-     S.Pi (base, nm, fib)
-  | `A [`String "sign"; j_sign] ->
-     let sign = json_to_sign j_sign in
-     S.Signature sign
-  | `String "nat" -> S.Nat
-  | `String "circle" -> S.Nat
-  | `A [`String "subst"; j_sub; j_tp] ->
-     let sub = json_to_sub j_sub in
-     let tp = json_to_tp j_tp in
-     S.TpESub (sub, tp)
-  | `A [`String "locked"; j_tm] ->
-     let tm = json_to_tm j_tm in
-     S.TpLockedPrf tm
-  | j -> J.parse_error j "json_to_tp"
-
-and json_to_sign : J.value -> S.sign =
-  function
-  | `O j_sign -> j_sign |> List.map @@ fun (j_path, j_tp) ->
-    let path = String.split_on_char '.' j_path in
-    let tp = json_to_tp j_tp in
-    (path, tp)
-  | j -> J.parse_error j "json_to_sign"
-
-let json_to_ctx : J.value -> (Ident.t * S.tp) list =
-  function
-  | `O j_ctx -> j_ctx |> List.map @@ fun (nm_str, j_tp) ->
-    let nm = `User (String.split_on_char '.' nm_str) in
-    let tp = json_to_tp j_tp in
-    (nm, tp)
-  | j -> J.parse_error j "json_to_ctx"
+  `O [ ("ctx", Syntax.json_of_ctx ctx);
+       ("goal", Syntax.json_of_tp tp) ]
 
 let deserialize_goal : J.t -> ((Ident.t * S.tp) list * S.tp) =
   function
   | `O [("ctx", j_ctx); ("goal", j_goal)] ->
-     let ctx = json_to_ctx j_ctx in
-     let goal = json_to_tp j_goal in
-     (ctx, goal)
+    let ctx = Syntax.json_to_ctx j_ctx in
+    let goal = Syntax.json_to_tp j_goal in
+    (ctx, goal)
   | j -> J.parse_error (J.value j) "deserialize_goal"

--- a/src/core/Serialize.mli
+++ b/src/core/Serialize.mli
@@ -1,7 +1,11 @@
 open CodeUnit
 
 module S = Syntax
+module D = Domain
 module J = Ezjsonm
 
 val serialize_goal : (Ident.t * S.tp) list -> S.tp -> J.t
 val deserialize_goal : J.t -> (Ident.t * S.tp) list * S.tp
+
+val serialize_bindings : (Ident.t * D.tp * D.con option) list -> J.t
+val deserialize_bindings : J.t -> (Ident.t * D.tp * D.con option) list

--- a/src/core/Serialize.mli
+++ b/src/core/Serialize.mli
@@ -1,0 +1,7 @@
+open CodeUnit
+
+module S = Syntax
+module J = Ezjsonm
+
+val serialize_goal : (Ident.t * S.tp) list -> S.tp -> J.t
+val deserialize_goal : J.t -> (Ident.t * S.tp) list * S.tp

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,6 +1,6 @@
 (library
  (name Core)
- (libraries bantorra cooltt.basis cooltt.cubical yuujinchou)
+ (libraries bantorra cooltt.basis cooltt.cubical ezjsonm yuujinchou)
  (preprocess
   (pps ppx_deriving.std))
  (flags

--- a/src/cubical/DimProbe.ml
+++ b/src/cubical/DimProbe.ml
@@ -1,3 +1,5 @@
+module J = Ezjsonm
+
 type t = int
 
 let global = ref 0
@@ -10,6 +12,16 @@ let pp fmt p =
   Format.fprintf fmt "#%i" p
 
 let show p = Int.to_string p
+
+let serialize (p : t) : J.value =
+  `String (Int.to_string p)
+
+let deserialize : J.value -> t =
+  function
+  | `String p -> int_of_string p
+  | j -> J.parse_error j "DimProbe.deserialize"
+
+
 
 let fresh () =
   let i = !global in

--- a/src/cubical/dune
+++ b/src/cubical/dune
@@ -4,5 +4,5 @@
   (:standard -w -32-38 -warn-error -a+31))
  (preprocess
   (pps ppx_deriving.std))
- (libraries uuseg uuseg.string uutf cooltt.basis)
+ (libraries ezjsonm uuseg uuseg.string uutf cooltt.basis)
  (public_name cooltt.cubical))


### PR DESCRIPTION
## Patch Description

This PR implements serialization/deserialization of terms and types of both the `Syntax` and `Domain` variety. This is required for a couple of features, most notably some of the coolttviz stuff, as well as interface files. This closes #81.

## Notes
Currently we serialize into JSON as it is a relatively common format. I know @favonia was interested in some alternative formats, so perhaps those are worth exploring as well.