### PR TITLE
🩹 Unfold when pattern matching against Univ/El Univ in intro_conversions

### DIFF
--- a/src/frontend/Tactics.ml
+++ b/src/frontend/Tactics.ml
@@ -82,7 +82,7 @@ let intro_conversions (tac : T.Syn.tac) : T.Chk.tac =
           | _ -> RM.ret @@ T.Chk.syn tac
         in
         T.Chk.run tac' tp
-      | _ ->  T.Chk.run (T.Chk.syn tac) tp
+      | _ -> T.Chk.run (T.Chk.syn tac) tp
       end
     | tp -> T.Chk.run (T.Chk.syn tac) tp
 

--- a/src/frontend/Tactics.ml
+++ b/src/frontend/Tactics.ml
@@ -64,7 +64,7 @@ let intro_conversions (tac : T.Syn.tac) : T.Chk.tac =
 
     Therefore, we do an explicit check here instead.
     If we add universe levels, this code should probably be reconsidered. *)
-    T.Chk.rule ~name:"intro_conversions" @@ function
+  T.Chk.rule ~name:"intro_conversions" @@ function
     | D.Univ | D.ElStable `Univ as tp -> 
       let* tm, tp' = T.Syn.run tac in
       let* vtm = RM.lift_ev @@ Sem.eval tm in

--- a/src/frontend/Tactics.ml
+++ b/src/frontend/Tactics.ml
@@ -64,7 +64,6 @@ let intro_conversions (tac : T.Syn.tac) : T.Chk.tac =
 
     Therefore, we do an explicit check here instead.
     If we add universe levels, this code should probably be reconsidered. *)
-    T.Chk.whnf ~style:`UnfoldAll @@
     T.Chk.rule ~name:"intro_conversions" @@ function
     | D.Univ | D.ElStable `Univ as tp -> 
       let* tm, tp' = T.Syn.run tac in

--- a/test/patch.cooltt
+++ b/test/patch.cooltt
@@ -48,3 +48,7 @@ def test-auto (fam : sig (x : nat) -> type) : type := fam
 
 def test-auto-patch (fam : sig (x : nat) -> type) : type := fam # [x .= 0]
 #print test-auto-patch
+
+def U : type := type
+def test-unfold-total (fam : sig (x : nat) -> U) : U := fam
+#print test-unfold-total

--- a/test/test.expected
+++ b/test/test.expected
@@ -992,6 +992,11 @@ patch.cooltt:50.7-50.22 [Info]:
   : (fam : (_x : sig (x : nat) ) → type) → type
   = fam => sig (x : ext nat ⊤ {_x => 0}) (fib : fam {struct (x : 0) }) 
 
+patch.cooltt:54.7-54.24 [Info]:
+  test-unfold-total
+  : (fam : (_x : sig (x : nat) ) → U) → U
+  = fam => sig (x : nat) (fib : fam {struct (x : x) }) 
+
 --------------------[path-types.cooltt]--------------------
 path-types.cooltt:8.11-8.20 [Info]:
   Computed normal form of formation as


### PR DESCRIPTION
The `intro_conversions` tactic (and the `total` tactic before it, actually) checked whether a certain term was equal to `Univ` or `ElStable Univ` by pattern matching, but did not reduce it first. So this test failed to type check:
```
def U : type := type
def test-unfold-total (fam : sig (x : nat) -> U) : U := fam
```
This PR fixes that.