### PR TITLE
↔️ Equational Reasoning DSL

### DIFF
--- a/emacs/cooltt.el
+++ b/emacs/cooltt.el
@@ -124,7 +124,7 @@
   "Command keywords.")
 
 (defconst cooltt-expression-keywords
-  '("zero" "suc" "nat" "in" "fst" "snd" "elim" "unfold" "type" "dim" "cof" "sub" "pathd" "coe" "hcom" "com" "hfill" "sig" "struct")
+  '("zero" "suc" "nat" "in" "fst" "snd" "elim" "unfold" "type" "dim" "cof" "sub" "pathd" "coe" "hcom" "com" "hfill" "sig" "struct" "equation" "begin" "end")
   "Expression keywords.")
 
 

--- a/src/core/RefineMonad.ml
+++ b/src/core/RefineMonad.ml
@@ -5,6 +5,7 @@ module S = Syntax
 module St = RefineState
 module Env = RefineEnv
 module Err = RefineError
+module Sem = Semantics
 module Qu = Quote
 module Conv = Conversion
 
@@ -82,6 +83,12 @@ let get_import path =
 let is_imported path =
   let+ st = get in
   St.is_imported path st
+
+let eval con =
+  lift_ev @@ Sem.eval con
+
+let eval_tp tp =
+  lift_ev @@ Sem.eval_tp tp
 
 let quote_con tp con =
   lift_qu @@ Qu.quote_con tp con

--- a/src/core/RefineMonad.mli
+++ b/src/core/RefineMonad.mli
@@ -30,6 +30,9 @@ val add_import : [< `Print of string option] Yuujinchou.Pattern.t -> id -> unit 
 val get_import : id -> (CodeUnit.t option) m
 val is_imported : id -> bool m
 
+val eval : S.t -> D.con m
+val eval_tp : S.tp -> D.tp m
+
 val quote_con : D.tp -> D.con -> S.t m
 val quote_tp : D.tp -> S.tp m
 val quote_cut : D.cut -> S.t m

--- a/src/core/TermBuilder.mli
+++ b/src/core/TermBuilder.mli
@@ -82,6 +82,7 @@ val cube : int -> (t m list -> tp m) -> tp m
 val code_pi : t m -> t m -> t m
 val code_sg : t m -> t m -> t m
 val code_path : t m -> t m -> t m
+(** A specialization of {!val:code_path} that performs a {!val:cof_split}. *)
 val code_path' : t m -> t m -> t m -> t m
 val code_v : t m -> t m -> t m -> t m -> t m
 val code_ext : int -> t m -> t m -> t m -> t m

--- a/src/core/TermBuilder.mli
+++ b/src/core/TermBuilder.mli
@@ -82,6 +82,7 @@ val cube : int -> (t m list -> tp m) -> tp m
 val code_pi : t m -> t m -> t m
 val code_sg : t m -> t m -> t m
 val code_path : t m -> t m -> t m
+val code_path' : t m -> t m -> t m -> t m
 val code_v : t m -> t m -> t m -> t m -> t m
 val code_ext : int -> t m -> t m -> t m -> t m
 val vproj : t m -> t m -> t m -> t m -> t m -> t m

--- a/src/frontend/ConcreteSyntaxData.ml
+++ b/src/frontend/ConcreteSyntaxData.ml
@@ -52,7 +52,7 @@ and con_ =
   | Elim of {mot : con; cases : case list; scrut : con}
   | Rec of {mot : con; cases : case list; scrut : con}
   | LamElim of case list
-  | Equations of { code : con; start : (con * con); eqns : eqns }
+  | Equations of { code : con; eqns : eqns step }
   | Dim
   | Cof
   | CofEq of con * con
@@ -96,8 +96,12 @@ and pat = Pat of {lbl : string list; args : pat_arg list}
 and pat_arg = [`Simple of Ident.t | `Inductive of Ident.t * Ident.t]
 [@@deriving show]
 
+and 'a step =
+  | Equals of con * con * 'a
+  | Trivial of con * 'a
+
 and eqns =
-  | Equals of con * con * eqns
+  | Step of eqns step
   | Qed of con
 
 type decl =

--- a/src/frontend/ConcreteSyntaxData.ml
+++ b/src/frontend/ConcreteSyntaxData.ml
@@ -52,6 +52,7 @@ and con_ =
   | Elim of {mot : con; cases : case list; scrut : con}
   | Rec of {mot : con; cases : case list; scrut : con}
   | LamElim of case list
+  | Equations of { code : con; start : (con * con); eqns : eqns }
   | Dim
   | Cof
   | CofEq of con * con
@@ -95,6 +96,10 @@ and pat = Pat of {lbl : string list; args : pat_arg list}
 and pat_arg = [`Simple of Ident.t | `Inductive of Ident.t * Ident.t]
 [@@deriving show]
 
+and eqns =
+  | Equals of con * con * eqns
+  | Qed of con
+
 type decl =
   | Def of {name : Ident.t; args : cell list; def : con option; tp : con}
   | Print of Ident.t node
@@ -102,6 +107,7 @@ type decl =
   | NormalizeTerm of con
   | Fail of {name : Ident.t; args : cell list; def : con; tp : con; info : info}
   | Quit
+
 
 type command =
   | NoOp

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -425,20 +425,29 @@ and syn_tm : CS.con -> T.Syn.tac =
       R.Pi.formation R.Dim.formation (`Anon, fun _ -> R.El.formation code_tac)
     | CS.Com (fam, src, trg, cof, tm) ->
       R.Univ.com (chk_tm fam) (chk_tm src) (chk_tm trg) (chk_tm cof) (chk_tm tm)
-    | CS.Equations {code; start = (lhs, p); eqns} ->
+    | CS.Equations {code; eqns} ->
+      let open Tactics.Equations in
       let code_tac = chk_tm code in
-      let rec mk_steps : CS.eqns -> T.Syn.tac * T.Chk.tac * T.Chk.tac =
+      let rec mk_steps : CS.eqns CS.step -> T.Syn.tac * T.Chk.tac * T.Chk.tac =
         function
-        | CS.Equals (x, p, eqns) ->
-          let (q_tac, mid_tac, rhs_tac) = mk_steps eqns in
-          let lhs_tac = chk_tm x in
-          Tactics.Equations.step code_tac lhs_tac mid_tac rhs_tac (chk_tm p) (T.Chk.syn q_tac), lhs_tac, rhs_tac
-        | CS.Qed x ->
+        | Equals (lhs, p, eqns) ->
+          let q_tac, mid_tac, rhs_tac = mk_eqns eqns in
+          let lhs_tac = chk_tm lhs in
+          step code_tac lhs_tac mid_tac rhs_tac (chk_tm p) (T.Chk.syn q_tac), lhs_tac, rhs_tac
+        | Trivial (lhs, eqns) ->
+          let q_tac, mid_tac, rhs_tac = mk_eqns eqns in
+          let lhs_tac = chk_tm lhs in
+          step code_tac lhs_tac mid_tac rhs_tac (T.Chk.syn @@ qed code_tac lhs_tac) (T.Chk.syn q_tac), lhs_tac, rhs_tac
+      and mk_eqns : CS.eqns -> T.Syn.tac * T.Chk.tac * T.Chk.tac =
+        function
+        | Step s ->
+          mk_steps s
+        | Qed x ->
           let x_tac = chk_tm x in
-          (Tactics.Equations.qed code_tac x_tac), x_tac, x_tac
+          qed code_tac x_tac, x_tac, x_tac
       in
-      let (q_tac, mid_tac, rhs_tac) = mk_steps eqns in
-      Tactics.Equations.step code_tac (chk_tm lhs) mid_tac rhs_tac (chk_tm p) (T.Chk.syn q_tac)
+      let (tac, _, _ ) = mk_steps eqns in
+      tac
     | _ ->
       T.Syn.rule @@
       RM.throw @@ ElabError.ElabError (ElabError.ExpectedSynthesizableTerm con.node, con.info)

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -51,7 +51,7 @@
 %token SEMISEMI EOF
 %token TOPC BOTC
 %token V VPROJ CAP
-%token BEGIN END LSQEQUALS
+%token BEGIN END LSQEQUALS LRSQEQUALS
 
 %nonassoc IN AS RRIGHT_ARROW SEMI
 %nonassoc COLON
@@ -366,12 +366,18 @@ plain_term_except_cof_case:
     { HFill (tp, src, phi, body) }
   | COM; fam = atomic_term; src = atomic_term; trg = atomic_term; phi = atomic_term; body = atomic_term
     { Com (fam, src, trg, phi, body) }
-  | BEGIN; code = term; WITH; tm = term; LSQEQUALS; pf = term; RSQ; eqns = eqns; END
-    { Equations { code; start = (tm, pf); eqns } }
+  | BEGIN; code = term; WITH; eqns = step; END
+    { Equations { code; eqns } }
 
-eqns:
+step:
   | tm = term; LSQEQUALS; pf = term; RSQ; r = eqns;
     { Equals (tm, pf, r) }
+  | tm = term; LRSQEQUALS; r = eqns;
+    { Trivial (tm, r) }
+
+eqns:
+  | s = step
+    { Step s }
   | tm = term
     { Qed tm }
 

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -51,6 +51,7 @@
 %token SEMISEMI EOF
 %token TOPC BOTC
 %token V VPROJ CAP
+%token BEGIN END LSQEQUALS
 
 %nonassoc IN AS RRIGHT_ARROW SEMI
 %nonassoc COLON
@@ -365,6 +366,14 @@ plain_term_except_cof_case:
     { HFill (tp, src, phi, body) }
   | COM; fam = atomic_term; src = atomic_term; trg = atomic_term; phi = atomic_term; body = atomic_term
     { Com (fam, src, trg, phi, body) }
+  | BEGIN; code = term; WITH; tm = term; LSQEQUALS; pf = term; RSQ; eqns = eqns; END
+    { Equations { code; start = (tm, pf); eqns } }
+
+eqns:
+  | tm = term; LSQEQUALS; pf = term; RSQ; r = eqns;
+    { Equals (tm, pf, r) }
+  | tm = term
+    { Qed tm }
 
 cases:
   | LSQ ioption(PIPE) cases = separated_list(PIPE, case) RSQ

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -51,7 +51,7 @@
 %token SEMISEMI EOF
 %token TOPC BOTC
 %token V VPROJ CAP
-%token BEGIN END LSQEQUALS LRSQEQUALS
+%token BEGIN EQUATION END LSQEQUALS LRSQEQUALS
 
 %nonassoc IN AS RRIGHT_ARROW SEMI
 %nonassoc COLON
@@ -366,7 +366,7 @@ plain_term_except_cof_case:
     { HFill (tp, src, phi, body) }
   | COM; fam = atomic_term; src = atomic_term; trg = atomic_term; phi = atomic_term; body = atomic_term
     { Com (fam, src, trg, phi, body) }
-  | BEGIN; code = term; WITH; eqns = step; END
+  | EQUATION; code = term; BEGIN; eqns = step; END
     { Equations { code; eqns } }
 
 step:

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -113,6 +113,7 @@ atomic_in_cof: t = located(plain_atomic_in_cof) {t}
 name: t = located(plain_name) {t}
 bracketed_modifier: t = located(plain_bracketed_modifier) {t}
 modifier: t = located(plain_modifier) {t}
+atomic_term_except_sq: t = located(plain_atomic_term_except_sq) {t}
 atomic_term_except_name: t = located(plain_atomic_term_except_name) {t}
 atomic_term: t = located(plain_atomic_term) {t}
 
@@ -228,7 +229,7 @@ plain_cof_or_term:
   | t = plain_cof_except_term
     { t }
 
-plain_atomic_term_except_name:
+plain_atomic_term_except_sq:
   | LBR t = plain_cof_or_term RBR
     { t }
   | ZERO
@@ -253,10 +254,14 @@ plain_atomic_term_except_name:
     { TopC }
   | BOTC
     { BotC }
-  | LSQ t = bracketed RSQ
-    { t }
   | LBANG; t = ioption(term); RBANG
     { BoundaryHole t }
+
+plain_atomic_term_except_name:
+  | t = plain_atomic_term_except_sq
+    { t }
+  | LSQ t = bracketed RSQ
+    { t }
 
 bracketed:
   | left = term COMMA right = term
@@ -315,6 +320,8 @@ plain_term_except_cof_case:
     { t }
   | ELIM; cases = cases
     { LamElim cases }
+  | ELIM; scrut = atomic_term_except_sq; AS; mot = atomic_term; WITH; cases = cases
+    { Elim { mot; cases; scrut } }
   | tele = nonempty_list(tele_cell); RIGHT_ARROW; cod = term
     { Pi (tele, cod) }
   | tele = nonempty_list(tele_cell); TIMES; cod = term

--- a/src/frontend/Lex.mll
+++ b/src/frontend/Lex.mll
@@ -65,6 +65,8 @@ let keywords =
     ("cap", CAP);
     ("with", WITH);
     ("import",IMPORT []);
+    ("begin", BEGIN);
+    ("end", END);
   ]
 }
 
@@ -130,6 +132,8 @@ and real_token = parse
     { LBANG }
   | "!}"
     { RBANG }
+  | "=["
+    { LSQEQUALS }
   | '|'
     { PIPE }
   | '#'

--- a/src/frontend/Lex.mll
+++ b/src/frontend/Lex.mll
@@ -134,6 +134,8 @@ and real_token = parse
     { RBANG }
   | "=["
     { LSQEQUALS }
+  | "=[]"
+    { LRSQEQUALS }
   | '|'
     { PIPE }
   | '#'

--- a/src/frontend/Lex.mll
+++ b/src/frontend/Lex.mll
@@ -67,6 +67,7 @@ let keywords =
     ("import",IMPORT []);
     ("begin", BEGIN);
     ("end", END);
+    ("equation", EQUATION);
   ]
 }
 

--- a/src/frontend/Tactics.ml
+++ b/src/frontend/Tactics.ml
@@ -1,5 +1,6 @@
 open Basis
 open Core
+open Cubical
 open CodeUnit
 
 module RM = RefineMonad
@@ -9,6 +10,7 @@ module S = Syntax
 module R = Refiner
 module CS = ConcreteSyntax
 module Sem = Semantics
+module TB = TermBuilder
 
 open Monad.Notation (RM)
 
@@ -150,4 +152,94 @@ struct
       R.El.elim @@ T.Var.syn x
     | _ ->
       RM.expected_connective `Pi tp
+end
+
+module Equations =
+struct
+
+  let step (code_tac : T.Chk.tac) (lhs_tac : T.Chk.tac) (mid_tac : T.Chk.tac) (rhs_tac : T.Chk.tac)
+      (p_tac : T.Chk.tac) (q_tac : T.Chk.tac) : T.Syn.tac =
+    T.Syn.rule ~name:"Equations.step" @@
+    let* code = RM.eval @<< T.Chk.run code_tac D.Univ in
+    let* tp = RM.lift_cmp @@ Sem.do_el code in
+
+    let* lhs = RM.eval @<< T.Chk.run lhs_tac tp in
+    let* mid = RM.eval @<< T.Chk.run mid_tac tp in
+    let* rhs = RM.eval @<< T.Chk.run rhs_tac tp in
+
+    let* p_tp =
+      RM.lift_cmp @@
+      Sem.splice_tp @@
+      Splice.con code @@ fun code ->
+      Splice.con lhs @@ fun lhs ->
+      Splice.con mid @@ fun mid ->
+      Splice.term @@
+      TB.el @@ TB.code_path' (TB.lam @@ fun _ -> code) lhs mid
+    in
+    let* q_tp =
+      RM.lift_cmp @@
+      Sem.splice_tp @@
+      Splice.con code @@ fun code ->
+      Splice.con mid @@ fun mid ->
+      Splice.con rhs @@ fun rhs ->
+      Splice.term @@
+      TB.el @@ TB.code_path' (TB.lam @@ fun _ -> code) mid rhs
+    in
+
+    let* p = RM.eval @<< T.Chk.run p_tac p_tp in
+    let* q = RM.eval @<< T.Chk.run q_tac q_tp in
+
+    let* path_tp =
+      RM.lift_cmp @@
+      Sem.splice_tp @@
+      Splice.con code @@ fun code ->
+      Splice.con lhs @@ fun lhs ->
+      Splice.con rhs @@ fun rhs ->
+      Splice.term @@
+      TB.el @@ TB.code_path' (TB.lam @@ fun _ -> code) lhs rhs
+    in
+    let* path =
+      RM.lift_cmp @@
+      Sem.splice_tm @@
+      Splice.con code @@ fun code ->
+      Splice.con p @@ fun p ->
+      Splice.con q @@ fun q ->
+      Splice.term @@
+      TB.el_in @@
+      TB.lam @@ fun i ->
+      TB.sub_in @@
+      TB.hcom code TB.dim0 TB.dim1 (TB.boundary i) @@
+      TB.lam @@ fun j ->
+      TB.lam @@ fun _ ->
+      TB.cof_split [
+        TB.join [TB.eq j TB.dim0; TB.eq i TB.dim0], TB.sub_out @@ TB.ap (TB.el_out p) [i];
+        TB.eq i TB.dim1, TB.sub_out @@ TB.ap (TB.el_out q) [j]
+      ]
+    in
+    let+ tpath = RM.quote_con path_tp path in
+    (tpath, path_tp)
+
+  let qed (code_tac : T.Chk.tac) (x_tac : T.Chk.tac) : T.Syn.tac =
+    T.Syn.rule ~name:"Equations.qed" @@
+    let* code = RM.eval @<< T.Chk.run code_tac D.Univ in
+    let* tp = RM.lift_cmp @@ Sem.do_el code in
+    let* x = RM.eval @<< T.Chk.run x_tac tp in
+    let* refl_tp =
+      RM.lift_cmp @@
+      Sem.splice_tp @@
+      Splice.con code @@ fun code ->
+      Splice.con x @@ fun x ->
+      Splice.term @@
+      TB.el @@ TB.code_path' (TB.lam @@ fun _ -> code) x x
+    in
+    let* refl =
+      RM.lift_cmp @@
+      Sem.splice_tm @@
+      Splice.con x @@ fun x ->
+      Splice.term @@
+      TB.el_in @@
+      TB.lam @@ fun _ -> TB.sub_in @@ x
+    in
+    let+ trefl = RM.quote_con refl_tp refl in
+    (trefl, refl_tp)
 end

--- a/src/frontend/Tactics.ml
+++ b/src/frontend/Tactics.ml
@@ -1,6 +1,5 @@
 open Basis
 open Core
-open Cubical
 open CodeUnit
 
 module RM = RefineMonad

--- a/src/frontend/Tactics.mli
+++ b/src/frontend/Tactics.mli
@@ -31,3 +31,8 @@ module Elim : sig
     : case_tac list
     -> Chk.tac
 end
+
+module Equations : sig
+  val step : Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac -> Syn.tac
+  val qed : Chk.tac -> Chk.tac -> Syn.tac
+end

--- a/test/equation.cooltt
+++ b/test/equation.cooltt
@@ -1,7 +1,7 @@
 import prelude
 
 def equational/trans (a : type) (x y z :  a) (p : path a x y) (q : path a y z) : path a x z :=
-  begin a with
+  equation a begin
     x =[ p ]
     y =[ q ]
     z
@@ -10,7 +10,7 @@ def equational/trans (a : type) (x y z :  a) (p : path a x y) (q : path a y z) :
 #print equational/trans
 
 def equational/refl/nat : path nat 4 4 :=
-  begin nat with
+  equation nat begin
     4 =[]
     4
   end

--- a/test/equation.cooltt
+++ b/test/equation.cooltt
@@ -1,0 +1,18 @@
+import prelude
+
+def equational/trans (a : type) (x y z :  a) (p : path a x y) (q : path a y z) : path a x z :=
+  begin a with
+    x =[ p ]
+    y =[ q ]
+    z
+  end
+
+#print equational/trans
+
+def equational/refl/nat : path nat 4 4 :=
+  begin nat with
+    4 =[]
+    4
+  end
+
+#print equational/refl/nat

--- a/test/test.expected
+++ b/test/test.expected
@@ -508,6 +508,26 @@ elab.cooltt:42.6-42.12 [Info]:
     |- ?hole1 : path nat x x
 
 
+--------------------[equation.cooltt]--------------------
+equation.cooltt:10.7-10.23 [Info]:
+  equational/trans
+  : (a : type) → (x : a) → (y : a) → (z : a) → (p : path a x y) → (q : path a y z) → path a x z
+  = a x y z p q _x =>
+    hcom a 0 1 {_x = 0 ∨ _x = 1}
+      {_x₁ _x₂ =>
+       [ _x₁ = 0 ∨ _x = 0 => p _x
+       | _x = 1 =>
+         hcom a 0 1 {_x₁ = 0 ∨ _x₁ = 1}
+           {_x₄ _x₅ => [ _x₄ = 0 ∨ _x₁ = 0 => q _x₁ | _x₁ = 1 => z ]}
+       ]}
+
+equation.cooltt:18.7-18.26 [Info]:
+  equational/refl/nat
+  : path nat 4 4
+  = _x =>
+    hcom nat 0 1 {_x = 0 ∨ _x = 1}
+      {_x₁ _x₂ => [ _x₁ = 0 ∨ _x = 0 => 4 | _x = 1 => 4 ]}
+
 --------------------[evan.cooltt]--------------------
 --------------------[groupoid-laws.cooltt]--------------------
 --------------------[hcom-type.cooltt]--------------------

--- a/vim/syntax/cooltt.vim
+++ b/vim/syntax/cooltt.vim
@@ -22,7 +22,7 @@ syn region  coolttEncl transparent matchgroup=coolttSymb start="{" end="}" conta
 
 syn match   coolttHole '?\k*'
 
-syn keyword coolttKeyw locked unlock zero suc nat in fst snd elim unfold generalize type dim
+syn keyword coolttKeyw locked unlock zero suc nat in fst snd elim unfold generalize type dim equation begin end
 syn keyword coolttKeyw cof sub ext coe hcom com hfill V vproj with struct sig tt ff #
 
 syn keyword coolttDecl def axiom let import


### PR DESCRIPTION
# Patch Description

This PR adds a small equational reasoning DSL, which makes it somewhat easier to write complicated, multi step proofs.
This closes #305.

Here's a quick example:
```
def equational/trans (a : type) (x y z :  a) (p : path a x y) (q : path a y z) : path a x z :=
  equation a begin
    x =[ p ]
    y =[ q ]
    z
  end

def equational/refl/nat : path nat 4 4 :=
  equation nat begin
    4 =[]
    4
  end
```

# Notes

It may be possible to have the tactics generate better paths, instead of naively doing `trans` absolutely everywhere. Would love to hear thoughts on this!