### PR TITLE
📥 Make Total Spaces Really Cool 😎

### DIFF
--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -355,99 +355,99 @@ and chk_tm : CS.con -> T.Chk.tac =
 
 and syn_tm : ?elim_total:bool -> CS.con -> T.Syn.tac =
   fun ?(elim_total = true) con ->
-    T.Syn.update_span con.info @@
-    (if elim_total then Tactics.elim_implicit_connectives_and_total else Tactics.elim_implicit_connectives) @@
-    match con.node with
-    | CS.Hole (name, None) -> Refiner.Hole.unleash_syn_hole name
-    | CS.Hole (name, Some con) -> Refiner.Probe.probe_syn name @@ syn_tm con
-    | CS.BoundaryHole None ->  Refiner.Hole.unleash_syn_hole None
-    | CS.BoundaryHole (Some con) ->  Refiner.Probe.probe_syn None @@ syn_tm con
-    | CS.Var id ->
-      R.Structural.lookup_var id
-    | CS.DeBruijnLevel lvl ->
-      R.Structural.level lvl
-    | CS.Ap (t, []) ->
-      syn_tm t
-    | CS.Ap (t, ts) ->
-      let rec go acc ts =
-        match ts with
-        | [] -> Tactics.elim_implicit_connectives acc
-        | t :: ts ->
-          let tac = R.Pi.apply (Tactics.elim_implicit_connectives acc) t in
-          go tac ts
-      in
-      go (syn_tm t) @@ List.map chk_tm ts
-    | CS.Fst t ->
-      R.Sg.pi1 @@ syn_tm t
-    | CS.Snd t ->
-      R.Sg.pi2 @@ syn_tm t
-    | CS.Proj (t, ident) ->
-      R.Signature.proj (syn_tm ~elim_total:false t) ident
-    | CS.VProj t ->
-      R.ElV.elim @@ syn_tm t
-    | CS.Cap t ->
-      R.ElHCom.elim @@ syn_tm t
-    | CS.Elim {mot; cases; scrut} ->
-      Tactics.Elim.elim
-        (chk_tm mot)
-        (chk_cases cases)
-        (syn_tm scrut)
-    | CS.Rec {mot; cases; scrut} ->
-      let mot_tac = chk_tm mot in
-      R.Structural.let_syn (T.Syn.ann mot_tac R.Univ.formation) @@ fun tp ->
-      Tactics.Elim.elim
-        (R.Pi.intro @@ fun _ -> T.Chk.syn @@ R.Sub.elim @@ T.Var.syn tp)
-        (chk_cases cases)
-        (syn_tm scrut)
+  T.Syn.update_span con.info @@
+  (if elim_total then Tactics.elim_implicit_connectives_and_total else Tactics.elim_implicit_connectives) @@
+  match con.node with
+  | CS.Hole (name, None) -> Refiner.Hole.unleash_syn_hole name
+  | CS.Hole (name, Some con) -> Refiner.Probe.probe_syn name @@ syn_tm con
+  | CS.BoundaryHole None ->  Refiner.Hole.unleash_syn_hole None
+  | CS.BoundaryHole (Some con) ->  Refiner.Probe.probe_syn None @@ syn_tm con
+  | CS.Var id ->
+    R.Structural.lookup_var id
+  | CS.DeBruijnLevel lvl ->
+    R.Structural.level lvl
+  | CS.Ap (t, []) ->
+    syn_tm t
+  | CS.Ap (t, ts) ->
+    let rec go acc ts =
+      match ts with
+      | [] -> Tactics.elim_implicit_connectives acc
+      | t :: ts ->
+        let tac = R.Pi.apply (Tactics.elim_implicit_connectives acc) t in
+        go tac ts
+    in
+    go (syn_tm t) @@ List.map chk_tm ts
+  | CS.Fst t ->
+    R.Sg.pi1 @@ syn_tm t
+  | CS.Snd t ->
+    R.Sg.pi2 @@ syn_tm t
+  | CS.Proj (t, ident) ->
+    R.Signature.proj (syn_tm ~elim_total:false t) ident
+  | CS.VProj t ->
+    R.ElV.elim @@ syn_tm t
+  | CS.Cap t ->
+    R.ElHCom.elim @@ syn_tm t
+  | CS.Elim {mot; cases; scrut} ->
+    Tactics.Elim.elim
+      (chk_tm mot)
+      (chk_cases cases)
+      (syn_tm scrut)
+  | CS.Rec {mot; cases; scrut} ->
+    let mot_tac = chk_tm mot in
+    R.Structural.let_syn (T.Syn.ann mot_tac R.Univ.formation) @@ fun tp ->
+    Tactics.Elim.elim
+      (R.Pi.intro @@ fun _ -> T.Chk.syn @@ R.Sub.elim @@ T.Var.syn tp)
+      (chk_cases cases)
+      (syn_tm scrut)
 
-    | CS.Ann {term; tp} ->
-      T.Syn.ann (chk_tm term) (chk_tp tp)
-    | CS.Unfold (idents, c) ->
-      (* TODO: move to a primitive rule *)
-      T.Syn.rule @@ unfold idents @@ T.Syn.run @@ syn_tm c
-    | CS.Coe (tp, src, trg, body) ->
-      R.Univ.coe (chk_tm tp) (chk_tm src) (chk_tm trg) (chk_tm body)
-    | CS.HCom (tp, src, trg, cof, tm) ->
-      R.Univ.hcom (chk_tm tp) (chk_tm src) (chk_tm trg) (chk_tm cof) (chk_tm tm)
-    | CS.HFill (code, src, cof, tm) ->
-      let code_tac = chk_tm code in
-      let tac =
-        R.Pi.intro ~ident:(`Machine "i") @@ fun i ->
-        Tactics.intro_implicit_connectives @@
-        T.Chk.syn @@
-        Tactics.elim_implicit_connectives @@
-        R.Univ.hcom code_tac (chk_tm src) (T.Chk.syn @@ T.Var.syn i) (chk_tm cof) (chk_tm tm)
-      in
-      T.Syn.ann tac @@
-      R.Pi.formation R.Dim.formation (`Anon, fun _ -> R.El.formation code_tac)
-    | CS.Com (fam, src, trg, cof, tm) ->
-      R.Univ.com (chk_tm fam) (chk_tm src) (chk_tm trg) (chk_tm cof) (chk_tm tm)
-    | CS.Equations {code; eqns} ->
-      let open Tactics.Equations in
-      let code_tac = chk_tm code in
-      let rec mk_steps : CS.eqns CS.step -> T.Syn.tac * T.Chk.tac * T.Chk.tac =
-        function
-        | Equals (lhs, p, eqns) ->
-          let q_tac, mid_tac, rhs_tac = mk_eqns eqns in
-          let lhs_tac = chk_tm lhs in
-          step code_tac lhs_tac mid_tac rhs_tac (chk_tm p) (T.Chk.syn q_tac), lhs_tac, rhs_tac
-        | Trivial (lhs, eqns) ->
-          let q_tac, mid_tac, rhs_tac = mk_eqns eqns in
-          let lhs_tac = chk_tm lhs in
-          step code_tac lhs_tac mid_tac rhs_tac (T.Chk.syn @@ qed code_tac lhs_tac) (T.Chk.syn q_tac), lhs_tac, rhs_tac
-      and mk_eqns : CS.eqns -> T.Syn.tac * T.Chk.tac * T.Chk.tac =
-        function
-        | Step s ->
-          mk_steps s
-        | Qed x ->
-          let x_tac = chk_tm x in
-          qed code_tac x_tac, x_tac, x_tac
-      in
-      let (tac, _, _ ) = mk_steps eqns in
-      tac
-    | _ ->
-      T.Syn.rule @@
-      RM.throw @@ ElabError.ElabError (ElabError.ExpectedSynthesizableTerm con.node, con.info)
+  | CS.Ann {term; tp} ->
+    T.Syn.ann (chk_tm term) (chk_tp tp)
+  | CS.Unfold (idents, c) ->
+    (* TODO: move to a primitive rule *)
+    T.Syn.rule @@ unfold idents @@ T.Syn.run @@ syn_tm c
+  | CS.Coe (tp, src, trg, body) ->
+    R.Univ.coe (chk_tm tp) (chk_tm src) (chk_tm trg) (chk_tm body)
+  | CS.HCom (tp, src, trg, cof, tm) ->
+    R.Univ.hcom (chk_tm tp) (chk_tm src) (chk_tm trg) (chk_tm cof) (chk_tm tm)
+  | CS.HFill (code, src, cof, tm) ->
+    let code_tac = chk_tm code in
+    let tac =
+      R.Pi.intro ~ident:(`Machine "i") @@ fun i ->
+      Tactics.intro_implicit_connectives @@
+      T.Chk.syn @@
+      Tactics.elim_implicit_connectives @@
+      R.Univ.hcom code_tac (chk_tm src) (T.Chk.syn @@ T.Var.syn i) (chk_tm cof) (chk_tm tm)
+    in
+    T.Syn.ann tac @@
+    R.Pi.formation R.Dim.formation (`Anon, fun _ -> R.El.formation code_tac)
+  | CS.Com (fam, src, trg, cof, tm) ->
+    R.Univ.com (chk_tm fam) (chk_tm src) (chk_tm trg) (chk_tm cof) (chk_tm tm)
+  | CS.Equations {code; eqns} ->
+    let open Tactics.Equations in
+    let code_tac = chk_tm code in
+    let rec mk_steps : CS.eqns CS.step -> T.Syn.tac * T.Chk.tac * T.Chk.tac =
+      function
+      | Equals (lhs, p, eqns) ->
+        let q_tac, mid_tac, rhs_tac = mk_eqns eqns in
+        let lhs_tac = chk_tm lhs in
+        step code_tac lhs_tac mid_tac rhs_tac (chk_tm p) (T.Chk.syn q_tac), lhs_tac, rhs_tac
+      | Trivial (lhs, eqns) ->
+        let q_tac, mid_tac, rhs_tac = mk_eqns eqns in
+        let lhs_tac = chk_tm lhs in
+        step code_tac lhs_tac mid_tac rhs_tac (T.Chk.syn @@ qed code_tac lhs_tac) (T.Chk.syn q_tac), lhs_tac, rhs_tac
+    and mk_eqns : CS.eqns -> T.Syn.tac * T.Chk.tac * T.Chk.tac =
+      function
+      | Step s ->
+        mk_steps s
+      | Qed x ->
+        let x_tac = chk_tm x in
+        qed code_tac x_tac, x_tac, x_tac
+    in
+    let (tac, _, _ ) = mk_steps eqns in
+    tac
+  | _ ->
+    T.Syn.rule @@
+    RM.throw @@ ElabError.ElabError (ElabError.ExpectedSynthesizableTerm con.node, con.info)
 
 and chk_cases cases =
   List.map chk_case cases

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -347,11 +347,38 @@ and chk_tm : CS.con -> T.Chk.tac =
         RM.ret @@ R.Pi.intro @@ fun _ -> chk_tm @@ CS.{node = CS.Ap (con, [CS.{node = DeBruijnLevel lvl; info = None}]); info = None}
       | D.Sg _ ->
         RM.ret @@ R.Sg.intro (chk_tm @@ CS.{node = CS.Fst con; info = None}) (chk_tm @@ CS.{node = CS.Snd con; info = None})
-      | D.Signature _ ->
+      | D.Signature _sign ->
         let field_tac lbl = Option.some @@ chk_tm @@ CS.{node = CS.Proj (con, lbl); info = None} in
         RM.ret @@ R.Signature.intro field_tac
+        (* let open RefineMonad in
+        begin
+        Tactics.is_total sign |>> function
+          | `TotalSome tp -> failwith ""
+          | `NotTotal -> 
+            let field_tac lbl = Option.some @@ chk_tm @@ CS.{node = CS.Proj (con, lbl); info = None} in
+            RM.ret @@ R.Signature.intro field_tac
+          | `TotalAll _tp -> failwith "impossible"
+        end *)
       | _ ->
         RM.ret @@ Tactics.intro_conversions @@ syn_tm con
+
+
+(* 
+
+Checking against `TotalAll => insert_implicit
+  if synth to comparse, normal
+
+Checking against `TotalSome => write down a record
+  if synth to compare, do NOT insert .fib
+
+Checking ainst `NotTotal => write down a record
+  if synth to compare, normal
+
+Synthing =>
+  if project, do NOT insert .fib
+  else if `TotalAll | `TotalSome, insert .fib
+
+*)
 
 and syn_tm : CS.con -> T.Syn.tac =
   function con ->

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -206,7 +206,7 @@ and chk_tm_in_tele (args : CS.cell list) (con : CS.con) : T.Chk.tac =
 and chk_tm : CS.con -> T.Chk.tac =
   fun con ->
   T.Chk.update_span con.info @@
-  Tactics.intro_subtypes @@
+  Tactics.intro_subtypes_and_total @@
   match con.node with
   | CS.Hole (name, None) -> Refiner.Hole.unleash_hole name
   | CS.Hole (name, Some con) -> Refiner.Probe.probe_chk name @@ chk_tm con

--- a/src/frontend/Elaborator.mli
+++ b/src/frontend/Elaborator.mli
@@ -10,5 +10,5 @@ val chk_tp : CS.con -> Tp.tac
 val chk_tp_in_tele : CS.cell list -> CS.con -> Tp.tac
 val chk_tm : CS.con -> Chk.tac
 val chk_tm_in_tele : CS.cell list -> CS.con -> Chk.tac
-val syn_tm : CS.con -> Syn.tac
+val syn_tm : ?elim_total:bool -> CS.con -> Syn.tac
 val modifier : CS.con -> [> `Print of string option] Yuujinchou.Pattern.t RM.m

--- a/src/frontend/Tactics.ml
+++ b/src/frontend/Tactics.ml
@@ -16,7 +16,7 @@ open Monad.Notation (RM)
 
 let is_total (sign : D.sign) = 
   let rec go acc = function
-    | D.Field (`User ["fib"],tp,D.Clo ([],_)) -> RM.ret @@ acc tp
+    | D.Field (`User ["fib"],_,D.Clo ([],_)) -> RM.ret @@ acc
     | D.Field (lbl,(D.ElStable (`Ext (0,_,`Global (Cof cof),_)) as tp),sign_clo) ->
       let* cof = RM.lift_cmp @@ Sem.cof_con_to_cof cof in
       RM.abstract (lbl :> Ident.t) tp @@ fun v ->
@@ -24,15 +24,15 @@ let is_total (sign : D.sign) =
         begin
           RM.lift_cmp @@ Monads.CmpM.test_sequent [] cof |>> function
             | true -> go acc sign
-            | false -> go (fun x -> `TotalSome x) sign
+            | false -> go `TotalSome sign
         end
     | D.Field (lbl,tp,sign_clo) -> 
       RM.abstract (lbl :> Ident.t) tp @@ fun v ->
         let* sign = RM.lift_cmp @@ Sem.inst_sign_clo sign_clo v in
-        go (fun x -> `TotalSome x) sign
+        go `TotalSome sign
     | D.Empty -> RM.ret `NotTotal
   in
-  go (fun x -> `TotalAll x) sign 
+  go `TotalAll sign 
 
 let is_total_code (code : (Ident.user * D.con) list) =
   let* sign = RM.lift_cmp @@ Sem.unfold_el (`Signature code) in
@@ -77,7 +77,7 @@ let rec elim_implicit_connectives_and_total : T.Syn.tac -> T.Syn.tac =
   | D.Signature sign ->
     begin
     is_total sign |>> function
-      | `TotalAll _ | `TotalSome _ -> T.Syn.run @@ elim_implicit_connectives_and_total @@ R.Signature.proj (T.Syn.rule @@ RM.ret (tm,tp)) (`User ["fib"])
+      | `TotalAll | `TotalSome -> T.Syn.run @@ elim_implicit_connectives_and_total @@ R.Signature.proj (T.Syn.rule @@ RM.ret (tm,tp)) (`User ["fib"])
       | `NotTotal -> RM.ret (tm,tp)
     end
   | _ ->
@@ -94,7 +94,7 @@ let rec intro_implicit_connectives : T.Chk.tac -> T.Chk.tac =
   | D.Signature sign, _, _ ->
     begin
     is_total sign |>> function
-      | `TotalAll _ -> RM.ret @@ R.Signature.intro (function `User ["fib"] -> Some (intro_implicit_connectives tac) | _ -> None) 
+      | `TotalAll -> RM.ret @@ R.Signature.intro (function `User ["fib"] -> Some (intro_implicit_connectives tac) | _ -> None) 
       | _ -> RM.ret tac
     end
   | _ ->

--- a/src/frontend/Tactics.ml
+++ b/src/frontend/Tactics.ml
@@ -33,13 +33,7 @@ let is_total (sign : D.sign) =
     | D.Empty -> RM.ret `NotTotal
   in
   go `TotalAll sign 
-
-let is_total_code (code : (Ident.user * D.con) list) =
-  let* sign = RM.lift_cmp @@ Sem.unfold_el (`Signature code) in
-  match sign with
-    | D.Signature sign -> is_total sign
-    | _ -> failwith "impossible"
-
+  
 let elab_err err =
   let* env = RM.read in
   RM.throw @@ ElabError.ElabError (err, RefineEnv.location env)

--- a/src/frontend/Tactics.mli
+++ b/src/frontend/Tactics.mli
@@ -11,9 +11,9 @@ module R := Refiner
 open Tactic
 
 (** Determines whether a signature is:
-   `TotalAll : A total space created by the `total` tactic, where all fields but `fib` are patched
-   `TotalSome : A total space created by the `total` tactic, where at least one non-`fib` field is *not* patched
-   `NotTotal : Not a total space created by the `total` tactic
+    `TotalAll : A total space created by the `total` tactic, where all fields but `fib` are patched
+    `TotalSome : A total space created by the `total` tactic, where at least one non-`fib` field is *not* patched
+    `NotTotal : Not a total space created by the `total` tactic
 *)
 val is_total : D.sign -> [`TotalAll | `TotalSome | `NotTotal] RM.m
 

--- a/src/frontend/Tactics.mli
+++ b/src/frontend/Tactics.mli
@@ -10,8 +10,8 @@ module R := Refiner
 
 open Tactic
 
-val is_total : D.sign -> [`TotalAll of D.tp | `TotalSome of D.tp | `NotTotal] RM.m
-val is_total_code : (Ident.user * D.con) list -> [`TotalAll of D.tp | `TotalSome of D.tp | `NotTotal] RM.m
+val is_total : D.sign -> [`TotalAll | `TotalSome | `NotTotal] RM.m
+val is_total_code : (Ident.user * D.con) list -> [`TotalAll | `TotalSome | `NotTotal] RM.m
 
 val intro_subtypes : Chk.tac -> Chk.tac
 val intro_implicit_connectives : Chk.tac -> Chk.tac

--- a/src/frontend/Tactics.mli
+++ b/src/frontend/Tactics.mli
@@ -16,6 +16,7 @@ val is_total_code : (Ident.user * D.con) list -> [`TotalAll of D.tp | `TotalSome
 val intro_subtypes : Chk.tac -> Chk.tac
 val intro_implicit_connectives : Chk.tac -> Chk.tac
 val elim_implicit_connectives : Syn.tac -> Syn.tac
+val elim_implicit_connectives_and_total : Syn.tac -> Syn.tac
 val intro_conversions : Syn.tac -> Chk.tac
 
 val tac_nary_quantifier : ('a, 'b) R.quantifier -> (Ident.t * 'a) list -> 'b -> 'b

--- a/src/frontend/Tactics.mli
+++ b/src/frontend/Tactics.mli
@@ -17,7 +17,7 @@ open Tactic
 *)
 val is_total : D.sign -> [`TotalAll | `TotalSome | `NotTotal] RM.m
 
-val intro_subtypes : Chk.tac -> Chk.tac
+val intro_subtypes_and_total : Chk.tac -> Chk.tac
 val intro_implicit_connectives : Chk.tac -> Chk.tac
 val elim_implicit_connectives : Syn.tac -> Syn.tac
 val elim_implicit_connectives_and_total : Syn.tac -> Syn.tac

--- a/src/frontend/Tactics.mli
+++ b/src/frontend/Tactics.mli
@@ -11,7 +11,6 @@ module R := Refiner
 open Tactic
 
 val is_total : D.sign -> [`TotalAll | `TotalSome | `NotTotal] RM.m
-val is_total_code : (Ident.user * D.con) list -> [`TotalAll | `TotalSome | `NotTotal] RM.m
 
 val intro_subtypes : Chk.tac -> Chk.tac
 val intro_implicit_connectives : Chk.tac -> Chk.tac

--- a/src/frontend/Tactics.mli
+++ b/src/frontend/Tactics.mli
@@ -10,6 +10,9 @@ module R := Refiner
 
 open Tactic
 
+val is_total : D.sign -> [`TotalAll of D.tp | `TotalSome of D.tp | `NotTotal] RM.m
+val is_total_code : (Ident.user * D.con) list -> [`TotalAll of D.tp | `TotalSome of D.tp | `NotTotal] RM.m
+
 val intro_subtypes : Chk.tac -> Chk.tac
 val intro_implicit_connectives : Chk.tac -> Chk.tac
 val elim_implicit_connectives : Syn.tac -> Syn.tac

--- a/src/frontend/Tactics.mli
+++ b/src/frontend/Tactics.mli
@@ -10,6 +10,11 @@ module R := Refiner
 
 open Tactic
 
+(** Determines whether a signature is:
+   `TotalAll : A total space created by the `total` tactic, where all fields but `fib` are patched
+   `TotalSome : A total space created by the `total` tactic, where at least one non-`fib` field is *not* patched
+   `NotTotal : Not a total space created by the `total` tactic
+*)
 val is_total : D.sign -> [`TotalAll | `TotalSome | `NotTotal] RM.m
 
 val intro_subtypes : Chk.tac -> Chk.tac

--- a/test/cool-total-space.cooltt
+++ b/test/cool-total-space.cooltt
@@ -31,3 +31,5 @@ def no-insert-fib-record : sig (fam : sig (x : nat) -> type) (test : fam -> nat)
     struct (fam : _ => sig (y : nat))
            (test : total => total.fib.y)
 #print no-insert-fib-record
+
+def test-hole (fam : sig (x : nat) -> type) : fam # [x .= 0] := ?

--- a/test/cool-total-space.cooltt
+++ b/test/cool-total-space.cooltt
@@ -1,0 +1,6 @@
+
+def test1 (fam : sig (x : nat) -> type) (fib : fam {struct (x : 0)}): fam # [x .= 0] :=
+    fib
+
+def test2 (fam : sig (x : nat) -> type) (a : fam # [x .= 0]) : fam # [x .= 0] := 
+    a

--- a/test/cool-total-space.cooltt
+++ b/test/cool-total-space.cooltt
@@ -1,6 +1,0 @@
-
-def test1 (fam : sig (x : nat) -> type) (fib : fam {struct (x : 0)}): fam # [x .= 0] :=
-    fib
-
-def test2 (fam : sig (x : nat) -> type) (a : fam # [x .= 0]) : fam # [x .= 0] := 
-    a

--- a/test/cool-total-space.cooltt
+++ b/test/cool-total-space.cooltt
@@ -1,0 +1,25 @@
+
+
+
+def fully-patched (fam : sig (x : nat) -> type) (fib : fam {struct (x : 0)}) : fam # [x .= 0] :=
+    fib
+
+def not-fully-patched (fam : sig (x : nat) -> type) (fib : fam {struct (x : 0)}) : fam := 
+    struct (x : 0) (fib : fib)
+
+def no-insert-fib (fam : sig (x : nat) -> type) (total : fam) : nat :=
+    total.x
+
+def insert-fib-plain (fam : sig (x : nat) -> type) (total : fam) : fam {struct (x : total.x)} := total
+
+def insert-fib-pi : sig (fam : sig (x : nat) -> type) (test : fam -> nat) :=
+    struct (fam : _ => nat -> nat)
+           (test : total => total 0)
+
+def insert-fib-sg : sig (fam : sig (x : nat) -> type) (test : fam -> nat) :=
+    struct (fam : _ => nat * nat)
+           (test : total => fst total)
+
+def no-insert-fib-record : sig (fam : sig (x : nat) -> type) (test : fam -> nat) :=
+    struct (fam : _ => sig (y : nat))
+           (test : total => total.fib.y)

--- a/test/cool-total-space.cooltt
+++ b/test/cool-total-space.cooltt
@@ -3,23 +3,31 @@
 
 def fully-patched (fam : sig (x : nat) -> type) (fib : fam {struct (x : 0)}) : fam # [x .= 0] :=
     fib
+#print fully-patched
 
 def not-fully-patched (fam : sig (x : nat) -> type) (fib : fam {struct (x : 0)}) : fam := 
     struct (x : 0) (fib : fib)
+#print not-fully-patched
 
 def no-insert-fib (fam : sig (x : nat) -> type) (total : fam) : nat :=
     total.x
+#print no-insert-fib
 
-def insert-fib-plain (fam : sig (x : nat) -> type) (total : fam) : fam {struct (x : total.x)} := total
+def insert-fib-plain (fam : sig (x : nat) -> type) (total : fam) : fam {struct (x : total.x)} := 
+    total
+#print insert-fib-plain
 
 def insert-fib-pi : sig (fam : sig (x : nat) -> type) (test : fam -> nat) :=
     struct (fam : _ => nat -> nat)
            (test : total => total 0)
+#print insert-fib-pi
 
 def insert-fib-sg : sig (fam : sig (x : nat) -> type) (test : fam -> nat) :=
     struct (fam : _ => nat * nat)
            (test : total => fst total)
+#print insert-fib-sg
 
 def no-insert-fib-record : sig (fam : sig (x : nat) -> type) (test : fam -> nat) :=
     struct (fam : _ => sig (y : nat))
            (test : total => total.fib.y)
+#print no-insert-fib-record

--- a/test/patch.cooltt
+++ b/test/patch.cooltt
@@ -41,11 +41,12 @@ def category : type :=
 def types : category :=
   struct (ob : type)
          (hom : args => {args.s} -> {args.t})
-         (idn : x => struct (fib : x => x))
-         (seq : f g => struct (fib : x => g.fib {f.fib x}))
+         (idn : x z => z)
+         (seq : f g x => g {f x})
          (seqL : f i => f)
          (seqR : f i => f)
-         (seqA : f g h i => struct (fib : x => {h.fib} {{g.fib} {{f.fib} x}}))
+         (seqA : f g h i x => h {g {f x}})
+
 
 def test-auto (fam : sig (x : nat) -> type) : type := fam
 #print test-auto

--- a/test/test.expected
+++ b/test/test.expected
@@ -527,6 +527,12 @@ cool-total-space.cooltt:33.7-33.27 [Info]:
   = struct (fam : {_x => sig (y : nat) }) 
     (test : {total => {total @ fib} @ y}) 
 
+cool-total-space.cooltt:35.64-35.65 [Info]:
+  Emitted hole:
+    fam : (_x : sig (x : nat) ) → type
+    |- ? : fam {struct (x : 0) }
+
+
 --------------------[elab.cooltt]--------------------
 elab.cooltt:7.11-7.24 [Info]:
   Computed normal form of boundary-test as

--- a/test/test.expected
+++ b/test/test.expected
@@ -476,6 +476,7 @@ com.cooltt:89.11-89.20 [Info]:
    A r r' φ p =>
    hcom {A r'} r r' φ {_x _x₁ => coe {_x₂ => A _x₂} _x r' {p _x _x₁}}
 
+--------------------[cool-total-space.cooltt]--------------------
 --------------------[elab.cooltt]--------------------
 elab.cooltt:7.11-7.24 [Info]:
   Computed normal form of boundary-test as

--- a/test/test.expected
+++ b/test/test.expected
@@ -1021,17 +1021,17 @@ patch.cooltt:39.7-39.15 [Info]:
        })
     
 
-patch.cooltt:51.7-51.16 [Info]:
+patch.cooltt:52.7-52.16 [Info]:
   test-auto
   : (fam : (_x : sig (x : nat) ) → type) → type
   = fam => sig (x : nat) (fib : fam {struct (x : x) }) 
 
-patch.cooltt:54.7-54.22 [Info]:
+patch.cooltt:55.7-55.22 [Info]:
   test-auto-patch
   : (fam : (_x : sig (x : nat) ) → type) → type
   = fam => sig (x : ext nat ⊤ {_x => 0}) (fib : fam {struct (x : 0) }) 
 
-patch.cooltt:58.7-58.24 [Info]:
+patch.cooltt:59.7-59.24 [Info]:
   test-unfold-total
   : (fam : (_x : sig (x : nat) ) → U) → U
   = fam => sig (x : nat) (fib : fam {struct (x : x) }) 

--- a/test/test.expected
+++ b/test/test.expected
@@ -477,6 +477,56 @@ com.cooltt:89.11-89.20 [Info]:
    hcom {A r'} r r' φ {_x _x₁ => coe {_x₂ => A _x₂} _x r' {p _x _x₁}}
 
 --------------------[cool-total-space.cooltt]--------------------
+cool-total-space.cooltt:6.7-6.20 [Info]:
+  fully-patched
+  : (fam : (_x : sig (x : nat) ) → type) → (fib : fam {struct (x : 0) }) → 
+  sig (x : ext nat ⊤ {_x => 0}) (fib : fam {struct (x : 0) }) 
+  = fam fib => struct (x : 0) (fib : fib) 
+
+cool-total-space.cooltt:10.7-10.24 [Info]:
+  not-fully-patched
+  : (fam : (_x : sig (x : nat) ) → type) → (fib : fam {struct (x : 0) }) → 
+  sig (x : nat) (fib : fam {struct (x : x) }) 
+  = fam fib => struct (x : 0) (fib : fib) 
+
+cool-total-space.cooltt:14.7-14.20 [Info]:
+  no-insert-fib
+  : (fam : (_x : sig (x : nat) ) → type) → (total : sig (x : nat) 
+                                                    (fib : fam {struct (x : x)
+                                                                })
+                                                    ) → nat
+  = fam total => total @ x
+
+cool-total-space.cooltt:18.7-18.23 [Info]:
+  insert-fib-plain
+  : (fam : (_x : sig (x : nat) ) → type) → (total : sig (x : nat) 
+                                                    (fib : fam {struct (x : x)
+                                                                })
+                                                    ) → fam {struct (x : 
+                                                             total @ x) }
+  = fam total => total @ fib
+
+cool-total-space.cooltt:23.7-23.20 [Info]:
+  insert-fib-pi
+  : sig (fam : (_x : sig (x : nat) ) → type) 
+    (test : (_x : sig (x : nat) (fib : fam {struct (x : x) }) ) → nat) 
+  = struct (fam : {_x => (_x₁ : nat) → nat}) 
+    (test : {total => {total @ fib} 0}) 
+
+cool-total-space.cooltt:28.7-28.20 [Info]:
+  insert-fib-sg
+  : sig (fam : (_x : sig (x : nat) ) → type) 
+    (test : (_x : sig (x : nat) (fib : fam {struct (x : x) }) ) → nat) 
+  = struct (fam : {_x => (_x₁ : nat) × nat}) 
+    (test : {total => fst {total @ fib}}) 
+
+cool-total-space.cooltt:33.7-33.27 [Info]:
+  no-insert-fib-record
+  : sig (fam : (_x : sig (x : nat) ) → type) 
+    (test : (_x : sig (x : nat) (fib : fam {struct (x : x) }) ) → nat) 
+  = struct (fam : {_x => sig (y : nat) }) 
+    (test : {total => {total @ fib} @ y}) 
+
 --------------------[elab.cooltt]--------------------
 elab.cooltt:7.11-7.24 [Info]:
   Computed normal form of boundary-test as


### PR DESCRIPTION
### New feature
This PR implements the proposal roughly described in #348 to make total spaces totally (lol) implicit whenever possible. We can now write down the definition of the category of types like this:
```
def types : category :=
  struct (ob : type)
         (hom : args => {args.s} -> {args.t})
         (idn : x z => z)
         (seq : f g x => g {f x})
         (seqL : f i => f)
         (seqR : f i => f)
         (seqA : f g h i x => h {g {f x}})
```
(Closes #348)
### How this is done
* Total spaces where all fields but `fib` have been patched are handled by `intro_implicit_connectives`. The user need only write down the value of the `fib` field
* Total spaces with unpatched fields are still just regular signature types, and the user must write down a record to inhabit them
* Any term that synths to a total space will have it's `fib` field implicitly projected, _unless_ the term was going to be projected from by the user. That is, `e .lbl` will not implicitly become `{e .fib} .lbl` if `e` synths to a total space. This allows us to project out the bundled fields of a total space. The one negative consequence of this is that if your `fib` field is itself a record, you must manually insert `.fib` projections. Perhaps we could introduce some special syntax to project total space fields?

The concern about the interaction of checking and synthing I mentioned in #348 happily turned out to be a non-issue. My experience was that it just magically worked haha. I'm pretty sure it's the eta-expansion during elaboration that handles it.


### Remaining issues
* **DONE:** This PR needs more tests
* I feel that the `elim_total` optional argument I've added to `syn_tm` is a little awkward/inelegant, thought it does work. Perhaps it should be part of the local state?
* **DONE:** When displaying a hole where the goal is a fully patched total space, the user should see the type of the `fib` field as the goal, but currently the whole signature is shown
