### PR TITLE
🩹 Bind field labels when pretty printing signatures

### DIFF
--- a/src/core/Syntax.ml
+++ b/src/core/Syntax.ml
@@ -484,8 +484,16 @@ struct
         Uuseg_string.pp_utf_8 "∘"
         (pp_sub env P.(right_of sub_compose)) sb1
 
-  and pp_sign env fmt (sign : sign) : unit = pp_fields pp_tp env fmt sign
-
+  and pp_sign env fmt : sign -> unit = 
+    function
+    | [] -> ()
+    | ((lbl, tp) :: fields) ->
+      let lbl,envlbl = ppenv_bind env (lbl :> Ident.t) in
+      Format.fprintf fmt "(%s : %a)@ @,%a"
+        lbl
+        (pp_tp env P.(right_of colon)) tp
+        (pp_sign envlbl) fields  
+  
   and pp_tp env =
     pp_braced_cond P.classify_tp @@ fun penv fmt ->
     function


### PR DESCRIPTION
This PR fixes a bug in `Syntax.pp_sign`, where field labels were not bound during pretty printing, leading to this code
```
def bad : type := sig (A : type) (a : A) (b : A)

def test (x : bad) : type :=
  let y := x in
  ?
```
causing this error
```
test.cooltt:5.2-5.3 [Info]:            
  Emitted hole:
    x : bad
    y : sub {sig (A : type) (a : x) 
        (y : cooltt: internal error, uncaught exception:
                     Failure("Pp printer: tried to resolve bound variable out of range")
```
