### PR TITLE
📏 Remember the lengths

### DIFF
--- a/src/basis/Pp.ml
+++ b/src/basis/Pp.ml
@@ -5,9 +5,9 @@ open BwdNotation
 
 module Env =
 struct
-  type t = string bwd
+  type t = int * string bwd
 
-  let emp = Emp
+  let emp = 0, Emp
 
   let nat_to_suffix n =
     let formatted = string_of_int n in
@@ -22,18 +22,18 @@ struct
     if BwdLabels.mem new_x ~set:xs then (rename [@tailcall]) xs x (i + 1) else new_x
 
   let choose_name (env : t) (x : string) =
-    if BwdLabels.mem x ~set:env then rename env x 1 else x
+    if BwdLabels.mem x ~set:(snd env) then rename (snd env) x 1 else x
 
   let var i env =
-    if i < BwdLabels.length env then
-      BwdLabels.nth env i
+    if i < fst env then
+      BwdLabels.nth (snd env) i
     else
       failwith "Pp printer: tried to resolve bound variable out of range"
 
   let proj xs =
     match xs with
-    | Emp -> failwith "ppenv/proj"
-    | Snoc (xs, _) -> xs
+    | _, Emp -> failwith "ppenv/proj"
+    | n, Snoc (xs, _) -> n-1, xs
 
   let bind (env : t) (nm : string option) : string * t =
     let x =
@@ -41,7 +41,7 @@ struct
       | None -> choose_name env "_x"
       | Some x -> choose_name env x
     in
-    x, env #< x
+    x, (fst env + 1, ((snd env) #< x))
 
   let rec bindn (env : t) (nms : string option list) : string list * t =
     match nms with
@@ -53,7 +53,7 @@ struct
       (x :: xs), env''
 
   let names (env : t) : string list =
-    env <>> []
+    snd env <>> []
 end
 
 let pp_sep_list ?(sep = ", ") pp_elem fmt xs =

--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -8,10 +8,10 @@ struct
   module S = Syntax.Make(Symbol)
 
   let const_tp_clo tp =
-    Clo (S.TpVar 0, {tpenv = Snoc (Emp, tp); conenv = Emp})
+    Clo (S.TpVar 0, {tpenv = 1, Snoc (Emp, tp); conenv = 0, Emp})
 
   let const_tm_clo con =
-    Clo (S.Var 0, {tpenv = Emp; conenv = Snoc (Emp, con)})
+    Clo (S.Var 0, {tpenv = 0, Emp; conenv = 1, Snoc (Emp, con)})
 
   let push frm (hd, sp) =
     hd, sp @ [frm]
@@ -21,19 +21,19 @@ struct
 
   let un_lam con =
     (* y, x |= y(x) *)
-    Clo (S.Ap (S.Var 1, S.Var 0), {tpenv = Emp; conenv = Snoc (Emp, con)})
+    Clo (S.Ap (S.Var 1, S.Var 0), {tpenv = 0, Emp; conenv = 1, Snoc (Emp, con)})
 
   let compose f g =
-    Lam (`Anon, Clo (S.Ap (S.Var 2, S.Ap (S.Var 1, S.Var 0)), {tpenv = Emp; conenv = Snoc (Snoc (Emp, f), g)}))
+    Lam (`Anon, Clo (S.Ap (S.Var 2, S.Ap (S.Var 1, S.Var 0)), {tpenv = 0, Emp; conenv = 2, Snoc (Snoc (Emp, f), g)}))
 
   let apply_to x =
-    Clo (S.Ap (S.Var 0, S.Var 1), {tpenv = Emp; conenv = Snoc (Emp, x)})
+    Clo (S.Ap (S.Var 0, S.Var 1), {tpenv = 0, Emp; conenv = 1, Snoc (Emp, x)})
 
-  let fst = Lam (`Anon, Clo (S.Fst (S.Var 0), {tpenv = Emp; conenv = Emp}))
-  let snd = Lam (`Anon, Clo (S.Snd (S.Var 0), {tpenv = Emp; conenv = Emp}))
+  let fst = Lam (`Anon, Clo (S.Fst (S.Var 0), {tpenv = 0, Emp; conenv = 0, Emp}))
+  let snd = Lam (`Anon, Clo (S.Snd (S.Var 0), {tpenv = 0, Emp; conenv = 0, Emp}))
 
-  let proj lbl = Lam (`Anon, Clo (S.Proj (S.Var 0, lbl), {tpenv = Emp; conenv = Emp}))
-  let el_out = Lam (`Anon, Clo (S.ElOut (S.Var 0), {tpenv = Emp; conenv = Emp}))
+  let proj lbl = Lam (`Anon, Clo (S.Proj (S.Var 0, lbl), {tpenv = 0, Emp; conenv = 0, Emp}))
+  let el_out = Lam (`Anon, Clo (S.ElOut (S.Var 0), {tpenv = 0, Emp; conenv = 0, Emp}))
 
   let tm_abort = Split []
   let tp_abort = TpSplit []
@@ -121,24 +121,24 @@ struct
     fun fmt (Clo (tm, {tpenv; conenv})) ->
       Format.fprintf fmt "clo[%a ; [%a ; %a]]"
         S.dump tm
-        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_tp) (BwdLabels.to_list tpenv)
-        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_con) (BwdLabels.to_list conenv)
+        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_tp) (BwdLabels.to_list (Stdlib.snd tpenv))
+        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_con) (BwdLabels.to_list (Stdlib.snd conenv))
 
   and pp_tp_clo : tp_clo Pp.printer =
     let sep fmt () = Format.fprintf fmt "," in
     fun fmt (Clo (tp, {tpenv; conenv})) ->
       Format.fprintf fmt "tpclo[%a ; [%a ; %a]]"
         S.dump_tp tp
-        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_tp) (BwdLabels.to_list tpenv)
-        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_con) (BwdLabels.to_list conenv)
+        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_tp) (BwdLabels.to_list (Stdlib.snd tpenv))
+        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_con) (BwdLabels.to_list (Stdlib.snd conenv))
 
   and pp_sign_clo : (S.sign clo) Pp.printer =
     let sep fmt () = Format.fprintf fmt "," in
     fun fmt (Clo (sign, {tpenv; conenv})) ->
       Format.fprintf fmt "tpclo[%a ; [%a ; %a]]"
         S.dump_sign sign
-        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_tp) (BwdLabels.to_list tpenv)
-        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_con) (BwdLabels.to_list conenv)
+        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_tp) (BwdLabels.to_list (Stdlib.snd tpenv))
+        (pp_list_group ~left:pp_lsq ~right:pp_rsq ~sep pp_con) (BwdLabels.to_list (Stdlib.snd conenv))
 
   and pp_con : con Pp.printer =
     fun fmt ->

--- a/src/core/DomainData.ml
+++ b/src/core/DomainData.ml
@@ -42,7 +42,7 @@ struct
       (** V types, for univalence *)
     ]
 
-  type env = {tpenv : tp bwd; conenv: con bwd}
+  type env = {tpenv : int * tp bwd; conenv: int * con bwd}
 
   (** A {i closure} combines a semantic environment with a syntactic object binding an additional variable. *)
   and 'a clo = Clo of 'a * env

--- a/src/core/Monads.ml
+++ b/src/core/Monads.ml
@@ -101,18 +101,18 @@ struct
   let drop_con (k : 'a m) : 'a m =
     let* {env; _} = M.read in
     match env.conenv with
-    | Snoc (conenv, _) ->
-      M.scope (fun local -> {local with env = {local.env with conenv}}) k
-    | Emp ->
+    | l, Snoc (conenv, _) ->
+      M.scope (fun local -> {local with env = {local.env with conenv = l-1, conenv}}) k
+    | _, Emp ->
       M.throw Drop
 
   let drop_all_cons (k : 'a m) : 'a m =
-    M.scope (fun local -> {local with env = {local.env with conenv = Emp}}) k
+    M.scope (fun local -> {local with env = {local.env with conenv = 0, Emp}}) k
 
   let append cells =
     M.scope @@ fun local ->
     let open BwdNotation in
-    {local with env = {local.env with conenv = local.env.conenv <>< cells}}
+    {local with env = {local.env with conenv = fst local.env.conenv + List.length cells, snd local.env.conenv <>< cells}}
 
   let lift_cmp (m : 'a compute) : 'a M.m =
     fun {state; cof_thy; _} ->

--- a/src/core/Refiner.ml
+++ b/src/core/Refiner.ml
@@ -173,7 +173,7 @@ struct
   let unleash_syn_hole name : T.Syn.tac =
     Probe.probe_syn name @@
     T.Syn.rule ~name:"unleash_syn_hole" @@
-    let* cut = make_hole name @@ (D.Univ, CofBuilder.bot, D.Clo (S.tm_abort, {tpenv = Emp; conenv = Emp})) in
+    let* cut = make_hole name @@ (D.Univ, CofBuilder.bot, D.Clo (S.tm_abort, {tpenv = 0, Emp; conenv = 0, Emp})) in
     let tp = D.ElCut cut in
     let+ tm = tp |> T.Chk.run @@ unleash_hole name in
     tm, tp

--- a/src/core/Serialize.ml
+++ b/src/core/Serialize.ml
@@ -472,7 +472,7 @@ struct
     | Clo (sign, env) -> labeled "clo" [Syntax.json_of_sign sign; json_of_env env]
 
   and json_of_env {tpenv; conenv} : J.value =
-    `O [("tpenv", json_of_bwd json_of_tp tpenv); ("conenv", json_of_bwd json_of_con conenv)]
+    `O [("tpenv", json_of_bwd json_of_tp (snd tpenv)); ("conenv", json_of_bwd json_of_con (snd conenv))]
 
   and json_of_cof (cof : D.cof) : J.value =
     Cof.json_of_cof json_of_dim json_of_int cof
@@ -601,7 +601,10 @@ struct
   and json_to_env : J.value -> D.env =
     function
     | `O [("tpenv", j_tpenv); ("conenv", j_conenv)] ->
-      { tpenv = json_to_bwd json_to_tp j_tpenv; conenv = json_to_bwd json_to_con j_conenv }
+      let tpenv = json_to_bwd json_to_tp j_tpenv
+      and conenv = json_to_bwd json_to_con j_conenv
+      in
+      { tpenv = BwdLabels.length tpenv, tpenv; conenv = BwdLabels.length conenv, conenv }
     | j -> J.parse_error j "Domain.json_to_env"
 
   and json_to_cof : J.value -> D.cof =

--- a/src/core/Splice.ml
+++ b/src/core/Splice.ml
@@ -11,8 +11,8 @@ type 'a t = D.env -> 'a TB.m * D.env
 
 let foreign con k : _ t =
   fun env ->
-  let env' = {env with conenv = env.conenv <>< [con]} in
-  let var = TB.lvl @@ BwdLabels.length env.conenv in
+  let env' = {env with conenv = fst env.conenv + 1, snd env.conenv <>< [con]} in
+  let var = TB.lvl @@ fst env.conenv in
   k var env'
 
 let foreign_cof phi = foreign @@ D.cof_to_con phi
@@ -21,8 +21,8 @@ let foreign_clo clo = foreign @@ D.Lam (`Anon, clo)
 
 let foreign_tp tp k : _ t =
   fun env ->
-  let env' = {env with tpenv = env.tpenv <>< [tp]} in
-  let var = TB.tplvl @@ BwdLabels.length env.tpenv in
+  let env' = {env with tpenv = fst env.tpenv + 1, snd env.tpenv <>< [tp]} in
+  let var = TB.tplvl @@ fst env.tpenv in
   k var env'
 
 let foreign_list (cons : D.con list) k : _ t =
@@ -37,9 +37,9 @@ let foreign_list (cons : D.con list) k : _ t =
   go cons k
 
 let compile (t : 'a t) : D.env * 'a  =
-  let m, env = t {tpenv = Emp; conenv = Emp} in
-  let tplen = BwdLabels.length env.tpenv in
-  let conlen = BwdLabels.length env.conenv in
+  let m, env = t {tpenv = 0, Emp; conenv = 0, Emp} in
+  let tplen = fst env.tpenv in
+  let conlen = fst env.conenv in
   env, TB.run ~tplen ~conlen m
 
 let term (m : 'a TB.m) : 'a t =

--- a/src/core/Tactic.ml
+++ b/src/core/Tactic.ml
@@ -115,7 +115,7 @@ struct
     | BChk (name, btac) ->
       debug_tactic name;
       fun tp ->
-        let triv = D.Clo (S.tm_abort, {tpenv = Emp; conenv = Emp}) in
+        let triv = D.Clo (S.tm_abort, {tpenv = 0, Emp; conenv = 0, Emp}) in
         btac (tp, CofBuilder.bot, triv)
 
   let brun =


### PR DESCRIPTION
What if we remember the lengths of contexts? For `circle.cooltt` with `loopn {300}` on my computer:

- The main branch (in seconds): 4.41, 4.61, 4.72, 4.39, 4.89
- This branch (in seconds): 4.52, 4.41, 4.26, 4.26, 4.68

It seems to help but can someone do a better profiling? The code is ugly, but I'd like to check whether this is really beneficial.