### PR TITLE
📥 Implement Conversion into the Total Space of a Type Family

### DIFF
--- a/src/basis/ListUtil.ml
+++ b/src/basis/ListUtil.ml
@@ -12,6 +12,14 @@ let rec unzip =
     let (xs, ys) = unzip xs in
     (x :: xs, y :: ys)
 
+let zip_with f xs ys =
+  let rec go acc xs ys =
+    match xs, ys with
+    | x :: xs, y :: ys -> go (Snoc (acc, f x y)) xs ys
+    | _, _ -> Bwd.to_list acc
+  in go Emp xs ys
+
+
 let rec map_opt f = function
   | [] -> Some []
   | (x :: xs) ->

--- a/src/basis/ListUtil.mli
+++ b/src/basis/ListUtil.mli
@@ -1,4 +1,5 @@
 val zip : 'a list -> 'b list -> ('a * 'b) list
 val unzip : ('a * 'b) list -> 'a list * 'b list
+val zip_with : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 val map_opt : ('a -> 'b option) -> 'a list -> 'b list option
 val map_accum_left : ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list

--- a/src/core/Ident.ml
+++ b/src/core/Ident.ml
@@ -1,5 +1,7 @@
 type t = [`Anon | `User of string list | `Machine of string]
 
+let user parts = `User parts
+
 let qual_to_string =
   function
   | [] -> "(root)"

--- a/src/core/Ident.mli
+++ b/src/core/Ident.mli
@@ -2,6 +2,8 @@ open Basis
 
 type t = [`Anon | `User of string list | `Machine of string]
 
+val user : string list -> t
+
 val pp : t Pp.printer
 val to_string : t -> string
 val to_string_opt : t -> string option

--- a/src/core/Refiner.ml
+++ b/src/core/Refiner.ml
@@ -748,15 +748,15 @@ struct
 
   let patch (sig_tac : T.Chk.tac) (tacs : string list -> T.Chk.tac option) : T.Chk.tac =
     univ_tac "Univ.patch" @@ fun univ ->
-    let* tp = T.Chk.run sig_tac univ in
-    let* vtp = RM.lift_ev @@ Sem.eval tp in
-    (* FIXME: Should I do_el here? *)
-    let* whnf_vtp = RM.lift_cmp @@ Sem.whnf_con_ ~style:`UnfoldAll vtp in
-    match whnf_vtp with
-    | D.StableCode (`Signature sign) ->
+    let* code = T.Chk.run sig_tac univ in
+    let* vcode = RM.lift_ev @@ Sem.eval code in
+    let* tp = RM.lift_cmp @@ Sem.do_el vcode in
+    let* whnf_tp = RM.lift_cmp @@ Sem.whnf_tp_ ~style:`UnfoldAll tp in
+    match whnf_tp with
+    | D.ElStable (`Signature sign) ->
       patch_fields sign tacs univ
     | _ ->
-      failwith "[FIXME] Better error handling in Univ.patch"
+      RM.expected_connective `Signature whnf_tp
 
   let total (fam_tac : T.Syn.tac) : T.Chk.tac =
     univ_tac "Univ.total" @@ fun univ ->

--- a/src/core/Refiner.ml
+++ b/src/core/Refiner.ml
@@ -635,25 +635,28 @@ struct
     let+ fam = T.Chk.run tac_fam famtp in
     base, fam
 
-  let quantifiers (tacs : (string list * T.Chk.tac) list) univ : (string list * S.t) list m =
-    let (lbls, tacs) = ListUtil.unzip tacs in
+  let quantifiers (mk_fields : (string list * (D.tp -> S.t m)) list) (univ : D.tp) : (string list * S.t) list m =
+    let (lbls, ks) = List.split mk_fields in
     let idents = List.map (fun lbl -> `User lbl) lbls in
     let rec mk_fams fams vfams =
       function
       | [] -> RM.ret fams
-      | tac :: tacs ->
+      | k :: ks ->
         let* famtp =
           RM.lift_cmp @@
           Sem.splice_tp @@
           Splice.tp univ @@ fun univ ->
           Splice.cons vfams @@ fun args -> Splice.term @@ TB.pis ~idents:idents args @@ fun _ -> univ
         in
-        let* fam = T.Chk.run tac famtp in
+        let* fam = k famtp in
         let* vfam = RM.lift_ev @@ Sem.eval fam in
-        mk_fams (fams @ [fam]) (vfams @ [vfam]) tacs
+        mk_fams (fams @ [fam]) (vfams @ [vfam]) ks
     in
-    let+ fams = mk_fams [] [] tacs in
-    ListUtil.zip lbls fams
+    let+ fams = mk_fams [] [] ks in
+    List.combine lbls fams
+
+  let quote_sign_codes (vsign : (string list * D.con) list) (univ : D.tp) : (string list * S.t) list m =
+    quantifiers (List.map (fun (lbl, vcode) -> (lbl, fun tp -> RM.quote_con tp vcode)) vsign) univ
 
   let pi tac_base tac_fam : T.Chk.tac =
     univ_tac "Univ.pi" @@ fun univ ->
@@ -685,63 +688,102 @@ struct
   *)
   let signature (tacs : (string list * T.Chk.tac) list) : T.Chk.tac =
     univ_tac "Univ.signature" @@ fun univ ->
-    let+ fields = quantifiers tacs univ in
+    let+ fields = quantifiers (List.map (fun (lbl, tac) -> (lbl, T.Chk.run tac)) tacs) univ in
     S.CodeSignature fields
 
   (* [NOTE: Patch Quantifiers]
      As described in [NOTE: Sig Code Quantifiers], the field types of a signature code
      all use lambdas to bind variables from earlier on in the signature. Therefore,
      when we construct the patched versions of the field codes, we need to re-insert
-     the lambdas.*)
-  let rec patch_fields (field_names : string list list) (field_tps : D.con list) (vpatches : D.con list) (ext_codes : S.t list) (sign : (string list * D.con) list) (patch_tacs : (string list * T.Chk.tac) list) (univ : D.tp) : S.t m =
-    match sign, patch_tacs with
-    | (field_name, vfield_tp) :: sign, (patch_name, patch_tac) :: patch_tacs when CCList.equal String.equal field_name patch_name ->
-      (* As the signatures field types are really lambdas (See [NOTE: Sig Code Quantifiers]),
-         we want to apply them to the patch values that we have already computed. *)
-      (* FIXME: This is bad! *)
-      let idents = List.map (fun nm -> `User nm) field_names in
-      let* patchtp =
-        RM.lift_cmp @@
-        Sem.splice_tp @@
-        Splice.con vfield_tp @@ fun field_tp ->
-        Splice.cons vpatches @@ fun patches -> Splice.term @@ TB.el @@ TB.ap field_tp patches
-      in
-      let* patch = T.Chk.run patch_tac patchtp in
-      let* vpatch = RM.lift_ev @@ Sem.eval patch in
+     the lambdas.
 
-      (* As noted in [NOTE: Patch Quantifiers], we need to re-add the lambda binders to the patched field types.
-         Therefore, we need to construct the type /of the patched field type/ to quote against. *)
-      let* fam_tp =
-        RM.lift_cmp @@
-        Sem.splice_tp @@
-        Splice.tp univ @@ fun univ ->
-        Splice.cons field_tps @@ fun args -> Splice.term @@ TB.pis ~idents args @@ fun _ -> univ
-      in
+     However, the situation is made more complicated by the fact that we only patching
+     _some_ of the values of the signature type. This means that we can't just naively
+     apply the field code to all the previous patch values, as their may not be any patch values
+     for some fields!
 
-      let* ext_code =
-        RM.lift_cmp @@
-        Sem.splice_tm @@
-        Splice.con vfield_tp @@ fun field_tp ->
-        Splice.cons vpatches @@ fun patches ->
-        Splice.con vpatch @@ fun patch -> Splice.term @@ TB.lams idents @@ fun _ -> TB.code_ext 0 (TB.ap field_tp patches) TB.top @@ TB.lam @@ fun _ -> patch
-      in
-      let* qext_code = RM.quote_con fam_tp ext_code in
-      (* FIXME: Bad Asymptotics!! *)
-      patch_fields (field_names @ [field_name]) (field_tps @ [vfield_tp]) (vpatches @ [vpatch]) (ext_codes @ [qext_code]) sign patch_tacs univ
-    | [], [] ->
-      RM.ret @@ S.CodeSignature (List.combine field_names ext_codes)
-    | _ -> failwith "[FIXME] Better Error Handling in Univ.patch_fields"
+     This requires us to run each of the patch tactics at pi types, which then causes
+     the patches to be lambdas. This means that we need to do some fancier application
+     when we construct the final codes.
 
-  let patch (sig_tac : T.Chk.tac) (patch_tacs : (string list * T.Chk.tac) list) : T.Chk.tac =
+  *)
+  let patch_fields (sign : (string list * D.con) list) (tacs : string list -> T.Chk.tac option) (univ : D.tp) : S.t m =
+    let rec go field_names (codes : D.con list) (elim_conns : (S.t TB.m -> S.t TB.m) list) sign =
+      match sign with
+      | (field_name, vfield_tp) :: sign ->
+        let idents = List.map Ident.user field_names in
+        let* (code, elim_conn) =
+          match tacs field_name with
+          | Some tac ->
+            let* patch_tp =
+              RM.lift_cmp @@
+              Sem.splice_tp @@
+              Splice.con vfield_tp @@ fun field_tp ->
+              Splice.cons codes @@ fun codes -> Splice.term @@ TB.pis ~idents codes @@ fun args -> TB.el @@ TB.ap field_tp @@ ListUtil.zip_with (@@) elim_conns args
+            in
+            let* patch = T.Chk.run tac patch_tp in
+            let* vpatch = RM.lift_ev @@ Sem.eval patch in
+            let+ ext_code =
+              RM.lift_cmp @@
+              Sem.splice_tm @@
+              Splice.con vfield_tp @@ fun field_tp ->
+              Splice.con vpatch @@ fun patch ->
+              Splice.term @@ TB.lams idents @@ fun args -> TB.code_ext 0 (TB.ap field_tp @@ ListUtil.zip_with (@@) elim_conns args) TB.top @@ TB.lam @@ fun _ -> TB.ap patch args
+            in
+            (ext_code, fun arg -> TB.sub_out @@ TB.el_out arg)
+          | None ->
+            let+ code =
+              RM.lift_cmp @@
+              Sem.splice_tm @@
+              Splice.con vfield_tp @@ fun field_tp ->
+              Splice.term @@ TB.lams idents @@ fun args -> TB.ap field_tp @@ ListUtil.zip_with (@@) elim_conns args
+            in
+            (code, Fun.id)
+        in
+        go (field_names @ [field_name]) (codes @ [code]) (elim_conns @ [elim_conn]) sign
+      | [] ->
+        let* qsign = quote_sign_codes (List.combine field_names codes) univ in
+        RM.ret @@ S.CodeSignature qsign
+    in go [] [] [] sign
+
+  let patch (sig_tac : T.Chk.tac) (tacs : string list -> T.Chk.tac option) : T.Chk.tac =
     univ_tac "Univ.patch" @@ fun univ ->
     let* tp = T.Chk.run sig_tac univ in
     let* vtp = RM.lift_ev @@ Sem.eval tp in
     let* whnf_vtp = RM.lift_cmp @@ Sem.whnf_con_ ~style:`UnfoldAll vtp in
     match whnf_vtp with
     | D.StableCode (`Signature sign) ->
-      patch_fields [] [] [] [] sign patch_tacs univ
-    | _ -> failwith "[FIXME] Better error handling in Univ.patch"
+      patch_fields sign tacs univ
+    | _ ->
+      failwith "[FIXME] Better error handling in Univ.patch"
 
+  let total (fam_tac : T.Syn.tac) : T.Chk.tac =
+    univ_tac "Univ.total" @@ fun univ ->
+    let* (tm, tp) = T.Syn.run fam_tac in
+    let* vtm = RM.lift_ev @@ Sem.eval tm in
+    match tp with
+    (* FIXME: We should ensure that this is actually a type family *)
+    | D.Pi (D.ElStable (`Signature vsign), _, fam) ->
+      let (sign_names, vsign_codes) = List.split vsign in
+      let idents = List.map Ident.user sign_names in
+      let* qsign = quote_sign_codes vsign univ in
+      (* See NOTE:Sig Code Quantifiers. *)
+      let* fib_tp =
+        RM.lift_cmp @@
+        Sem.splice_tp @@
+        Splice.tp univ @@ fun univ ->
+        Splice.cons vsign_codes @@ fun sign_codes ->
+        Splice.term @@ TB.pis ~idents sign_codes @@ fun _ -> univ
+      in
+      let* fib =
+        RM.lift_cmp @@
+        Sem.splice_tm @@
+        Splice.con vtm @@ fun tm ->
+        Splice.term @@ TB.lams idents @@ fun args -> TB.el_out @@ TB.ap tm [TB.el_in @@ TB.struct_ @@ List.combine sign_names args]
+      in
+      let+ qfib = RM.quote_con fib_tp fib in
+      S.CodeSignature (qsign @ [["fib"], qfib])
+    | _ -> RM.expected_connective `Pi tp
 
   let ext (n : int) (tac_fam : T.Chk.tac) (tac_cof : T.Chk.tac) (tac_bdry : T.Chk.tac) : T.Chk.tac =
     univ_tac "Univ.ext" @@ fun univ ->

--- a/src/core/Refiner.mli
+++ b/src/core/Refiner.mli
@@ -62,7 +62,8 @@ module Univ : sig
   val pi : Chk.tac -> Chk.tac -> Chk.tac
   val sg : Chk.tac -> Chk.tac -> Chk.tac
   val signature : (string list * Chk.tac) list -> Chk.tac
-  val patch : Chk.tac -> (string list * Chk.tac) list -> Chk.tac
+  val patch : Chk.tac -> (string list -> Chk.tac option) -> Chk.tac
+  val total : Syn.tac -> Chk.tac
   val ext : int -> Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac
   val code_v : Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac
   val coe : Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac -> Syn.tac

--- a/src/core/Syntax.ml
+++ b/src/core/Syntax.ml
@@ -584,8 +584,10 @@ struct
   and pp_binders env penv fmt tm =
     match tm with
     | Lam (nm, tm) ->
-      let _, envx = ppenv_bind env nm in
-      pp_binders envx penv fmt tm
+      let x, envx = ppenv_bind env nm in
+      if Debug.is_debug_mode ()
+      then Format.fprintf fmt "`{%s} =>@ @[%a@]" x (pp_binders envx penv) tm
+      else pp_binders envx penv fmt tm
     | _ -> pp env penv fmt tm
 
   let pp_sequent_boundary env fmt tm =

--- a/src/frontend/ConcreteSyntaxData.ml
+++ b/src/frontend/ConcreteSyntaxData.ml
@@ -37,7 +37,8 @@ and con_ =
   | Signature of field list
   | Struct of field list
   | Proj of con * string list
-  | Patch of con * Ident.t * field list
+  | Patch of con * field list
+  | Total of con * field list
   | Sub of con * con * con
   | Pair of con * con
   | Fst of con

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -302,10 +302,12 @@ and chk_tm : CS.con -> T.Chk.tac =
       let tacs = bind_sig_tacs @@ List.map (fun (CS.Field field) -> field.lbl, chk_tm field.tp) fields in
       R.Univ.signature tacs
 
-    | CS.Patch (tp, _ident, patches) ->
-      let tacs = List.map (fun (CS.Field field) -> field.lbl, chk_tm field.tp) patches in
-      R.Univ.patch (chk_tm tp) tacs
-
+    | CS.Patch (tp, patches) ->
+      let tacs = bind_sig_tacs @@ List.map (fun (CS.Field field) -> field.lbl, chk_tm field.tp) patches in
+      R.Univ.patch (chk_tm tp) (R.Signature.find_field_tac tacs)
+    | CS.Total (tp, patches) ->
+      let tacs = bind_sig_tacs @@ List.map (fun (CS.Field field) -> field.lbl, chk_tm field.tp) patches in
+      R.Univ.patch (R.Univ.total (syn_tm tp)) (R.Signature.find_field_tac tacs)
     | CS.V (r, pcode, code, pequiv) ->
       R.Univ.code_v (chk_tm r) (chk_tm pcode) (chk_tm code) (chk_tm pequiv)
 

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -34,7 +34,7 @@
 %token <string> ATOM
 %token <string option> HOLE_NAME
 %token LOCKED UNLOCK
-%token BANG COLON COLON_EQUALS PIPE COMMA DOT DOT_EQUALS SEMI RIGHT_ARROW RRIGHT_ARROW UNDERSCORE DIM COF BOUNDARY
+%token BANG COLON COLON_EQUALS HASH PIPE COMMA DOT DOT_EQUALS SEMI RIGHT_ARROW RRIGHT_ARROW UNDERSCORE DIM COF BOUNDARY
 %token LPR RPR LBR RBR LSQ RSQ LBANG RBANG
 %token EQUALS JOIN MEET
 %token TYPE
@@ -56,6 +56,7 @@
 %nonassoc COLON
 %left PROJ
 %right RIGHT_ARROW TIMES
+%nonassoc HASH
 
 %start <ConcreteSyntax.signature> sign
 %start <ConcreteSyntax.command> command
@@ -321,8 +322,10 @@ plain_term_except_cof_case:
   /* So the issue is when we have a cofibration split case, we will have a bunch of pipe separated things
    We need to ensure that any patches occur in brackets...
    */
-  | tp = term; AS; n = plain_name; ps = patches
-    { Patch (tp, n, ps) }
+  | tp = term; AS; ps = patches
+    { Patch (tp, ps) }
+  | tp = term; HASH; ps = patches
+    { Total (tp, ps) }
   | SUB; tp = atomic_term; phi = atomic_term; tm = atomic_term
     { Sub (tp, phi, tm) }
   | FST; t = atomic_term

--- a/src/frontend/Lex.mll
+++ b/src/frontend/Lex.mll
@@ -128,6 +128,8 @@ and real_token = parse
     { RBANG }
   | '|'
     { PIPE }
+  | '#'
+    { HASH }
   | ','
     { COMMA }
   | '.'

--- a/test/patch.cooltt
+++ b/test/patch.cooltt
@@ -1,13 +1,41 @@
+import prelude
+
 def el : type := sig (A : type) (a : A)
-def el-patch : type := el as x [ A .= nat | a .= 4 ]
+def el-patch : type := el as [ A .= nat | a .= 4 ]
+def el-patch-partial : type := el as [ A .= nat ]
 
 def patch/inhabit : el-patch := struct (A : nat) (a : 4)
 def patch/inhabit/hole : el-patch := struct (A : ?) (a : ?)
 
 print el-patch
+print el-patch-partial
 print patch/inhabit
 
-def testing (A Z : type) (B : A → type) (p : Z → sig (x : A) (bx : B x)) (z : Z) : sig (x : A) (bx : B x) as _ [ x .= p z @ x | bx .= p z @ bx ] :=
+def patch-depends : type := {sig (A : type) (B : type)} as [ A .= nat | B .= A ]
+print patch-depends
+def patch-depends/inhabit : patch-depends := struct (A : nat) (B : nat)
+
+def testing (A Z : type) (B : A → type) (p : Z → sig (x : A) (bx : B x)) (z : Z) : sig (x : A) (bx : B x) as [ x .= p z @ x | bx .= p z @ bx ] :=
   p z
 
 print testing
+
+def category : type :=
+  sig (ob : type)
+      (hom : sig (s : ob) (t : ob) → type)
+      (idn : (x : ob) -> hom # [ s .= x | t .= x ])
+      (seq : (f : hom # []) -> (g : hom # [ s .= f @ t ]) -> hom # [ s .= f @ s | t .= g @ t ])
+      (seqL : (f : hom # []) -> path {hom # [ s .= f @ s | t .= f @ t ]} {seq {idn {f @ s}} f} f)
+      (seqR : (f : hom # []) -> path {hom # [ s .= f @ s | t .= f @ t ]} {seq f {idn {f @ t}}} f)
+      (seqA : (f : hom # []) -> (g : hom # [ s .= f @ t ]) -> (h : hom # [ s .= g @ t ]) -> path {hom # [ s .= f @ s | t .= h @ t ]} {seq f {seq g h}} {seq {seq f g} h})
+
+print category
+
+def types : category :=
+  struct (ob : type)
+         (hom : args => {args @ s} -> {args @ t})
+         (idn : x => struct (s : x) (t : x) (fib : x => x))
+         (seq : f g => struct (s : f @ s) (t : g @ t) (fib : x => g @ fib {f @ fib x}))
+         (seqL : f i => f)
+         (seqR : f i => f)
+         (seqA : f g h i => struct (s : f @ s) (t : h @ t) (fib : x => {h @ fib} {{g @ fib} {{f @ fib} x}}))

--- a/test/patch.cooltt
+++ b/test/patch.cooltt
@@ -20,6 +20,9 @@ def testing (A Z : type) (B : A → type) (p : Z → sig (x : A) (bx : B x)) (z 
 
 print testing
 
+-- Record Patching + Total Space Conversion
+fail total-space/fail (fam : sig (A : type) (a : A) -> nat -> type) : type := fam # []
+
 def category : type :=
   sig (ob : type)
       (hom : sig (s : ob) (t : ob) → type)

--- a/test/test.expected
+++ b/test/test.expected
@@ -782,7 +782,7 @@ nat.cooltt:9.10-9.15 [Info]:
   Computed normal form of + 2 3 as 5
 
 --------------------[patch.cooltt]--------------------
-patch.cooltt:5.49-5.50 [Info]:
+patch.cooltt:8.49-8.50 [Info]:
   Emitted hole:
     |- ? : type
     
@@ -791,7 +791,7 @@ patch.cooltt:5.49-5.50 [Info]:
     |- nat
 
 
-patch.cooltt:5.57-5.58 [Info]:
+patch.cooltt:8.57-8.58 [Info]:
   Emitted hole:
     |- ? : nat
     
@@ -800,17 +800,27 @@ patch.cooltt:5.57-5.58 [Info]:
     |- 4
 
 
-patch.cooltt:7.6-7.14 [Info]:
+patch.cooltt:10.6-10.14 [Info]:
   el-patch
   : type
   = sig (A : ext type #t {_x => nat}) (a : ext nat #t {_x => 4}) 
 
-patch.cooltt:8.6-8.19 [Info]:
+patch.cooltt:11.6-11.22 [Info]:
+  el-patch-partial
+  : type
+  = sig (A : ext type #t {_x => nat}) (a : nat) 
+
+patch.cooltt:12.6-12.19 [Info]:
   patch/inhabit
   : el-patch
   = struct (A : nat) (a : 4) 
 
-patch.cooltt:13.6-13.13 [Info]:
+patch.cooltt:15.6-15.19 [Info]:
+  patch-depends
+  : type
+  = sig (A : ext type #t {_x => nat}) (B : ext type #t {_x => nat}) 
+
+patch.cooltt:21.6-21.13 [Info]:
   testing
   : (A : type) → (Z : type) → (B : (_x : A) → type) → (p : (_x : Z) → 
   sig (x : A) (bx : B x) ) → (z : Z) → sig (x : ext A #t {_x => p z @ x}) 
@@ -818,6 +828,110 @@ patch.cooltt:13.6-13.13 [Info]:
                                                                    p z @ bx})
                                        
   = A Z B p z => struct (x : p z @ x) (bx : p z @ bx) 
+
+patch.cooltt:32.6-32.14 [Info]:
+  category
+  : type
+  = sig (ob : type) (hom : (_x : sig (s : ob) (t : ob) ) → type) 
+    (idn : (x : ob) → sig (s : ext ob #t {_x => x}) (t : ext ob #t {_x => x}) 
+                      (fib : hom {struct (s : x) (t : x) }) )
+    (seq : (f : sig (s : ob) (t : ob) (fib : hom {struct (s : s) (t : t) }) ) → (g : 
+    sig (s : ext ob #t {_x => f @ t}) (t : ob) 
+    (fib : hom {struct (s : f @ t) (t : t) }) ) → sig (s : ext ob #t {
+                                                           _x => f @ s})
+                                                  (t : ext ob #t {_x => g @ t})
+                                                  (fib : hom {struct (s : 
+                                                              f @ s) 
+                                                              (t : g @ t) })
+                                                  )
+    (seqL : (f : sig (s : ob) (t : ob) (fib : hom {struct (s : s) (t : t) }) ) → path {
+    sig (s : ext ob #t {_x => f @ s}) (t : ext ob #t {_x => f @ t}) 
+    (fib : hom {struct (s : f @ s) (t : f @ t) }) } {struct (s : f @ s) 
+                                                     (t : f @ t) 
+                                                     (fib : seq {struct (s : 
+                                                                 f @ s) 
+                                                                 (t : 
+                                                                 f @ s) 
+                                                                 (fib : 
+                                                                 idn {
+                                                                 f @ s} @ fib)
+                                                                 } {struct (s : 
+                                                                    f @ s) 
+                                                                    (t : 
+                                                                    f @ t) 
+                                                                    (fib : 
+                                                                    f @ fib) } @ fib)
+                                                     } {struct (s : f @ s) 
+                                                        (t : f @ t) 
+                                                        (fib : f @ fib) })
+    (seqR : (f : sig (s : ob) (t : ob) (fib : hom {struct (s : s) (t : t) }) ) → path {
+    sig (s : ext ob #t {_x => f @ s}) (t : ext ob #t {_x => f @ t}) 
+    (fib : hom {struct (s : f @ s) (t : f @ t) }) } {struct (s : f @ s) 
+                                                     (t : f @ t) 
+                                                     (fib : seq {struct (s : 
+                                                                 f @ s) 
+                                                                 (t : 
+                                                                 f @ t) 
+                                                                 (fib : 
+                                                                 f @ fib) } {
+                                                            struct (s : 
+                                                            f @ t) 
+                                                            (t : f @ t) 
+                                                            (fib : idn {
+                                                                   f @ t} @ fib)
+                                                            } @ fib)
+                                                     } {struct (s : f @ s) 
+                                                        (t : f @ t) 
+                                                        (fib : f @ fib) })
+    (seqA : (f : sig (s : ob) (t : ob) (fib : hom {struct (s : s) (t : t) }) ) → (g : 
+    sig (s : ext ob #t {_x => f @ t}) (t : ob) 
+    (fib : hom {struct (s : f @ t) (t : t) }) ) → (h : sig (s : ext ob #t {
+                                                                _x => 
+                                                                g @ t})
+                                                       (t : ob) 
+                                                       (fib : hom {struct (s : 
+                                                                   g @ t) 
+                                                                   (t : t) })
+                                                       ) → path {sig (s : 
+                                                                 ext ob #t {
+                                                                 _x => 
+                                                                 f @ s}) 
+                                                                 (t : 
+                                                                 ext ob #t {
+                                                                 _x => 
+                                                                 h @ t}) 
+                                                                 (fib : hom {
+                                                                 struct (s : 
+                                                                 f @ s) 
+                                                                 (t : 
+                                                                 h @ t) }) } {
+    struct (s : f @ s) (t : h @ t) 
+    (fib : seq {struct (s : f @ s) (t : f @ t) (fib : f @ fib) } {struct (s : 
+                                                                  f @ t) 
+                                                                  (t : 
+                                                                  h @ t) 
+                                                                  (fib : 
+                                                                  seq {
+                                                                  struct (s : 
+                                                                  f @ t) 
+                                                                  (t : 
+                                                                  g @ t) 
+                                                                  (fib : 
+                                                                  g @ fib) } {
+                                                                  struct (s : 
+                                                                  g @ t) 
+                                                                  (t : 
+                                                                  h @ t) 
+                                                                  (fib : 
+                                                                  h @ fib) } @ fib)
+                                                                  } @ fib)
+    } {struct (s : f @ s) (t : h @ t) 
+       (fib : seq {struct (s : f @ s) (t : g @ t) 
+                   (fib : seq {struct (s : f @ s) (t : f @ t) (fib : f @ fib) } {
+                          struct (s : f @ t) (t : g @ t) (fib : g @ fib) } @ fib)
+                   } {struct (s : g @ t) (t : h @ t) (fib : h @ fib) } @ fib)
+       })
+    
 
 --------------------[path-types.cooltt]--------------------
 path-types.cooltt:8.10-8.19 [Info]:

--- a/test/test.expected
+++ b/test/test.expected
@@ -829,7 +829,11 @@ patch.cooltt:21.6-21.13 [Info]:
                                        
   = A Z B p z => struct (x : p z @ x) (bx : p z @ bx) 
 
-patch.cooltt:32.6-32.14 [Info]:
+patch.cooltt:24.78-24.86 [Info]:
+  fail total-space/fail:
+  Head connective mismatch, expected univ but got (_x₁ : nat) → type
+
+patch.cooltt:35.6-35.14 [Info]:
   category
   : type
   = sig (ob : type) (hom : (_x : sig (s : ob) (t : ob) ) → type) 


### PR DESCRIPTION
## Patch Description
This PR implements a means of converting a type family `sig fields -> type` into it's total space, as described in #267. It also tidies up some of the code regarding record patching (#266), most notably allowing support for "partial patches", where only some of the fields are patched. In concert, these allow us to write the following code:
```
def category : type :=
  sig (ob : type)
      (hom : sig (s : ob) (t : ob) → type)
      (idn : (x : ob) -> hom # [ s .= x | t .= x ])
      (seq : (f : hom # []) -> (g : hom # [ s .= f @ t ]) -> hom # [ s .= f @ s | t .= g @ t ])
      (seqL : (f : hom # []) -> path {hom # [ s .= f @ s | t .= f @ t ]} {seq {idn {f @ s}} f} f)
      (seqR : (f : hom # []) -> path {hom # [ s .= f @ s | t .= f @ t ]} {seq f {idn {f @ t}}} f)
      (seqA : (f : hom # []) -> (g : hom # [ s .= f @ t ]) -> (h : hom # [ s .= g @ t ]) -> path {hom # [ s .= f @ s | t .= h @ t ]} {seq f {seq g h}} {seq {seq f g} h})


def types : category :=
  struct (ob : type)
         (hom : args => {args @ s} -> {args @ t})
         (idn : x => struct (s : x) (t : x) (fib : x => x))
         (seq : f g => struct (s : f @ s) (t : g @ t) (fib : x => g @ fib {f @ fib x}))
         (seqL : f i => f)
         (seqR : f i => f)
         (seqA : f g h i => struct (s : f @ s) (t : h @ t) (fib : x => {h @ fib} {{g @ fib} {{f @ fib} x}}))
```
## Notes
There is one minor hack that had to be added while implementing this. As we are using Weak Tarski Universes, `el code-univ` is not the same as `univ`. This causes some trouble when we are trying to check that a function really is a type family.

The grammar is also sub-par. On one hand, we don't need to use `as x` when patching, as things are brought into scope using the same mechanisms that we do with `sig` types. Perhaps we should steal SML's `where`, though I don't have any nifty ideas for the total space conversion.