### PR TITLE
🚨 Add `fail` top-level form

### DIFF
--- a/emacs/cooltt.el
+++ b/emacs/cooltt.el
@@ -112,7 +112,7 @@
   "Syntax table for cooltt.")
 
 (defconst cooltt-declaration-keywords
-  '("def" "let" "normalize" "quit" "import")
+  '("def" "let" "normalize" "quit" "import" "fail")
   "Declaration keywords.")
 
 

--- a/src/frontend/ConcreteSyntaxData.ml
+++ b/src/frontend/ConcreteSyntaxData.ml
@@ -98,6 +98,7 @@ type decl =
   | Print of Ident.t node
   | Import of string list * con option
   | NormalizeTerm of con
+  | Fail of {name : Ident.t; args : cell list; def : con; tp : con; info : info}
   | Quit
 
 type command =

--- a/src/frontend/Driver.ml
+++ b/src/frontend/Driver.ml
@@ -63,18 +63,21 @@ let print_fail (name : Ident.t) (info : CS.info) (res : (D.tp * D.con, exn) resu
     let* tp = RM.quote_tp vtp in
     let* env = RM.read in
     let penv = Env.pp_env env in
-    let+ () = RM.emit ~lvl:`Error info (fun fmt () ->
-        Format.fprintf fmt "fail %a:@.  Expected (%a : %a) to fail but it succeded."
-          Ident.pp name
-          (Syntax.pp penv) tm
-          (Syntax.pp_tp penv) tp) ()
+    let pp_failure fmt () =
+      Format.fprintf fmt "fail %a:@.  Expected (%a : %a) to fail but it succeded."
+        Ident.pp name
+        (Syntax.pp penv) tm
+        (Syntax.pp_tp penv) tp
     in
+    let+ () = RM.emit ~lvl:`Error info pp_failure () in
     Continue Fun.id
   | Error (Err.RefineError (err, info)) ->
-    let+ () = RM.emit ~lvl:`Info info (fun fmt () ->
-        Format.fprintf fmt "fail %a:@.  %a"
-          Ident.pp name
-          RefineError.pp err) () in
+    let pp_err_info fmt () =
+      Format.fprintf fmt "fail %a:@.  %a"
+        Ident.pp name
+        RefineError.pp err
+    in
+    let+ () = RM.emit ~lvl:`Info info pp_err_info () in
     Continue Fun.id
   | Error exn ->
     let+ () = RM.emit ~lvl:`Error info PpExn.pp exn in

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -5,6 +5,9 @@
   let locate (start, stop) node =
     {node; info = Some {start; stop}}
 
+  let info_at (start, stop) : info =
+    Some {start; stop}
+
   let name_of_atoms parts = `User parts
 
   let name_of_underscore = `Anon
@@ -42,7 +45,7 @@
 %token SIG STRUCT PROJ
 %token EXT
 %token COE COM HCOM HFILL
-%token QUIT NORMALIZE PRINT DEF AXIOM
+%token QUIT NORMALIZE PRINT DEF AXIOM FAIL
 %token <string list> IMPORT
 %token ELIM
 %token SEMISEMI EOF
@@ -127,6 +130,8 @@ decl:
     { Def {name = nm; args = tele; def = Some body; tp} }
   | AXIOM; nm = plain_name; tele = list(tele_cell); COLON; tp = term
     { Def {name = nm; args = tele; def = None; tp} }
+  | FAIL; nm = plain_name; tele = list(tele_cell); COLON; tp = term; COLON_EQUALS; body = term
+    { Fail {name = nm; args = tele; def = body; tp; info = info_at $loc} }
   | QUIT
     { Quit }
   | NORMALIZE; tm = term

--- a/src/frontend/Lex.mll
+++ b/src/frontend/Lex.mll
@@ -39,6 +39,7 @@ let keywords =
     ("generalize", GENERALIZE);
     ("def", DEF);
     ("axiom", AXIOM);
+    ("fail", FAIL);
     ("normalize", NORMALIZE);
     ("print", PRINT);
     ("quit", QUIT);

--- a/test/holes.cooltt
+++ b/test/holes.cooltt
@@ -13,5 +13,7 @@ def incomplete-trans₂ (A : type) (p : 𝕀 → A) (q : (i : 𝕀) → sub A {i
 def incomplete-trans₃ (A : type) (p : 𝕀 → A) (q : (i : 𝕀) → sub A {i=0} {p 1}) : path A {p 0} {q 1} :=
   i => {! trans/filler A p q 1 i !}
 
-def cone-of-silence-hcom  (A : type) (p : 𝕀 → A) (q : (i : 𝕀) → sub A {i=0} {p 1}) : path A {p 0} {q 1} :=
+-- Test that the cone of silence tactic still triggers failures when it ought to
+fail cone-of-silence-hcom (A : type) (p : 𝕀 → A) (q : (i : 𝕀) → sub A {i=0} {p 1}) : path A {p 0} {q 1} :=
   i => hcom A 0 1 {∂ i} {!!}
+

--- a/test/test.expected
+++ b/test/test.expected
@@ -625,7 +625,7 @@ holes.cooltt:14.7-14.35 [Info]:
        i = 1 => q 1
 
 
-holes.cooltt:17.26-17.30 [Info]:
+holes.cooltt:18.26-18.30 [Info]:
   Emitted hole:
     A : type
     p : (_x : 𝕀) → A
@@ -634,7 +634,8 @@ holes.cooltt:17.26-17.30 [Info]:
     |- ? : (_x : 𝕀) → (_x₁ : [ _x = 0 ∨ i = 0 ∨ i = 1 ]) → A
 
 
-holes.cooltt:17.7-17.30 [Error]:
+holes.cooltt:18.7-18.30 [Info]:
+  fail cone-of-silence-hcom:
   Expected #10 A p q i 1 * = [ i = 0 => p 0 | i = 1 => q 1 ] : A
 
 --------------------[import.cooltt]--------------------

--- a/vim/syntax/cooltt.vim
+++ b/vim/syntax/cooltt.vim
@@ -25,7 +25,7 @@ syn match   coolttHole '?\k*'
 syn keyword coolttKeyw locked unlock zero suc nat in fst snd elim unfold generalize type dim
 syn keyword coolttKeyw cof sub ext coe hcom com hfill V vproj with struct sig
 
-syn keyword coolttDecl def axiom let normalize print quit import
+syn keyword coolttDecl def axiom let normalize print quit import fail
 
 syn match   coolttSymb '=>\|[|,*×:;=≔_𝕀𝔽∂∧∨→⇒!]\|->\|#t\|#f'
 syn match   coolttSymb '\\/\|/\\'


### PR DESCRIPTION
## Patch Description

It is often useful to assert that a given term is *not* supposed to typecheck, especially for our test suite. This PR adds the new `fail` top level declaration, which allows us to do just this!

Here's some examples of how it can be used:
```cooltt
fail nat-fail : nat := type

> holes.cooltt:20.23-20.27 [Info]:
>   fail nat-fail:
>   Head connective mismatch, expected univ but got nat

fail bad-fail : nat := 1

> holes.cooltt:21.0-21.24 [Error]:
>   fail bad-fail:
>   Expected (1 : nat) to fail but it succeded.
```

## Notes
We log out the cause of the failure under `Info`, as we want to still be able to know that things failed in the way that we expect them to!
