### PR TITLE
🆙 Upgrade Yuujinchou to 2.x

### DIFF
--- a/cooltt.opam
+++ b/cooltt.opam
@@ -18,7 +18,7 @@ depends: [
   "menhir" {>= "20180703"}
   "uuseg" {>= "12.0.0"}
   "uutf" {>= "1.0.2"}
-  "yuujinchou" {>= "1.0.0"}
+  "yuujinchou" {>= "2.0.0" & < "3"}
   "odoc" {with-doc}
   "bantorra"
 ]


### PR DESCRIPTION
Currently blocked by ocaml/opam-repository#20859, but the OPAM repository maintainers are very industrious.