### PR TITLE
📝 Use pp boxes in logging even if span is not available

### DIFF
--- a/src/core/Log.ml
+++ b/src/core/Log.ml
@@ -13,16 +13,15 @@ let pp_lvl fmt =
 
 (*
 We have 2 types of messages. Errors from the driver load_file and runtime messages
-which may be output or errors.
-
-Error messages either have a span where we can output lots of data about where
-the error occured or no span where we just output the data we have avaiable
+which may be output or errors. Messages may or may not have a span.
 
 *)
 let pp_runtime_message ~loc ~lvl pp data =
   match loc with
   | None ->
-    pp Format.std_formatter data
+    Format.printf "@[[%a]:@,  @[<v>%a@]@]@.@."
+      pp_lvl lvl
+      pp data
   | Some span ->
     Format.printf "@[<v>%a [%a]:@,  @[<v>%a@]@]@.@."
       LexingUtil.pp_span span
@@ -33,7 +32,9 @@ let pp_runtime_message ~loc ~lvl pp data =
 let pp_error_message ~loc ~lvl pp data =
   match loc with
   | None ->
-    pp Format.std_formatter data
+    Format.printf "@[[%a]:@,  @[<v>%a@]@]@.@."
+      pp_lvl lvl
+      pp data
   | Some span ->
     Format.printf "@[<v>%a [%a]:@,  @[<v>%a@]@]@.@."
       LexingUtil.pp_span span


### PR DESCRIPTION
Before this PR, the error messages without a span could lead to (in my opinion) very ugly output. Such as:
```
Virtual type (dim, cof, etc.) cannot appear in this positioncooltt: encountered one or more errors
```
(no space between "position" and "cooltt"). With this PR, this would be changed to
```
[Error]:  Virtual type (dim, cof, etc.) cannot appear in this position

cooltt: encountered one or more errors
```