### PR TITLE
🗑 Use the blessed dumper for cofibrations

### DIFF
--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -108,8 +108,7 @@ struct
     | KElOut -> Uuseg_string.pp_utf_8 fmt "⭝ₑₗ"
 
   and pp_cof : cof Pp.printer =
-    fun fmt cof ->
-    pp_con fmt @@ cof_to_con cof
+    Cof.dump_cof Dim.dump Format.pp_print_int
 
   and pp_dim : dim Pp.printer =
     fun fmt r ->
@@ -159,12 +158,7 @@ struct
         (Pp.pp_sep_list (fun fmt (lbl, tp) -> Format.fprintf fmt "%a : %a" Ident.pp_user lbl pp_con tp)) fields
     | Prf ->
       Format.fprintf fmt "*"
-    | Cof (Cof.Join phis) ->
-      Format.fprintf fmt "join[%a]" (Pp.pp_sep_list pp_con) phis
-    | Cof (Cof.Meet phis) ->
-      Format.fprintf fmt "meet[%a]" (Pp.pp_sep_list pp_con) phis
-    | Cof (Cof.Eq (r, s)) ->
-      Format.fprintf fmt "eq[%a,%a]" pp_con r pp_con s
+    | Cof phi -> Cof.dump_cof_f pp_con pp_con fmt phi
     | DimProbe x ->
       Format.fprintf fmt "probe[%a]" DimProbe.pp x
     | Lam (_, clo) ->

--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -158,7 +158,7 @@ struct
         (Pp.pp_sep_list (fun fmt (lbl, tp) -> Format.fprintf fmt "%a : %a" Ident.pp_user lbl pp_con tp)) fields
     | Prf ->
       Format.fprintf fmt "*"
-    | Cof phi -> Cof.dump_cof_f pp_con pp_con fmt phi
+    | Cof phi -> Cof.pp_cof_f pp_con pp_con fmt phi
     | DimProbe x ->
       Format.fprintf fmt "probe[%a]" DimProbe.pp x
     | Lam (_, clo) ->

--- a/src/core/Syntax.ml
+++ b/src/core/Syntax.ml
@@ -109,11 +109,7 @@ struct
     | TpLockedPrf _ -> Format.fprintf fmt "<locked>"
 
 
-  and dump_cof fmt =
-    function
-    | Cof.Eq (r1, r2) -> Format.fprintf fmt "eq[%a, %a]" dump r1 dump r2
-    | Cof.Join cofs -> Format.fprintf fmt "join[%a]" (Pp.pp_sep_list dump) cofs
-    | Cof.Meet cofs -> Format.fprintf fmt "meet[%a]" (Pp.pp_sep_list dump) cofs
+  and dump_cof fmt = Cof.dump_cof_f dump dump fmt
 
   and dump_branch fmt (cof, bdy) =
     Format.fprintf fmt "[%a, %a]" dump cof dump bdy

--- a/src/cubical/Cof.ml
+++ b/src/cubical/Cof.ml
@@ -58,3 +58,7 @@ let rec dump_cof dump_r dump_v fmt =
   function
   | Cof cof -> dump_cof_f dump_r (dump_cof dump_r dump_v) fmt cof
   | Var v -> dump_v fmt v
+
+let pp_cof = dump_cof
+
+let pp_cof_f = dump_cof_f

--- a/src/cubical/Cof.mli
+++ b/src/cubical/Cof.mli
@@ -37,6 +37,10 @@ val boundary : dim0:'r -> dim1:'r -> 'r -> ('r, 'v) cof
 
 val complexity_cof : ('r, 'a) cof -> int
 
+val pp_cof_f : 'r Basis.Pp.printer -> 'a Basis.Pp.printer -> ('r, 'a) cof_f Basis.Pp.printer
+
+val pp_cof : 'r Basis.Pp.printer -> 'v Basis.Pp.printer -> ('r, 'v) cof Basis.Pp.printer
+
 val dump_cof_f : 'r Basis.Pp.printer -> 'a Basis.Pp.printer -> ('r, 'a) cof_f Basis.Pp.printer
 
 val dump_cof : 'r Basis.Pp.printer -> 'v Basis.Pp.printer -> ('r, 'v) cof Basis.Pp.printer


### PR DESCRIPTION
When checking how cofibrations are used across the codebase, I noticed that `dump` has been re-implemented many times, and that does not seem to be good.