### PR TITLE
🌌 Make the Universe Strict

### DIFF
--- a/src/core/Conversion.ml
+++ b/src/core/Conversion.ml
@@ -107,10 +107,10 @@ let rec equate_tp (tp0 : D.tp) (tp1 : D.tp) =
   | D.Univ, D.Univ ->
     ret ()
   | D.ElStable code0, _ ->
-    let* tp0 = ConvM.lift_cmp @@ Sem.unfold_el code0 in
+    let* tp0 = lift_cmp @@ Sem.unfold_el code0 in
     equate_tp tp0 tp1
   | _, D.ElStable code1 ->
-    let* tp1 = ConvM.lift_cmp @@ Sem.unfold_el code1 in
+    let* tp1 = lift_cmp @@ Sem.unfold_el code1 in
     equate_tp tp0 tp1
   | D.ElCut cut0, D.ElCut cut1 ->
     equate_cut cut0 cut1

--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -33,8 +33,6 @@ struct
   let snd = Lam (`Anon, Clo (S.Snd (S.Var 0), {tpenv = Emp; conenv = Emp}))
 
   let proj lbl = Lam (`Anon, Clo (S.Proj (S.Var 0, lbl), {tpenv = Emp; conenv = Emp}))
-  let el_out = Lam (`Anon, Clo (S.ElOut (S.Var 0), {tpenv = Emp; conenv = Emp}))
-
   let tm_abort = Split []
   let tp_abort = TpSplit []
 
@@ -106,7 +104,6 @@ struct
     | KProj lbl -> Format.fprintf fmt "proj[%a]" Ident.pp_user lbl
     | KNatElim _ -> Format.fprintf fmt "<nat-elim>"
     | KCircleElim _ -> Format.fprintf fmt "<circle-elim>"
-    | KElOut -> Uuseg_string.pp_utf_8 fmt "⭝ₑₗ"
 
   and pp_cof : cof Pp.printer =
     fun fmt cof ->
@@ -174,8 +171,6 @@ struct
       Format.fprintf fmt "dim0"
     | Dim1 ->
       Format.fprintf fmt "dim1"
-    | ElIn con ->
-      Format.fprintf fmt "el/in[%a]" pp_con con
     | StableCode `Nat ->
       Format.fprintf fmt "nat/code"
     | StableCode `Circle ->

--- a/src/core/Domain.mli
+++ b/src/core/Domain.mli
@@ -23,7 +23,6 @@ module Make : functor (Symbol : Symbol.S) -> sig
   val fst : con
   val snd : con
   val proj : Ident.user -> con
-  val el_out : con
 
   val tm_abort : con
   val tp_abort : tp

--- a/src/core/DomainData.ml
+++ b/src/core/DomainData.ml
@@ -70,10 +70,7 @@ struct
     | Pair of con * con
     | Struct of (Ident.user * con) list
     | SubIn of con
-
-    | ElIn of con
-    (** The introduction form for the extension of a {i stable} type code only (see {!constructor:ElStable} and {!constructor:ElUnstable}). *)
-
+    
     | Dim0
     | Dim1
     | DimProbe of DimProbe.t
@@ -138,10 +135,6 @@ struct
     | KProj of Ident.user
     | KNatElim of con * con * con
     | KCircleElim of con * con * con
-
-    | KElOut
-    (** The elimination form for the extension of a {i stable} type code only (see {!constructor:ElStable}). *)
-
 
   (** An {i unstable} frame is a {i dimension substitution-unstable} elimination form with a hole in place of its principal argument. *)
   and unstable_frm =

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -115,12 +115,8 @@ let rec quote_con (tp : D.tp) con =
     S.SubIn tout
 
   | D.ElStable code, _ ->
-    let+ tout =
-      let* unfolded = lift_cmp @@ unfold_el code in
-      let* out = lift_cmp @@ do_el_out con in
-      quote_con unfolded out
-    in
-    S.ElIn tout
+    let* unfolded = lift_cmp @@ unfold_el code in
+    quote_con unfolded con
 
   | _, D.Zero ->
     ret S.Zero
@@ -160,10 +156,9 @@ let rec quote_con (tp : D.tp) con =
       Splice.con bdy @@ fun bdy ->
       Splice.term @@
       TB.lam @@ fun i -> TB.lam @@ fun prf ->
-      TB.el_in @@ TB.ap bdy [i; prf]
+      TB.ap bdy [i; prf]
     in
-    let+ tm = quote_hcom (D.StableCode `Nat) r s phi bdy' in
-    S.ElOut tm
+    quote_hcom (D.StableCode `Nat) r s phi bdy'
 
   | _univ, D.UnstableCode (`V (r, pcode, code, pequiv)) ->
     let+ tr, t_pcode, tcode, t_pequiv = quote_v_data r pcode code pequiv in
@@ -176,10 +171,9 @@ let rec quote_con (tp : D.tp) con =
       Splice.con bdy @@ fun bdy ->
       Splice.term @@
       TB.lam @@ fun i -> TB.lam @@ fun prf ->
-      TB.el_in @@ TB.ap bdy [i; prf]
+      TB.ap bdy [i; prf]
     in
-    let+ tm = quote_hcom (D.StableCode `Univ) r s phi bdy' in
-    S.ElOut tm
+    quote_hcom (D.StableCode `Univ) r s phi bdy'
 
   | D.Circle, D.FHCom (`Circle, r, s, phi, bdy) ->
     let* bdy' =
@@ -187,10 +181,9 @@ let rec quote_con (tp : D.tp) con =
       Splice.con bdy @@ fun bdy ->
       Splice.term @@
       TB.lam @@ fun i -> TB.lam @@ fun prf ->
-      TB.el_in @@ TB.ap bdy [i; prf]
+      TB.ap bdy [i; prf]
     in
-    let+ tm = quote_hcom (D.StableCode `Circle) r s phi bdy' in
-    S.ElOut tm
+    quote_hcom (D.StableCode `Circle) r s phi bdy'
 
   | D.ElUnstable (`HCom (r,s,phi,bdy)), _ ->
     let+ tr = quote_dim r
@@ -650,5 +643,3 @@ and quote_frm tm =
   | D.KAp (tp, con) ->
     let+ targ = quote_con tp con in
     S.Ap (tm, targ)
-  | D.KElOut ->
-    ret @@ S.ElOut tm

--- a/src/core/Semantics.mli
+++ b/src/core/Semantics.mli
@@ -31,7 +31,6 @@ val do_fst : D.con -> D.con compute
 val do_snd : D.con -> D.con compute
 val do_proj : D.con -> Ident.user -> D.con compute
 val do_sub_out : D.con -> D.con compute
-val do_el_out : D.con -> D.con compute
 val unfold_el : D.con D.stable_code -> D.tp compute
 val do_el : D.con -> D.tp compute
 val do_spine : D.con -> D.frm list -> D.con compute

--- a/src/core/Serialize.ml
+++ b/src/core/Serialize.ml
@@ -137,8 +137,6 @@ struct
     | S.ForallCof cof -> labeled "forall" [json_of_tm cof]
     | S.CofSplit branches -> labeled "split" @@ List.map (fun (tphi, tm) -> json_of_pair (json_of_tm tphi) (json_of_tm tm)) branches
     | S.Prf -> `String "prf"
-    | S.ElIn tm -> labeled "el_in" [json_of_tm tm]
-    | S.ElOut tm -> labeled "el_out" [json_of_tm tm]
     | S.Box (r, s, phi, sides, cap) -> labeled "box" [json_of_tm r; json_of_tm s; json_of_tm phi; json_of_tm sides; json_of_tm cap]
     | S.Cap (r, s, phi, code, box) -> labeled "cap" [json_of_tm r; json_of_tm s; json_of_tm phi; json_of_tm code; json_of_tm box]
     | S.VIn (r, pequiv, pivot, base) -> labeled "v_in" [json_of_tm r; json_of_tm pequiv; json_of_tm pivot; json_of_tm base]
@@ -285,12 +283,6 @@ struct
       let branches = List.map (json_to_pair json_to_tm json_to_tm) j_branches in
       S.CofSplit branches
     | `String "prf" -> S.Prf
-    | `A [`String "el_in"; j_tm] ->
-      let tm = json_to_tm j_tm in
-      S.ElIn tm
-    | `A [`String "el_out"; j_tm] ->
-      let tm = json_to_tm j_tm in
-      S.ElOut tm
     | `A [`String "box"; j_r; j_s; j_phi; j_sides; j_cap] ->
       let r = json_to_tm j_r in
       let s = json_to_tm j_s in
@@ -445,7 +437,6 @@ struct
     | Pair (con0, con1) -> labeled "pair" [json_of_con con0; json_of_con con1]
     | Struct fields -> labeled "struct" [json_of_labeled json_of_con fields]
     | SubIn con -> labeled "sub_in" [json_of_con con]
-    | ElIn con -> labeled "el_in" [json_of_con con]
     | Dim0 -> `String "dim0"
     | Dim1 -> `String "dim1"
     | DimProbe dim_probe -> labeled "dim_probe" [DimProbe.serialize dim_probe]
@@ -522,7 +513,6 @@ struct
     | D.KProj lbl -> labeled "k_proj" [json_of_user lbl]
     | D.KNatElim (mot, z, s) -> labeled "k_nat_elim" [json_of_con mot; json_of_con z; json_of_con s]
     | D.KCircleElim (mot, b, l) -> labeled "k_circle_elim" [json_of_con mot; json_of_con b; json_of_con l]
-    | D.KElOut -> `String "k_el_out"
 
   and json_of_unstable_frm : D.unstable_frm -> J.value =
     function
@@ -568,7 +558,6 @@ struct
     | `A [`String "pair"; j_con0; j_con1] -> Pair (json_to_con j_con0, json_to_con j_con1)
     | `A [`String "struct"; j_fields] -> Struct (json_to_labeled json_to_con j_fields)
     | `A [`String "sub_in"; j_con] -> SubIn (json_to_con j_con)
-    | `A [`String "el_in"; j_con] -> ElIn (json_to_con j_con)
     | `String "dim0" -> Dim0
     | `String "dim1" -> Dim1
     | `A [`String "dim_probe"; j_dim_probe] -> DimProbe (DimProbe.deserialize j_dim_probe)
@@ -656,7 +645,6 @@ struct
     | `A [`String "k_proj"; j_lbl] -> KProj (json_to_user j_lbl)
     | `A [`String "k_nat_elim"; j_mot; j_z; j_s] -> KNatElim (json_to_con j_mot, json_to_con j_z, json_to_con j_s)
     | `A [`String "k_circle_elim"; j_mot; j_b; j_l] -> KCircleElim (json_to_con j_mot, json_to_con j_b, json_to_con j_l)
-    | `String "k-el_out" -> KElOut
     | j -> J.parse_error j "Domain.json_to_frm"
 
   and json_to_unstable_frm : J.value -> D.unstable_frm =

--- a/src/core/Syntax.ml
+++ b/src/core/Syntax.ml
@@ -58,9 +58,6 @@ struct
     | CofSplit branches -> Format.fprintf fmt "cof/split[%a]" (Pp.pp_sep_list dump_branch) branches
     | Prf -> Format.fprintf fmt "prf"
 
-    | ElIn tm -> Format.fprintf fmt "el/in[%a]" dump tm
-    | ElOut tm -> Format.fprintf fmt "el/out[%a]" dump tm
-
     | Box _ -> Format.fprintf fmt "<box>"
     | Cap _ -> Format.fprintf fmt "<cap>"
 
@@ -160,7 +157,7 @@ struct
       | NatElim _ | Loop _
       | CircleElim _ -> juxtaposition
 
-      | SubIn _ | SubOut _ | ElIn _ | ElOut _ -> passed
+      | SubIn _ | SubOut _ -> passed
       | CodePi _ -> arrow
       | CodeSg _ -> times
       | CodeSignature _ -> juxtaposition
@@ -330,11 +327,7 @@ struct
       Format.fprintf fmt "sub/in %a" (pp_atomic env) tm
     | SubOut tm when Debug.is_debug_mode () ->
       Format.fprintf fmt "sub/out %a" (pp_atomic env) tm
-    | ElIn tm when Debug.is_debug_mode () ->
-      Format.fprintf fmt "el/in %a" (pp_atomic env) tm
-    | ElOut tm when Debug.is_debug_mode () ->
-      Format.fprintf fmt "el/out %a" (pp_atomic env) tm
-    | SubIn tm | SubOut tm | ElIn tm | ElOut tm ->
+    | SubIn tm | SubOut tm ->
       pp env penv fmt tm
 
     | CodePi (base, fam) when Debug.is_debug_mode () ->
@@ -566,7 +559,7 @@ struct
       Format.fprintf fmt "%a %a"
         Uuseg_string.pp_utf_8 x
         (pp_lambdas envx) tm
-    | (SubIn tm | SubOut tm | ElIn tm | ElOut tm) when not @@ Debug.is_debug_mode () ->
+    | (SubIn tm | SubOut tm) when not @@ Debug.is_debug_mode () ->
       pp_lambdas env fmt tm
     | _ ->
       Format.fprintf fmt "=>@ @[%a@]"

--- a/src/core/SyntaxData.ml
+++ b/src/core/SyntaxData.ml
@@ -42,9 +42,6 @@ struct
     | CofSplit of (t * t) list
     | Prf
 
-    | ElIn of t
-    | ElOut of t
-
     | Box of t * t * t * t * t
     | Cap of t * t * t * t * t
 

--- a/src/core/TermBuilder.mli
+++ b/src/core/TermBuilder.mli
@@ -50,9 +50,6 @@ val tm_abort : t m
 val sub_out : t m -> t m
 val sub_in : t m -> t m
 
-val el_in : t m -> t m
-val el_out : t m -> t m
-
 val univ : tp m
 val nat : tp m
 val code_nat : t m


### PR DESCRIPTION
This PR does away with `ElIn` and `ElOut`, and makes `ElStable code` definitionally equal to `unfold_el code`, and closes #189.

I initially tried removing `ElStable` entirely, but found that this solution was the simplest, as there are several places where we rely on something being a code.

The main complication this introduces is that pattern matching on a type requires _also_ matching on its code, because they're now equal. The only place we don't have to do this is when matching on the goal in a tactic, because we have still have `intro_implicit_connectives` and `elim_implicit_connectives`, which now unfold an `ElStable` but do not add `ElIn` or `ElOut`. Perhaps `ElStable` should no longer be an "implicit connective" and we should instead be pattern matching on codes in tactics as a matter of consistency?

Having multiple representations of definitionally equal types in the core theory initially felt awkward to me, but @TOTBWF pointed out to me that this is sort of like an eta law for the universe. The main difference is that we're not usually pattern matching on "a variable at function type or a lambda" but we match on types pretty regularly.

This is a non-trivial change to cooltt, so please let me know if this implementation is a Bad Idea and needs to be reworked.