### PR TITLE
📥 Implicit Total Space Conversion

### DIFF
--- a/src/core/Refiner.ml
+++ b/src/core/Refiner.ml
@@ -1190,15 +1190,15 @@ struct
         begin
         match tp' with
         | D.Pi (D.ElStable (`Signature vsign) as base, ident, clo) ->
-          let* _ = T.abstract ~ident base @@ fun var ->
+          let* tac' = T.abstract ~ident base @@ fun var ->
             let* fam = RM.lift_cmp @@ Sem.inst_tp_clo clo (T.Var.con var) in
             (* Same HACK *)
             match fam with
-            | D.Univ -> RM.ret ()
-            | D.ElStable `Univ -> RM.ret ()
-            | _ -> RM.expected_connective `Univ fam
+            | D.Univ 
+            | D.ElStable `Univ -> RM.ret @@ Univ.total vsign vtm
+            | _ -> RM.ret @@ T.Chk.syn tac
           in
-          T.Chk.run (Univ.total vsign vtm) tp
+          T.Chk.run tac' tp
         | _ -> T.Chk.run (T.Chk.syn tac) tp
         end
       | tp -> T.Chk.run (T.Chk.syn tac) tp

--- a/src/core/Refiner.mli
+++ b/src/core/Refiner.mli
@@ -63,7 +63,7 @@ module Univ : sig
   val sg : Chk.tac -> Chk.tac -> Chk.tac
   val signature : (Ident.user * Chk.tac) list -> Chk.tac
   val patch : Chk.tac -> (Ident.user -> Chk.tac option) -> Chk.tac
-  val total : Syn.tac -> Chk.tac
+  val total : (Ident.user * CodeUnit.Domain.con) list -> CodeUnit.Domain.con -> Chk.tac
   val ext : int -> Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac
   val code_v : Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac
   val coe : Chk.tac -> Chk.tac -> Chk.tac -> Chk.tac -> Syn.tac
@@ -145,4 +145,5 @@ module Structural : sig
   val lookup_var : Ident.t -> Syn.tac
   val level : int -> Syn.tac
   val generalize : Ident.t -> Chk.tac -> Chk.tac
+  val intro_conversions : Syn.tac -> Chk.tac
 end

--- a/src/core/Refiner.mli
+++ b/src/core/Refiner.mli
@@ -145,5 +145,4 @@ module Structural : sig
   val lookup_var : Ident.t -> Syn.tac
   val level : int -> Syn.tac
   val generalize : Ident.t -> Chk.tac -> Chk.tac
-  val intro_conversions : Syn.tac -> Chk.tac
 end

--- a/src/frontend/ConcreteSyntaxData.ml
+++ b/src/frontend/ConcreteSyntaxData.ml
@@ -40,7 +40,6 @@ and con_ =
   | Struct of field list
   | Proj of con * Ident.user
   | Patch of con * field list
-  | Total of con * field list
   | Sub of con * con * con
   | Pair of con * con
   | Fst of con

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -305,9 +305,6 @@ and chk_tm : CS.con -> T.Chk.tac =
     | CS.Patch (tp, patches) ->
       let tacs = bind_sig_tacs @@ List.map (fun (CS.Field field) -> field.lbl, chk_tm field.tp) patches in
       R.Univ.patch (chk_tm tp) (R.Signature.find_field_tac tacs)
-    | CS.Total (tp, patches) ->
-      let tacs = bind_sig_tacs @@ List.map (fun (CS.Field field) -> field.lbl, chk_tm field.tp) patches in
-      R.Univ.patch (R.Univ.total (syn_tm tp)) (R.Signature.find_field_tac tacs)
     | CS.V (r, pcode, code, pequiv) ->
       R.Univ.code_v (chk_tm r) (chk_tm pcode) (chk_tm code) (chk_tm pequiv)
 
@@ -354,7 +351,7 @@ and chk_tm : CS.con -> T.Chk.tac =
         let field_tac lbl = Option.some @@ chk_tm @@ CS.{node = CS.Proj (con, lbl); info = None} in
         RM.ret @@ R.Signature.intro field_tac
       | _ ->
-        RM.ret @@ T.Chk.syn @@ syn_tm con
+        RM.ret @@ R.Structural.intro_conversions @@ syn_tm con
 
 and syn_tm : CS.con -> T.Syn.tac =
   function con ->

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -351,7 +351,7 @@ and chk_tm : CS.con -> T.Chk.tac =
         let field_tac lbl = Option.some @@ chk_tm @@ CS.{node = CS.Proj (con, lbl); info = None} in
         RM.ret @@ R.Signature.intro field_tac
       | _ ->
-        RM.ret @@ R.Structural.intro_conversions @@ syn_tm con
+        RM.ret @@ Tactics.intro_conversions @@ syn_tm con
 
 and syn_tm : CS.con -> T.Syn.tac =
   function con ->

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -54,11 +54,11 @@
 %token BEGIN EQUATION END LSQEQUALS LRSQEQUALS
 %token SECTION VIEW EXPORT REPACK
 
-%nonassoc IN AS RRIGHT_ARROW SEMI
+%nonassoc IN RRIGHT_ARROW SEMI
 %nonassoc COLON
 %left DOT
 %right RIGHT_ARROW TIMES
-%nonassoc HASH
+%nonassoc AS
 
 %start <ConcreteSyntax.signature> sign
 %start <ConcreteSyntax.command> command
@@ -355,8 +355,6 @@ plain_term_except_cof_case:
    */
   | tp = term; AS; ps = patches
     { Patch (tp, ps) }
-  | tp = term; HASH; ps = patches
-    { Total (tp, ps) }
   | SUB; tp = atomic_term; phi = atomic_term; tm = atomic_term
     { Sub (tp, phi, tm) }
   | FST; t = atomic_term

--- a/src/frontend/Grammar.mly
+++ b/src/frontend/Grammar.mly
@@ -58,7 +58,7 @@
 %nonassoc COLON
 %left DOT
 %right RIGHT_ARROW TIMES
-%nonassoc AS
+%nonassoc HASH
 
 %start <ConcreteSyntax.signature> sign
 %start <ConcreteSyntax.command> command
@@ -353,7 +353,7 @@ plain_term_except_cof_case:
   /* So the issue is when we have a cofibration split case, we will have a bunch of pipe separated things
    We need to ensure that any patches occur in brackets...
    */
-  | tp = term; AS; ps = patches
+  | tp = term; HASH; ps = patches
     { Patch (tp, ps) }
   | SUB; tp = atomic_term; phi = atomic_term; tm = atomic_term
     { Sub (tp, phi, tm) }

--- a/src/frontend/Tactics.mli
+++ b/src/frontend/Tactics.mli
@@ -13,6 +13,7 @@ open Tactic
 val intro_subtypes : Chk.tac -> Chk.tac
 val intro_implicit_connectives : Chk.tac -> Chk.tac
 val elim_implicit_connectives : Syn.tac -> Syn.tac
+val intro_conversions : Syn.tac -> Chk.tac
 
 val tac_nary_quantifier : ('a, 'b) R.quantifier -> (Ident.t * 'a) list -> 'b -> 'b
 

--- a/test/patch.cooltt
+++ b/test/patch.cooltt
@@ -1,8 +1,8 @@
 import prelude
 
 def el : type := sig (A : type) (a : A)
-def el-patch : type := el as [ A .= nat | a .= 4 ]
-def el-patch-partial : type := el as [ A .= nat ]
+def el-patch : type := el # [ A .= nat | a .= 4 ]
+def el-patch-partial : type := el # [ A .= nat ]
 
 def patch/inhabit : el-patch := struct (A : nat) (a : 4)
 def patch/inhabit/hole : el-patch := struct (A : ?) (a : ?)
@@ -11,11 +11,11 @@ def patch/inhabit/hole : el-patch := struct (A : ?) (a : ?)
 #print el-patch-partial
 #print patch/inhabit
 
-def patch-depends : type := {sig (A : type) (B : type)} as [ A .= nat | B .= A ]
+def patch-depends : type := {sig (A : type) (B : type)} # [ A .= nat | B .= A ]
 #print patch-depends
 def patch-depends/inhabit : patch-depends := struct (A : nat) (B : nat)
 
-def testing (A Z : type) (B : A → type) (p : Z → sig (x : A) (bx : B x)) (z : Z) : sig (x : A) (bx : B x) as [ x .= p z.x | bx .= p z.bx ] :=
+def testing (A Z : type) (B : A → type) (p : Z → sig (x : A) (bx : B x)) (z : Z) : sig (x : A) (bx : B x) # [ x .= p z.x | bx .= p z.bx ] :=
   p z
 
 #print testing
@@ -26,11 +26,11 @@ def testing (A Z : type) (B : A → type) (p : Z → sig (x : A) (bx : B x)) (z 
 def category : type :=
   sig (ob : type)
       (hom : sig (s : ob) (t : ob) → type)
-      (idn : (x : ob) -> hom as [ s .= x | t .= x ])
-      (seq : (f : hom) -> (g : hom as [ s .= f.t ]) -> hom as [ s .= f.s | t .= g.t ])
-      (seqL : (f : hom) -> path {hom as [ s .= f.s | t .= f.t ]} {seq {idn {f.s}} f} f)
-      (seqR : (f : hom) -> path {hom as [ s .= f.s | t .= f.t ]} {seq f {idn {f.t}}} f)
-      (seqA : (f : hom) -> (g : hom as [ s .= f.t ]) -> (h : hom as [ s .= g.t ]) -> path {hom as [ s .= f.s | t .= h.t ]} {seq f {seq g h}} {seq {seq f g} h})
+      (idn : (x : ob) -> hom # [ s .= x | t .= x ])
+      (seq : (f : hom) -> (g : hom # [ s .= f.t ]) -> hom # [ s .= f.s | t .= g.t ])
+      (seqL : (f : hom) -> path {hom # [ s .= f.s | t .= f.t ]} {seq {idn {f.s}} f} f)
+      (seqR : (f : hom) -> path {hom # [ s .= f.s | t .= f.t ]} {seq f {idn {f.t}}} f)
+      (seqA : (f : hom) -> (g : hom # [ s .= f.t ]) -> (h : hom # [ s .= g.t ]) -> path {hom # [ s .= f.s | t .= h.t ]} {seq f {seq g h}} {seq {seq f g} h})
 
 #print category
 
@@ -46,5 +46,5 @@ def types : category :=
 def test-auto (fam : sig (x : nat) -> type) : type := fam
 #print test-auto
 
-def test-auto-patch (fam : sig (x : nat) -> type) : type := fam as [x .= 0]
+def test-auto-patch (fam : sig (x : nat) -> type) : type := fam # [x .= 0]
 #print test-auto-patch

--- a/test/patch.cooltt
+++ b/test/patch.cooltt
@@ -21,16 +21,16 @@ def testing (A Z : type) (B : A → type) (p : Z → sig (x : A) (bx : B x)) (z 
 #print testing
 
 -- Record Patching + Total Space Conversion
-#fail total-space/fail (fam : sig (A : type) (a : A) -> nat -> type) : type := fam # []
+#fail total-space/fail (fam : sig (A : type) (a : A) -> nat -> type) : type := fam
 
 def category : type :=
   sig (ob : type)
       (hom : sig (s : ob) (t : ob) → type)
-      (idn : (x : ob) -> hom # [ s .= x | t .= x ])
-      (seq : (f : hom # []) -> (g : hom # [ s .= f.t ]) -> hom # [ s .= f.s | t .= g.t ])
-      (seqL : (f : hom # []) -> path {hom # [ s .= f.s | t .= f.t ]} {seq {idn {f.s}} f} f)
-      (seqR : (f : hom # []) -> path {hom # [ s .= f.s | t .= f.t ]} {seq f {idn {f.t}}} f)
-      (seqA : (f : hom # []) -> (g : hom # [ s .= f.t ]) -> (h : hom # [ s .= g.t ]) -> path {hom # [ s .= f.s | t .= h.t ]} {seq f {seq g h}} {seq {seq f g} h})
+      (idn : (x : ob) -> hom as [ s .= x | t .= x ])
+      (seq : (f : hom) -> (g : hom as [ s .= f.t ]) -> hom as [ s .= f.s | t .= g.t ])
+      (seqL : (f : hom) -> path {hom as [ s .= f.s | t .= f.t ]} {seq {idn {f.s}} f} f)
+      (seqR : (f : hom) -> path {hom as [ s .= f.s | t .= f.t ]} {seq f {idn {f.t}}} f)
+      (seqA : (f : hom) -> (g : hom as [ s .= f.t ]) -> (h : hom as [ s .= g.t ]) -> path {hom as [ s .= f.s | t .= h.t ]} {seq f {seq g h}} {seq {seq f g} h})
 
 #print category
 
@@ -42,3 +42,9 @@ def types : category :=
          (seqL : f i => f)
          (seqR : f i => f)
          (seqA : f g h i => struct (s : f.s) (t : h.t) (fib : x => {h.fib} {{g.fib} {{f.fib} x}}))
+
+def test-auto (fam : sig (x : nat) -> type) : type := fam
+#print test-auto
+
+def test-auto-patch (fam : sig (x : nat) -> type) : type := fam as [x .= 0]
+#print test-auto-patch

--- a/test/test.expected
+++ b/test/test.expected
@@ -874,7 +874,7 @@ patch.cooltt:21.7-21.14 [Info]:
                                        
   = A Z B p z => struct (x : p z @ x) (bx : p z @ bx) 
 
-patch.cooltt:24.79-24.87 [Info]:
+patch.cooltt:24.79-24.82 [Info]:
   fail total-space/fail:
   Head connective mismatch, expected univ but got (_x₁ : nat) → type
 
@@ -981,6 +981,16 @@ patch.cooltt:35.7-35.15 [Info]:
                    } {struct (s : g @ t) (t : h @ t) (fib : h @ fib) } @ fib)
        })
     
+
+patch.cooltt:47.7-47.16 [Info]:
+  test-auto
+  : (fam : (_x : sig (x : nat) ) → type) → type
+  = fam => sig (x : nat) (fib : fam {struct (x : x) }) 
+
+patch.cooltt:50.7-50.22 [Info]:
+  test-auto-patch
+  : (fam : (_x : sig (x : nat) ) → type) → type
+  = fam => sig (x : ext nat ⊤ {_x => 0}) (fib : fam {struct (x : 0) }) 
 
 --------------------[path-types.cooltt]--------------------
 path-types.cooltt:8.11-8.20 [Info]:

--- a/test/test.expected
+++ b/test/test.expected
@@ -876,7 +876,7 @@ patch.cooltt:21.7-21.14 [Info]:
 
 patch.cooltt:24.79-24.82 [Info]:
   fail total-space/fail:
-  Head connective mismatch, expected univ but got (_x₁ : nat) → type
+  Expected type = (_x : sig (A : type) (a : A) ) → (_x₁ : nat) → type
 
 patch.cooltt:35.7-35.15 [Info]:
   category


### PR DESCRIPTION
Hello! I'm a first time cooltt contributor :)

This PR makes implicit the conversion between a signature indexed type family and its total space (as implemented in #280), and replaces `as` with `#` as the patch operator. Now instead of writing `fam # []`, one can write `fam` and `tp # [ patches ]` can be written if `tp` is either a signature indexed type family or a signature. This takes cooltt one step closer to the original total space conversion proposal in #267. 
A patch now looks like this:
```
def el : type := sig (A : type) (a : A)
def el-patch : type := el # [ A .= nat | a .= 4 ]
```
The definition of a category now looks like this:
```
def category : type :=
  sig (ob : type)
      (hom : sig (s : ob) (t : ob) → type)
      (idn : (x : ob) -> hom # [ s .= x | t .= x ])
      (seq : (f : hom) -> (g : hom # [ s .= f.t ]) -> hom # [ s .= f.s | t .= g.t ])
      (seqL : (f : hom) -> path {hom # [ s .= f.s | t .= f.t ]} {seq {idn {f.s}} f} f)
      (seqR : (f : hom) -> path {hom # [ s .= f.s | t .= f.t ]} {seq f {idn {f.t}}} f)
      (seqA : (f : hom) -> (g : hom # [ s .= f.t ]) -> (h : hom # [ s .= g.t ]) -> path {hom # [ s .= f.s | t .= h.t ]} {seq f {seq g h}} {seq {seq f g} h})
```

I may have violated some cooltt style guidelines or misunderstood some implementation details, and would be happy to refactor this as needed. I wasn't sure where to put the new tactic which handles this, so I put it in `Refiner.Structural`, but this may have been the wrong place.

If this goes well, I also have some ideas for making it more convenient to inhabit patched record types that I'd love to try!