### PR TITLE
🧟 0️⃣ 1️⃣ Resurrect Virtual Type Globals/Axioms

### DIFF
--- a/emacs/cooltt.el
+++ b/emacs/cooltt.el
@@ -124,7 +124,7 @@
   "Syntax table for cooltt.")
 
 (defconst cooltt-declaration-keywords
-  '("def" "let" "import" "section" "view" "export" "repack")
+  '("def" "axiom" "let" "import" "section" "view" "export" "repack")
   "Declaration keywords.")
 
 (defconst cooltt-command-keywords

--- a/src/core/CodeUnit.ml
+++ b/src/core/CodeUnit.ml
@@ -49,6 +49,9 @@ end
 
 module Domain = Domain.Make (Global)
 module Syntax = Syntax.Make (Global)
+module CofVar = CofVar.Make (Global)
+module CofBuilder = CofBuilder.Make (Global)
+module CofThy = CofThy.Make (Global)
 
 module CodeUnit =
 struct

--- a/src/core/CodeUnit.ml
+++ b/src/core/CodeUnit.ml
@@ -50,6 +50,7 @@ end
 module Domain = Domain.Make (Global)
 module Syntax = Syntax.Make (Global)
 module CofVar = CofVar.Make (Global)
+module Dim = Dim.Make (Global)
 module CofBuilder = CofBuilder.Make (Global)
 module CofThy = CofThy.Make (Global)
 

--- a/src/core/CodeUnit.mli
+++ b/src/core/CodeUnit.mli
@@ -20,6 +20,7 @@ end
 module Domain : module type of Domain.Make(Global)
 module Syntax : module type of Syntax.Make(Global)
 module CofVar : module type of CofVar.Make(Global)
+module Dim : module type of Dim.Make(Global)
 module CofBuilder : module type of CofBuilder.Make(Global)
 module CofThy : module type of CofThy.Make(Global)
 

--- a/src/core/CodeUnit.mli
+++ b/src/core/CodeUnit.mli
@@ -19,6 +19,9 @@ end
 
 module Domain : module type of Domain.Make(Global)
 module Syntax : module type of Syntax.Make(Global)
+module CofVar : module type of CofVar.Make(Global)
+module CofBuilder : module type of CofBuilder.Make(Global)
+module CofThy : module type of CofThy.Make(Global)
 
 module CodeUnit : sig
 

--- a/src/core/CofBuilder.ml
+++ b/src/core/CofBuilder.ml
@@ -3,6 +3,7 @@ open Basis
 module Make (Symbol : Symbol.S) =
 struct
   module CofVar = CofVar.Make(Symbol)
+  module Dim = Dim.Make(Symbol)
 
   include Kado.Builder.Free.Make
       (struct

--- a/src/core/CofBuilder.ml
+++ b/src/core/CofBuilder.ml
@@ -1,8 +1,15 @@
-include Kado.Builder.Free.Make
-    (struct
-      type dim = Dim.t
-      type var = int
-      let dim0 = Dim.dim0
-      let dim1 = Dim.dim1
-      let equal_dim = Dim.equal
-    end)
+open Basis
+
+module Make (Symbol : Symbol.S) =
+struct
+  module CofVar = CofVar.Make(Symbol)
+
+  include Kado.Builder.Free.Make
+      (struct
+        type dim = Dim.t
+        type var = CofVar.t
+        let dim0 = Dim.dim0
+        let dim1 = Dim.dim1
+        let equal_dim = Dim.equal
+      end)
+end

--- a/src/core/CofThy.ml
+++ b/src/core/CofThy.ml
@@ -3,6 +3,8 @@ open Basis
 module Make (Symbol : Symbol.S) =
 struct
   module CofVar = CofVar.Make(Symbol)
+  module Dim = Dim.Make(Symbol)
+
   include Kado.Theory.Make
       (struct
         type dim = Dim.t

--- a/src/core/CofThy.ml
+++ b/src/core/CofThy.ml
@@ -1,9 +1,15 @@
-include Kado.Theory.Make
-    (struct
-      type dim = Dim.t
-      type var = int
-      let dim0 = Dim.dim0
-      let dim1 = Dim.dim1
-      let compare_dim = Dim.compare
-      let compare_var = Int.compare
-    end)
+open Basis
+
+module Make (Symbol : Symbol.S) =
+struct
+  module CofVar = CofVar.Make(Symbol)
+  include Kado.Theory.Make
+      (struct
+        type dim = Dim.t
+        type var = CofVar.t
+        let dim0 = Dim.dim0
+        let dim1 = Dim.dim1
+        let compare_dim = Dim.compare
+        let compare_var = CofVar.compare
+      end)
+end

--- a/src/core/CofVar.ml
+++ b/src/core/CofVar.ml
@@ -1,0 +1,21 @@
+open Basis
+
+module Make (Symbol : Symbol.S) =
+struct
+
+  type t =
+    | Local of int
+    | Axiom of Symbol.t
+
+  let compare v0 v1 =
+    match v0, v1 with
+    | Local lvl0, Local lvl1 -> Int.compare lvl0 lvl1
+    | Axiom sym0, Axiom sym1 -> Symbol.compare sym0 sym1
+    | Local _, Axiom _ -> -1
+    | Axiom _, Local _ -> 1
+
+  let dump fmt =
+    function
+    | Local lvl -> Format.pp_print_int fmt lvl
+    | Axiom sym -> Symbol.pp fmt sym
+end

--- a/src/core/CofVar.mli
+++ b/src/core/CofVar.mli
@@ -1,0 +1,10 @@
+open Basis
+
+module Make : functor (Symbol : Symbol.S) -> sig
+  type t =
+    | Local of int
+    | Axiom of Symbol.t
+
+  val compare : t -> t -> int
+  val dump : Format.formatter -> t -> unit
+end

--- a/src/core/Dim.ml
+++ b/src/core/Dim.ml
@@ -1,18 +1,26 @@
-type t =
-  | Dim0
-  | Dim1
-  | DimVar of int
-  | DimProbe of DimProbe.t
+open Basis
 
-let equal : t -> t -> bool = (=)
-let compare : t -> t -> int = compare
+module Make (Symbol : Symbol.S) =
+struct
+  module CofVar = CofVar.Make (Symbol)
+  type t =
+    | Dim0
+    | Dim1
+    | DimVar of CofVar.t
+    | DimProbe of DimProbe.t
 
-let dim0 = Dim0
-let dim1 = Dim1
+  let equal : t -> t -> bool = (=)
+  let compare : t -> t -> int = compare
 
-let dump fmt =
-  function
-  | Dim0 -> Format.fprintf fmt "dim0"
-  | Dim1 -> Format.fprintf fmt "dim1"
-  | DimVar i -> Format.fprintf fmt "dim#var[%i]" i
-  | DimProbe sym -> Format.fprintf fmt "dim#probe[%a]" DimProbe.pp sym
+  let dim0 = Dim0
+  let dim1 = Dim1
+  let var lvl = DimVar (CofVar.Local lvl)
+  let axiom sym = DimVar (CofVar.Axiom sym)
+
+  let dump fmt =
+    function
+    | Dim0 -> Format.fprintf fmt "dim0"
+    | Dim1 -> Format.fprintf fmt "dim1"
+    | DimVar v -> Format.fprintf fmt "dim#var[%a]" CofVar.dump v
+    | DimProbe sym -> Format.fprintf fmt "dim#probe[%a]" DimProbe.pp sym
+end

--- a/src/core/Dim.mli
+++ b/src/core/Dim.mli
@@ -1,22 +1,27 @@
 open Basis
 
-type t =
-  | Dim0
-  (** The left endpoint of the abstract interval. *)
+module Make : functor (Symbol : Symbol.S) -> sig
+  module CofVar := CofVar.Make(Symbol)
+  type t =
+    | Dim0
+    (** The left endpoint of the abstract interval. *)
 
-  | Dim1
-  (** The right endpoint of the abstract interval. *)
+    | Dim1
+    (** The right endpoint of the abstract interval. *)
 
-  | DimVar of int
-  (** In [cooltt], most dimension variables are represented as natural numbers (pointers into the context). *)
+    | DimVar of CofVar.t
+    (** In [cooltt], most dimension variables are represented as natural numbers (pointers into the context). *)
 
-  | DimProbe of DimProbe.t
-  (** Some dimension variables must be generated to probe underneath a binder. Subject to substitution. *)
+    | DimProbe of DimProbe.t
+    (** Some dimension variables must be generated to probe underneath a binder. Subject to substitution. *)
 
-val dim0 : t
-val dim1 : t
+  val dim0 : t
+  val dim1 : t
+  val var : int -> t
+  val axiom : Symbol.t -> t
 
-val equal : t -> t -> bool
-val compare : t -> t -> int
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
 
-val dump : t Pp.printer
+  val dump : t Pp.printer
+end

--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -47,8 +47,10 @@ struct
     function
     | Dim.Dim0 -> Dim0
     | Dim.Dim1 -> Dim1
-    | Dim.DimVar lvl ->
+    | Dim.DimVar (CofVar.Local lvl) ->
       Cut {tp = TpDim; cut = Var lvl, []}
+    | Dim.DimVar (CofVar.Axiom sym) ->
+      Cut {tp = TpDim; cut = Global sym, []}
     | Dim.DimProbe sym ->
       DimProbe sym
 

--- a/src/core/Domain.ml
+++ b/src/core/Domain.ml
@@ -58,7 +58,8 @@ struct
     | K.Cof (S.Cof.Eq (r, s)) -> Cof (K.Eq (dim_to_con r, dim_to_con s))
     | K.Cof (S.Cof.Join phis) -> Cof (K.Join (List.map cof_to_con phis))
     | K.Cof (S.Cof.Meet phis) -> Cof (K.Meet (List.map cof_to_con phis))
-    | K.Var lvl -> Cut {tp = TpCof; cut = Var lvl, []}
+    | K.Var (CofVar.Local lvl) -> Cut {tp = TpCof; cut = Var lvl, []}
+    | K.Var (CofVar.Axiom sym) -> Cut {tp = TpCof; cut = Global sym, []}
 
   let pp_lsq fmt () = Format.fprintf fmt "["
   let pp_rsq fmt () = Format.fprintf fmt "]"

--- a/src/core/DomainData.ml
+++ b/src/core/DomainData.ml
@@ -5,6 +5,7 @@ module Make (Symbol : Symbol.S) =
 struct
   module S = Syntax.Make(Symbol)
   module CofVar = CofVar.Make(Symbol)
+  module Dim = Dim.Make(Symbol)
   module Cof = CofBuilder.Make(Symbol)
 
   type dim = Dim.t

--- a/src/core/DomainData.ml
+++ b/src/core/DomainData.ml
@@ -4,9 +4,12 @@ open Bwd
 module Make (Symbol : Symbol.S) =
 struct
   module S = Syntax.Make(Symbol)
+  module CofVar = CofVar.Make(Symbol)
+  module Cof = CofBuilder.Make(Symbol)
 
   type dim = Dim.t
-  type cof = CofBuilder.cof
+  type cof_var = CofVar.t
+  type cof = Cof.cof
 
   (** A type code whose head constructor is stable under dimension substitution. *)
   type 'a stable_code =

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -70,10 +70,10 @@ let rec quote_con (tp : D.tp) con =
     (* for dimension variables, check to see if we can prove them to be
         the same as 0 or 1 and return those instead if so. *)
     begin
-      lift_cmp @@ CmpM.test_sequent [] @@ CofBuilder.eq0 (Dim.DimVar lvl) |>> function
+      lift_cmp @@ CmpM.test_sequent [] @@ CofBuilder.eq0 (Dim.var lvl) |>> function
       | true -> ret S.Dim0
       | false ->
-        lift_cmp @@ CmpM.test_sequent [] @@ CofBuilder.eq1 (Dim.DimVar lvl) |>> function
+        lift_cmp @@ CmpM.test_sequent [] @@ CofBuilder.eq1 (Dim.var lvl) |>> function
         | true -> ret S.Dim1
         | false ->
           let+ ix = quote_var lvl in

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -565,9 +565,11 @@ and quote_cof phi =
   let module K = Kado.Syntax in
   let rec go =
     function
-    | K.Var lvl ->
+    | K.Var (CofVar.Local lvl) ->
       let+ ix = quote_var lvl in
       S.Var ix
+    | K.Var (CofVar.Axiom sym) ->
+      ret @@ S.Global sym
     | K.Cof phi ->
       match phi with
       | K.Eq (r, s) ->

--- a/src/core/Semantics.ml
+++ b/src/core/Semantics.ml
@@ -64,7 +64,8 @@ and con_to_cof =
     whnf_inspect_con ~style:`UnfoldAll con |>>
     function
     | D.Cof cof -> cof_con_to_cof cof
-    | D.Cut {cut = D.Var l, []; _} -> ret @@ CofBuilder.var l
+    | D.Cut {cut = D.Var l, []; _} -> ret @@ CofBuilder.var (CofVar.Local l)
+    | D.Cut {cut = D.Global sym, []; _} -> ret @@ CofBuilder.var (CofVar.Axiom sym)
     | _ -> throw @@ NbeFailed "con_to_cof"
 
 and con_to_dim =

--- a/src/core/Semantics.ml
+++ b/src/core/Semantics.ml
@@ -76,7 +76,8 @@ and con_to_dim =
     | D.Dim0 -> ret Dim.Dim0
     | D.Dim1 -> ret Dim.Dim1
     | D.DimProbe x -> ret @@ Dim.DimProbe x
-    | D.Cut {cut = Var l, []; _} -> ret @@ Dim.DimVar l
+    | D.Cut {cut = D.Var l, []; _} -> ret @@ Dim.DimVar (CofVar.Local l)
+    | D.Cut {cut = D.Global sym, []; _} -> ret @@ Dim.DimVar (CofVar.Axiom sym)
     | con ->
       Format.eprintf "bad: %a@." D.pp_con con;
       throw @@ NbeFailed "con_to_dim"

--- a/src/core/Serialize.ml
+++ b/src/core/Serialize.ml
@@ -485,7 +485,7 @@ struct
     function
     | Dim0 -> `String "dim0"
     | Dim1 -> `String "dim1"
-    | DimVar n -> labeled "dim_var" [json_of_int n]
+    | DimVar n -> labeled "dim_var" [json_of_cof_var n]
     | DimProbe dim_probe -> labeled "dim_probe" [DimProbe.serialize dim_probe]
 
   and json_of_tp : D.tp -> J.value =
@@ -622,7 +622,7 @@ struct
     function
     | `String "dim0" -> Dim0
     | `String "dim1" -> Dim1
-    | `A [`String "dim_var"; j_n] -> DimVar (json_to_int j_n)
+    | `A [`String "dim_var"; j_n] -> DimVar (json_to_cof_var j_n)
     | `A [`String "dim_probe"; j_dim_probe] -> DimProbe (DimProbe.deserialize j_dim_probe)
     | j -> J.parse_error j "Domain.json_to_dim"
 

--- a/src/core/Serialize.ml
+++ b/src/core/Serialize.ml
@@ -1,4 +1,3 @@
-open Basis
 open Bwd
 open CodeUnit
 
@@ -474,8 +473,13 @@ struct
   and json_of_env {tpenv; conenv} : J.value =
     `O [("tpenv", json_of_bwd json_of_tp tpenv); ("conenv", json_of_bwd json_of_con conenv)]
 
+  and json_of_cof_var : D.cof_var -> J.value  = 
+    function
+    | CofVar.Local lvl -> labeled "local" [json_of_int lvl]
+    | CofVar.Axiom sym -> labeled "axiom" [Global.serialize sym]
+
   and json_of_cof (cof : D.cof) : J.value =
-    Cof.json_of_cof json_of_dim json_of_int cof
+    Cof.json_of_cof json_of_dim json_of_cof_var cof
 
   and json_of_dim : D.dim -> J.value =
     function
@@ -604,8 +608,15 @@ struct
       { tpenv = json_to_bwd json_to_tp j_tpenv; conenv = json_to_bwd json_to_con j_conenv }
     | j -> J.parse_error j "Domain.json_to_env"
 
+  and json_to_cof_var : J.value -> D.cof_var =
+    function
+    | `A [`String "local"; j_lvl] -> CofVar.Local (json_to_int j_lvl)
+    | `A [`String "axiom"; j_sym] -> CofVar.Axiom (Global.deserialize j_sym)
+    | j -> J.parse_error j "Domain.json_to_cof_var"
+
+
   and json_to_cof : J.value -> D.cof =
-    fun j_cof -> Cof.json_to_cof json_to_dim json_to_int j_cof
+    fun j_cof -> Cof.json_to_cof json_to_dim json_to_cof_var j_cof
 
   and json_to_dim : J.value -> D.dim =
     function

--- a/src/core/Syntax.ml
+++ b/src/core/Syntax.ml
@@ -1,4 +1,3 @@
-open Kado
 open Basis
 
 module Make (Symbol : Symbol.S) =

--- a/src/frontend/Driver.ml
+++ b/src/frontend/Driver.ml
@@ -23,7 +23,7 @@ type command = continuation RM.m
 (* Refinement Helpers *)
 
 let elaborate_typed_term _name (args : CS.cell list) tp tm =
-  let* tp = Tactic.Tp.run @@ Elaborator.chk_tp_in_tele args tp in
+  let* tp = Tactic.Tp.run_virtual @@ Elaborator.chk_tp_in_tele args tp in
   let* vtp = RM.lift_ev @@ Sem.eval_tp tp in
   let* tm = Tactic.Chk.run (Elaborator.chk_tm_in_tele args tm) vtp in
   let+ vtm = RM.lift_ev @@ Sem.eval tm in
@@ -166,7 +166,7 @@ and execute_decl (decl : CS.decl) : command =
     Continue
   | CS.Def {shadowing; name; args; def = None; tp} ->
     Debug.print "Defining Axiom %a@." Ident.pp name;
-    let* tp = Tactic.Tp.run @@ Elaborator.chk_tp_in_tele args tp in
+    let* tp = Tactic.Tp.run_virtual @@ Elaborator.chk_tp_in_tele args tp in
     let* vtp = RM.lift_ev @@ Sem.eval_tp tp in
     let* _ = RM.add_global ~shadowing name vtp None in
     RM.ret Continue

--- a/test/axiom.cooltt
+++ b/test/axiom.cooltt
@@ -1,0 +1,32 @@
+axiom φ/path : 𝔽
+axiom u/path : locked φ/path
+axiom path (A : type) (x : A) (y : A)
+  : sub type φ/path {ext i => A with [i=0 => x | i=1 => y]}
+
+#normalize path
+
+def test : path nat 3 3 :=
+  unlock u/path in
+  i => 3
+
+#normalize test
+
+def test2 : unlock u/path in path {path nat 3 3} test {_ => 3} :=
+  unlock u/path in
+  _ _ => 3
+
+#print test2
+
+
+axiom foo : 𝕀
+
+def test3 : sub nat {foo=0} 34 :=
+  34
+
+def i0 : 𝕀 := 0
+def i1 : 𝕀 := 1
+
+axiom test-globals/path : ext i => nat with [i=0 => 1 | i=1 => 2]
+
+#normalize test-globals/path i0
+#normalize test-globals/path i1

--- a/test/axiom.cooltt
+++ b/test/axiom.cooltt
@@ -30,3 +30,10 @@ axiom test-globals/path : ext i => nat with [i=0 => 1 | i=1 => 2]
 
 #normalize test-globals/path i0
 #normalize test-globals/path i1
+
+axiom ψ/i : 𝕀
+axiom ψ/j : 𝕀
+
+axiom ψ/proof : locked {ψ/i = ψ/j}
+
+#print ψ/proof

--- a/test/axiom.cooltt
+++ b/test/axiom.cooltt
@@ -34,6 +34,14 @@ axiom test-globals/path : ext i => nat with [i=0 => 1 | i=1 => 2]
 axiom ψ/i : 𝕀
 axiom ψ/j : 𝕀
 
-axiom ψ/proof : locked {ψ/i = ψ/j}
+def ψ : 𝔽 := {ψ/i = ψ/j}
+axiom ψ/proof : locked ψ
 
 #print ψ/proof
+
+axiom ψ/single (A : type) (x : A) : sub type ψ {ext => A with [⊤ => x]}
+
+def ψ/test : unlock ψ/proof in ψ/single nat 4 :=
+  unlock ψ/proof in 4
+
+#print ψ/test

--- a/test/test.expected
+++ b/test/test.expected
@@ -1,3 +1,27 @@
+--------------------[axiom.cooltt]--------------------
+axiom.cooltt:6.11-6.15 [Info]:
+  Computed normal form of path as path
+
+axiom.cooltt:12.11-12.15 [Info]:
+  Computed normal form of test as unlock u/path : φ/path in _x i => 3
+
+axiom.cooltt:18.7-18.12 [Info]:
+  test2
+  : unlock u/path : φ/path in
+    _x =>
+    ext {i =>
+         ext {i₁ => nat} {i => i = 0 ∨ i = 1} {i₁ _x₁ =>
+                                               [ i₁ = 0 => 3 | i₁ = 1 => 3 ]}} {
+    i => i = 0 ∨ i = 1} {i _x₁ =>
+                         [ i = 0 => _x₃ => test _x₃ | i = 1 => _x₃ => 3 ]}
+  = unlock u/path : φ/path in _x _x₁ _x₂ => 3
+
+axiom.cooltt:31.11-31.31 [Info]:
+  Computed normal form of test-globals/path i0 as 1
+
+axiom.cooltt:32.11-32.31 [Info]:
+  Computed normal form of test-globals/path i1 as 2
+
 --------------------[base-types.cooltt]--------------------
 --------------------[circle.cooltt]--------------------
 circle.cooltt:20.11-20.21 [Info]:

--- a/test/test.expected
+++ b/test/test.expected
@@ -22,6 +22,14 @@ axiom.cooltt:31.11-31.31 [Info]:
 axiom.cooltt:32.11-32.31 [Info]:
   Computed normal form of test-globals/path i1 as 2
 
+axiom.cooltt:40.7-40.15 [Info]:
+  ψ/proof : locked {ψ/i = ψ/j}
+
+axiom.cooltt:47.7-47.14 [Info]:
+  ψ/test
+  : unlock ψ/proof : ψ/i = ψ/j in _x => ext nat ⊤ {_x₁ => 4}
+  = unlock ψ/proof : ψ/i = ψ/j in _x => 4
+
 --------------------[base-types.cooltt]--------------------
 --------------------[circle.cooltt]--------------------
 circle.cooltt:20.11-20.21 [Info]:


### PR DESCRIPTION
## Patch Description

This PR brings back axioms/globals for virtual types, which were removed during the implementation of imports (see #190).
This was pretty mechanical luckily, and wasn't too difficult.