### PR TITLE
🙈 Implicit Cofibration Proofs

### DIFF
--- a/src/basis/Pp.ml
+++ b/src/basis/Pp.ml
@@ -42,6 +42,9 @@ struct
     in
     x, env #< x
 
+  let bind_underscore (env : t) : string * t =
+    "_", env #< "_"
+
   let rec bindn (env : t) (nms : string option list) : string list * t =
     match nms with
     | [] ->

--- a/src/basis/Pp.mli
+++ b/src/basis/Pp.mli
@@ -7,6 +7,7 @@ sig
   val var : int -> t -> string
   val bind : t -> string option -> string * t
   val bindn : t -> string option list -> string list * t
+  val bind_underscore : t -> string * t
 
   val proj : t -> t
   val names : t -> string list

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -51,6 +51,8 @@ let rec quote_con (tp : D.tp) con =
     if norm then contractum_or con <@> lift_cmp @@ Sem.whnf_con con else QuM.ret con
   in
   match tp, con with
+  | D.TpPrf _, _ ->
+    ret S.Prf
   | _, D.Split branches ->
     let quote_branch (phi, clo) =
       lift_cmp @@ CmpM.test_sequent [phi] CofBuilder.bot |>> function
@@ -147,9 +149,6 @@ let rec quote_con (tp : D.tp) con =
   | D.TpCof, D.Cof cof ->
     let* cof = lift_cmp @@ cof_con_to_cof cof in
     quote_cof cof
-
-  | D.TpPrf _, _ ->
-    ret S.Prf
 
   | univ, D.StableCode code ->
     quote_stable_code univ code

--- a/src/core/Syntax.ml
+++ b/src/core/Syntax.ml
@@ -490,7 +490,11 @@ struct
         fmt
         branches
     | Pi (base, ident, fam) ->
-      let x, envx = ppenv_bind env ident in
+      let x, envx =
+        match base with
+        | TpPrf _ -> Pp.Env.bind_underscore env
+        | _ -> ppenv_bind env ident
+      in
       Format.fprintf fmt "(%a : %a) %a %a"
         Uuseg_string.pp_utf_8 x
         (pp_tp env P.(right_of colon)) base
@@ -590,7 +594,11 @@ struct
     match ctx with
     | [] -> pp_goal env fmt goal
     | (var, var_tp) :: ctx ->
-      let x, envx = ppenv_bind env var in
+      let x, envx =
+        match var_tp with
+        | TpPrf _ -> Pp.Env.bind_underscore env
+        | _ -> ppenv_bind env var
+      in
       Fmt.fprintf fmt "%a : %a@;%a"
         Uuseg_string.pp_utf_8 x
         (pp_tp env P.(right_of colon)) var_tp
@@ -607,7 +615,7 @@ struct
     let lbl = Option.value ~default:"" lbl in
     match get_constraints tp with
     | `Boundary (tp, phi, tm) ->
-      let _x, envx = Pp.Env.bind env (Some "_") in
+      let _x, envx = Pp.Env.bind_underscore env in
       Format.fprintf fmt "|- ?%a : @[<hov>%a@]@,@,Boundary:@,%a@,|- @[<v>%a@]"
         Uuseg_string.pp_utf_8 lbl
         (pp_tp env P.(right_of colon)) tp
@@ -633,7 +641,7 @@ struct
   let pp_partial_sequent_goal bdry_sat env fmt (partial, tp) =
     match get_constraints tp with
     | `Boundary (tp, phi, tm) ->
-      let _x, envx = Pp.Env.bind env (Some "_") in
+      let _x, envx = Pp.Env.bind_underscore env in
       Format.fprintf fmt "|- {! %a !} : @[<hov>%a@]@,@,Boundary (%a):@,%a@,|- @[<v>%a@]"
         (pp env P.(right_of colon)) partial
         (pp_tp env P.(right_of colon)) tp

--- a/src/frontend/Elaborator.ml
+++ b/src/frontend/Elaborator.ml
@@ -145,7 +145,7 @@ let rec cool_chk_tp : CS.con -> CoolTp.tac =
     let n = List.length idents in
     let tac_fam = chk_tm @@ CS.{node = CS.Lam (idents, tp); info = tp.info} in
     let tac_cof = chk_tm @@ CS.{node = CS.Lam (idents, {node = CS.Join (List.map fst cases); info = None}); info = None} in
-    let tac_bdry = chk_tm @@ CS.{node = CS.Lam (idents @ [Ident.anon], {node = CS.CofSplit cases; info = None}); info = None} in
+    let tac_bdry = chk_tm @@ CS.{node = CS.Lam (idents, {node = CS.CofSplit cases; info = None}); info = None} in
     CoolTp.ext n tac_fam tac_cof tac_bdry
   | _ -> CoolTp.code @@ chk_tm con
 
@@ -314,7 +314,7 @@ and chk_tm : CS.con -> T.Chk.tac =
       let n = List.length idents in
       let tac_fam = chk_tm @@ CS.{node = CS.Lam (idents, tp); info = tp.info} in
       let tac_cof = chk_tm @@ CS.{node = CS.Lam (idents, {node = CS.Join (List.map fst cases); info = None}); info = None} in
-      let tac_bdry = chk_tm @@ CS.{node = CS.Lam (idents @ [Ident.anon], {node = CS.CofSplit cases; info = None}); info = None} in
+      let tac_bdry = chk_tm @@ CS.{node = CS.Lam (idents, {node = CS.CofSplit cases; info = None}); info = None} in
       R.Univ.ext n tac_fam tac_cof tac_bdry
 
 

--- a/src/frontend/Tactics.ml
+++ b/src/frontend/Tactics.ml
@@ -55,6 +55,7 @@ let rec elim_implicit_connectives : T.Syn.tac -> T.Syn.tac =
   (* The above code only makes sense because I know that the argument to Sub.elim will not be called under a further binder *)
   | D.ElStable _ ->
     T.Syn.run @@ elim_implicit_connectives @@ R.El.elim @@ T.Syn.rule @@ RM.ret (tm, tp)
+  | D.Pi (TpPrf _,_,_) -> T.Syn.run @@ elim_implicit_connectives @@ R.Pi.apply (T.Syn.rule @@ RM.ret (tm, tp)) R.Prf.intro
   | _ ->
     RM.ret (tm, tp)
 
@@ -68,6 +69,7 @@ let rec elim_implicit_connectives_and_total : T.Syn.tac -> T.Syn.tac =
   (* The above code only makes sense because I know that the argument to Sub.elim will not be called under a further binder *)
   | D.ElStable _ ->
     T.Syn.run @@ elim_implicit_connectives_and_total @@ R.El.elim @@ T.Syn.rule @@ RM.ret (tm, tp)
+  | D.Pi (TpPrf _,_,_) -> T.Syn.run @@ elim_implicit_connectives @@ R.Pi.apply (T.Syn.rule @@ RM.ret (tm, tp)) R.Prf.intro
   | D.Signature sign ->
     begin
       is_total sign |>> function
@@ -85,6 +87,7 @@ let rec intro_implicit_connectives : T.Chk.tac -> T.Chk.tac =
     RM.ret @@ R.Sub.intro @@ intro_implicit_connectives tac
   | D.ElStable _, _, _ ->
     RM.ret @@ R.El.intro @@ intro_implicit_connectives tac
+  | D.Pi (TpPrf _,_,_), _, _  -> RM.ret @@ R.Pi.intro @@ fun _ -> intro_implicit_connectives tac
   | D.Signature sign, _, _ ->
     begin
       is_total sign |>> function
@@ -100,6 +103,7 @@ let rec intro_subtypes_and_total : T.Chk.tac -> T.Chk.tac =
   match_goal @@ function
   | D.Sub _, _, _ ->
     RM.ret @@ R.Sub.intro @@ intro_subtypes_and_total tac
+  | D.Pi (TpPrf _,_,_), _, _  -> RM.ret @@ R.Pi.intro @@ fun _ -> intro_implicit_connectives tac
   | ElStable (`Signature sign_code), _, _ ->
     begin
       RM.lift_cmp @@ Sem.unfold_el (`Signature sign_code) |>> function

--- a/test/circle.cooltt
+++ b/test/circle.cooltt
@@ -9,7 +9,7 @@ def loopn : nat -> Ω1s1 :=
   | zero => _ => base
   | suc {n => loopn} =>
     i =>
-    hcom circle 0 1 {∂ i} {k _ =>
+    hcom circle 0 1 {∂ i} {k =>
       [ k=0 => loopn i
       | i=0 => base
       | i=1 => loop k

--- a/test/com.cooltt
+++ b/test/com.cooltt
@@ -10,13 +10,13 @@ def mycoe/fun
 
 def mycom/fun
   (A B : 𝕀 → type)
-  (com/A : (r : 𝕀) (φ : 𝔽) (p : (i : 𝕀) (_ : [i=r ∨ φ]) → A i) (i : 𝕀) → sub {A i} {i=r ∨ φ} {p i _})
-  (com/B : (r : 𝕀) (φ : 𝔽) (p : (i : 𝕀) (_ : [i=r ∨ φ]) → B i) (i : 𝕀) → sub {B i} {i=r ∨ φ} {p i _})
-  (r : 𝕀) (φ : 𝔽) (p : (i : 𝕀) (_ : [i=r ∨ φ]) (_ : A i) → B i) (i : 𝕀)
-  : sub {(_ : A i) → B i} {i=r ∨ φ} {p i _}
+  (com/A : (r : 𝕀) (φ : 𝔽) (p : (i : 𝕀) → [i=r ∨ φ] → A i) (i : 𝕀) → sub {A i} {i=r ∨ φ} {p i})
+  (com/B : (r : 𝕀) (φ : 𝔽) (p : (i : 𝕀) → [i=r ∨ φ] → B i) (i : 𝕀) → sub {B i} {i=r ∨ φ} {p i})
+  (r : 𝕀) (φ : 𝔽) (p : (i : 𝕀) → [i=r ∨ φ] → A i → B i) (i : 𝕀)
+  : sub {(_ : A i) → B i} {i=r ∨ φ} {p i}
   :=
   x =>
-  com/B r φ {j _ => p j _ {com/A i ⊥ {_ _ => x} j}} i
+  com/B r φ {j => p j {com/A i ⊥ {_ => x} j}} i
 
 #normalize mycom/fun
 
@@ -54,7 +54,7 @@ def coe/pathd
   (b : (i : 𝕀) -> A i 1)
   (m : pathd {A r} {a r} {b r})
   : sub {pathd {A r'} {a r'} {b r'}} ⊤ {j =>
-      com {i => A i j} r r' {∂ j} {i p =>
+      com {i => A i j} r r' {∂ j} {i =>
         [j=0 => a i | j=1 => b i | i=r => m j]
       }
     }
@@ -65,15 +65,15 @@ def coe/pathd
 
 def hcom/intro
   (A : type) (r r' : 𝕀) (φ : 𝔽)
-  (p : (i : 𝕀) (_ : [i=r ∨ φ]) → A)
-  : sub A {r=r' ∨ φ} {p r' _}
+  (p : (i : 𝕀) → [i=r ∨ φ] → A)
+  : sub A {r=r' ∨ φ} {p r'}
   :=
   hcom A r r' φ p
 
 def hcom/fun
   (A B : type) (r r' : 𝕀) (φ : 𝔽)
-  (p : (i : 𝕀) (_ : [i=r ∨ φ]) → A → B)
-  : sub {A → B} ⊤ {x => hcom B r r' φ {j _ => p j _ x}}
+  (p : (i : 𝕀) → [i=r ∨ φ] → A → B)
+  : sub {A → B} ⊤ {x => hcom B r r' φ {j => p j x}}
   :=
   hcom {A → B} r r' φ p
 
@@ -81,8 +81,8 @@ def hcom/fun
 
 def com/intro
   (A : 𝕀 → type) (r r' : 𝕀) (φ : 𝔽)
-  (p : (i : 𝕀) (_ : [i=r ∨ φ]) → A i)
-  : sub {A r'} {r=r' ∨ φ} {p r' _}
+  (p : (i : 𝕀) → [i=r ∨ φ] → A i)
+  : sub {A r'} {r=r' ∨ φ} {p r'}
   :=
   com A r r' φ p
 
@@ -90,7 +90,7 @@ def com/intro
 
 def com/decomposition
   (A : 𝕀 → type) (r r' : 𝕀) (φ : 𝔽)
-  (p : (i : 𝕀) (_ : [i=r ∨ φ]) → A i)
-  : sub {A r'} ⊤ {hcom {A r'} r r' φ {j _ => coe A j r' {p j _}}}
+  (p : (i : 𝕀) → [i=r ∨ φ] → A i)
+  : sub {A r'} ⊤ {hcom {A r'} r r' φ {j => coe A j r' {p j}}}
   :=
   com A r r' φ p

--- a/test/elab.cooltt
+++ b/test/elab.cooltt
@@ -1,5 +1,5 @@
-def boundary-test : (i : 𝕀) (_ : [∂ i]) → nat :=
-  i _ =>
+def boundary-test : (i : 𝕀) → [∂ i] → nat :=
+  i =>
   [ i=1 => 5
   | i=0 => 19
   ]

--- a/test/groupoid-laws.cooltt
+++ b/test/groupoid-laws.cooltt
@@ -11,13 +11,13 @@ def special-j (A : type) (x : A) (B : (φ : 𝔽) → {(i : 𝕀) → sub A {i=0
   :=
   let filler : 𝕀 → 𝕀 → A :=
     j i =>
-    hcom A 0 i {∂ j ∨ φ} {i _ =>
+    hcom A 0 i {∂ j ∨ φ} {i =>
       [ i=0 ∨ j=0 ∨ φ => p 0
       | j=1 => p i
       ]
     }
   in
-  com {j => B {φ ∨ j=0} {filler j}} 0 1 {φ} {j _ => d}
+  com {j => B {φ ∨ j=0} {filler j}} 0 1 {φ} {j => d}
 
 shadowing def trans (A : type) (p : (i : 𝕀) → A)
   : (φ : 𝔽) (q : (i : 𝕀) → sub A {i=0 ∨ φ} {p 1})

--- a/test/hcom-type.cooltt
+++ b/test/hcom-type.cooltt
@@ -1,19 +1,18 @@
 def v-test (r : 𝕀) (A : type) : type :=
-  V r {_ => A} A {_ =>
+  V r A A
     [ x => x
     , x =>
       [ [x, _ => x]
       , p i =>
-        let aux := hfill A 1 {∂ i} {k _ => [ k=1 => x | i=1 => {snd p} k | i=0 => x ] } in
+        let aux := hfill A 1 {∂ i} {k => [ k=1 => x | i=1 => {snd p} k | i=0 => x ] } in
         [aux 0, aux]
       ]
     ]
-  }
 
 def hcom-type (i : 𝕀) : type :=
-  hcom type 0 1 {∂ i} {j _ => [j=0 => v-test i nat | ∂ i => nat]}
+  hcom type 0 1 {∂ i} {j => [j=0 => v-test i nat | ∂ i => nat]}
 
 def hcom-box (i : 𝕀) : hcom-type i :=
-  [_ => ?asdf, [?,?]]
+  [?asdf, [?,?]]
 
 

--- a/test/hlevel.cooltt
+++ b/test/hlevel.cooltt
@@ -41,7 +41,7 @@ abstract
 unfold has-hlevel
 def prop-set (A : type) (A/prop : is-prop A) : is-set A :=
   a b p q i j =>
-  hcom A 0 1 {∂ i ∨ ∂ j} {k _ =>
+  hcom A 0 1 {∂ i ∨ ∂ j} {k =>
     [ k=0 ∨ ∂ j ∨ i=0 => A/prop a {p j} k
     | i=1 => A/prop a {q j} k
     ]
@@ -85,7 +85,7 @@ def path-based-contr (A : type) (a : A) : is-contr {(x : A) × path A a x} :=
   [ [a, i => a]
   , x i =>
     let aux : 𝕀 → A := j =>
-      hcom A 0 j {∂ i} {k _ =>
+      hcom A 0 j {∂ i} {k =>
         [ k=0 ∨ i=0 => a
         | i=1 => {snd x} k
         ]

--- a/test/isos.cooltt
+++ b/test/isos.cooltt
@@ -3,7 +3,7 @@ import prelude
 
 shadowing
 def trans/filler (A : type) (p : 𝕀 → A) (q : (i : 𝕀) → sub A {i=0} {p 1}) (j i : 𝕀) : A :=
-  hcom A 0 j {∂ i} {j _ =>
+  hcom A 0 j {∂ i} {j =>
     [ j=0 ∨ i=0 => p i
     | i=1 => q j
     ]

--- a/test/nat-path.cooltt
+++ b/test/nat-path.cooltt
@@ -10,7 +10,7 @@ def evan-test (A : type) (φ : 𝔽) (a : A)
 abstract
 def J (A : type) (p : 𝕀 → A) (C : {(i : 𝕀) → sub A {i=0} {p 0}} → type) (d : C {_ => p 0}) : C p :=
   coe {i =>
-    C {hfill A 0 {∂ i} {k _ => [k=0 ∨ i=0 => p 0 | i=1 => p k]}}
+    C {hfill A 0 {∂ i} {k => [k=0 ∨ i=0 => p 0 | i=1 => p k]}}
   } 0 1 d
 
 unfold J
@@ -18,23 +18,23 @@ unfold J
 
 abstract
 def J/eq (A : type) (p : 𝕀 → A) (C : {(i : 𝕀) → sub A {i=0} {p 0}} → type) (d : C {_ => p 0}) : path {C {_ => p 0}} {J A {_ => p 0} C d} d :=
-  let square : 𝕀 → 𝕀 → A := i => hfill A 0 {∂ i} {_ _ => p 0} in
+  let square : 𝕀 → 𝕀 → A := i => hfill A 0 {∂ i} {_ => p 0} in
   k =>
   let mot : 𝕀 → type :=
-    i => C {hfill A 0 {∂ k ∨ ∂ i} {j _ => [k=0 => square i j | j=0 ∨ k=1 ∨ ∂ i => p 0]}}
+    i => C {hfill A 0 {∂ k ∨ ∂ i} {j => [k=0 => square i j | j=0 ∨ k=1 ∨ ∂ i => p 0]}}
   in
   unfold J in
-  com mot 0 1 {∂ k} {i _ => [k=0 => coe {j => C {square j}} 0 i d | k=1 ∨ i=0 => d]}
+  com mot 0 1 {∂ k} {i => [k=0 => coe {j => C {square j}} 0 i d | k=1 ∨ i=0 => d]}
 
 abstract
 def trans-left-unit (A : type) (p : 𝕀 → A) : path {path A {p 0} {p 1}} p {trans A {_ => p 0} p} :=
   k i =>
   unfold trans in
-  hcom A 0 1 {k=0 ∨ ∂ i} {j _ =>
+  hcom A 0 1 {k=0 ∨ ∂ i} {j =>
     [ j=0 ∨ i=0 => p 0
     | i=1 => p j
     | k=0 =>
-      hcom A 0 1 {∂ i ∨ ∂ j} {l _ =>
+      hcom A 0 1 {∂ i ∨ ∂ j} {l =>
         let filler : 𝕀 → A := k => trans/filler A {_ => p 0} p k l in
         [ l=0 ∨ i=0 ∨ j=1 => filler i
         | i=1 ∨ j=0 => filler j
@@ -51,7 +51,7 @@ def trans-right-unit (A : type) (p : 𝕀 → A) : path {path A {p 0} {p 1}} p {
 def trans-symm-refl (A : type) (p : 𝕀 → A) : path {path A {p 0} {p 0}} {_ => p 0} {trans A p {symm A p}} :=
   k i =>
   unfold trans symm in
-  hcom A 0 1 {k=0 ∨ ∂ i} {j _ =>
+  hcom A 0 1 {k=0 ∨ ∂ i} {j =>
     symm/filler A p j i
   }
 
@@ -92,4 +92,4 @@ def test2 : (i : 𝕀) → nat :=
 -- reduced as they could be, it is of no consequence for definitional
 -- equivalence. That is, we don't bother pushing eliminators through all the
 -- branches of a disjunction split, but our equational theory acts as if we do.
-def test2' : sub {𝕀 → nat} ⊤ {i => hcom nat 0 1 {∂ i} {_ _ => 0}} := unfold symm in test2
+def test2' : sub {𝕀 → nat} ⊤ {i => hcom nat 0 1 {∂ i} {_ => 0}} := unfold symm in test2

--- a/test/path-types.cooltt
+++ b/test/path-types.cooltt
@@ -34,8 +34,8 @@ def funext : {
 def funextdep : {
   (A : 𝕀 → type) (B : (i : 𝕀) → A i → type)
   (f : (i : 𝕀) → [∂ i] → (x : A i) → B i x)
-  (h : (p : (i : 𝕀) → A i) → ext i => B i {p i} with [∂ i => f i _ {p i}])
-  → ext i => (x : A i) → B i x with [∂ i => f i _]
+  (h : (p : (i : 𝕀) → A i) → ext i => B i {p i} with [∂ i => f i {p i}])
+  → ext i => (x : A i) → B i x with [∂ i => f i]
 } := {
   A B f h i x =>
   h {j => coe A i j x} i

--- a/test/prelude.cooltt
+++ b/test/prelude.cooltt
@@ -10,7 +10,7 @@ def refl (A : type) (x : A) : path A x x :=
   i => x
 
 def symm/filler (A : type) (p : 𝕀 → A) (i : 𝕀) : 𝕀 → A :=
-  hfill A 0 {∂ i} {j _ =>
+  hfill A 0 {∂ i} {j =>
     [ j=0 ∨ i=1 => p 0
     | i=0 => p j
     ]
@@ -21,7 +21,7 @@ def symm (A : type) (p : 𝕀 → A) : path A {p 1} {p 0} :=
   i => symm/filler A p i 1
 
 def trans/filler (A : type) (p : 𝕀 → A) (q : (i : 𝕀) → sub A {i=0} {p 1}) (j : 𝕀) (i : 𝕀) : A :=
-  hcom A 0 j {∂ i} {j _ =>
+  hcom A 0 j {∂ i} {j =>
     [ j=0 ∨ i=0 => p i
     | i=1 => q j
     ]

--- a/test/test.expected
+++ b/test/test.expected
@@ -8,7 +8,7 @@ hlevel.cooltt:34.11-34.16 [Info]:
 
 abstract.cooltt:104.7-104.15 [Info]:
   def abs-test : nat :=
-    suc {abs-test∷foo _x}
+    suc {abs-test∷foo *}
 
 abstract.cooltt:107.7-107.15 [Info]:
   def abs-test : nat :=
@@ -18,11 +18,11 @@ abstract.cooltt:107.7-107.15 [Info]:
 base-types.cooltt:44.7-44.11 [Info]:
   def case : (A : type) → (B : type) → (P : (_x : sum A B) → type) → (P/inl : (a : A) → P {inl A B a}) → (P/inr : (b : B) → P {inr A B b}) → (s : sum A B) → P s :=
     A B P P/inl P/inr s =>
-    blocked[sum] _x A B P P/inl P/inr s {_x₁ =>
-                                         elim _x₁ @ {_x₂ => type}
-                                           [ zero => B
-                                           | suc => _x₂ _x₃ => empty
-                                           ]} {blocked[inr] _x A B P P/inl P/inr s {
+    blocked[sum] * A B P P/inl P/inr s {_x₁ =>
+                                        elim _x₁ @ {_x₂ => type}
+                                          [ zero => B
+                                          | suc => _x₂ _x₃ => empty
+                                          ]} {blocked[inr] * A B P P/inl P/inr s {
     _x₁ => elim _x₁ @ {_x₂ => type} [ zero => B
                                     | suc => _x₂ _x₃ => empty
                                     ]}} {_x₁ =>
@@ -34,10 +34,10 @@ base-types.cooltt:44.7-44.11 [Info]:
                                                       | suc => _x₃ _x₄ =>
                                                                empty
                                                       ]
-                                           ]} {blocked[sum,inl] _x A B P P/inl P/inr s {
+                                           ]} {blocked[sum,inl] * A B P P/inl P/inr s {
     _x₁ => elim _x₁ @ {_x₂ => type} [ zero => B
                                     | suc => _x₂ _x₃ => empty
-                                    ]} {blocked[inr] _x A B P P/inl P/inr s {
+                                    ]} {blocked[inr] * A B P P/inl P/inr s {
     _x₁ => elim _x₁ @ {_x₂ => type} [ zero => B
                                     | suc => _x₂ _x₃ => empty
                                     ]}} {_x₁ =>
@@ -1283,7 +1283,7 @@ hcom-type.cooltt:16.11-16.12 [Info]:
     
     Boundary:
     ⊤
-    |- ?asdf _x 0 *
+    |- ?asdf * 0 *
 
 
 hcom-type.cooltt:16.13-16.14 [Info]:
@@ -1294,9 +1294,9 @@ hcom-type.cooltt:16.13-16.14 [Info]:
     
     Boundary:
     i = 0 ∨ i = 0 ∨ i = 1
-    |- i = 0 => #3 _x 0 *
-       i = 0 => ?asdf _x 0 *
-       i = 1 => ?asdf _x 1 *
+    |- i = 0 => #3 * 0 *
+       i = 0 => ?asdf * 0 *
+       i = 1 => ?asdf * 1 *
 
 
 [Warn]:  There are 3 unsolved holes
@@ -1342,7 +1342,7 @@ holes.cooltt:8.27-8.28 [Info]:
     p : (_x₁ : 𝕀) → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
-    |- ? : (i₁ : 𝕀) → sub A {i₁ = 0} {#2 _x A p q i 1}
+    |- ? : (i₁ : 𝕀) → sub A {i₁ = 0} {#2 * A p q i 1}
 
 
 holes.cooltt:8.7-8.35 [Info]:
@@ -1352,7 +1352,7 @@ holes.cooltt:8.7-8.35 [Info]:
     p : (_x₁ : 𝕀) → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
-    |- {! trans/filler A {#2 _x A p q i} {#3 _x A p q i} 1 i !} : A
+    |- {! trans/filler A {#2 * A p q i} {#3 * A p q i} 1 i !} : A
     
     Boundary (unsatisfied):
     i = 0 ∨ i = 1
@@ -1402,7 +1402,7 @@ holes.cooltt:18.26-18.30 [Info]:
 
 holes.cooltt:17.5-18.30 [Info]:
   Failure encountered, as expected:
-   Expected hcom A 0 1 {i = 0 ∨ i = 1} {_x₂ _x₃ => #10 _x A p q i _x₂ _x₃} =
+   Expected hcom A 0 1 {i = 0 ∨ i = 1} {_x₂ _x₃ => #10 * A p q i _x₂ *} =
             [ i = 0 ∨ i = 1 => [ i = 0 => p 0 | i = 1 => q 1 ] ]
             : A
 

--- a/test/test.expected
+++ b/test/test.expected
@@ -1126,12 +1126,12 @@ com.cooltt:64.11-64.20 [Info]:
 
 com.cooltt:80.11-80.19 [Info]:
   Computed normal form of hcom/fun as
-   A B r r' φ p _x => hcom B r r' φ {_x₁ _x₂ => p _x₁ _x₂ _x}
+   A B r r' φ p _x => hcom B r r' φ {_x₁ _x₂ => p _x₁ * _x}
 
 com.cooltt:89.11-89.20 [Info]:
   Computed normal form of com/intro as
    A r r' φ p =>
-   hcom {A r'} r r' φ {_x _x₁ => coe {_x₂ => A _x₂} _x r' {p _x _x₁}}
+   hcom {A r'} r r' φ {_x _x₁ => coe {_x₂ => A _x₂} _x r' {p _x *}}
 
 --------------------[cool-total-space.cooltt]--------------------
 cool-total-space.cooltt:6.7-6.20 [Info]:
@@ -1266,7 +1266,7 @@ groupoid-laws.cooltt:128.7-128.11 [Info]:
     assoc A {_x₂ => p _x₂} ⊥ {_x₂ => q _x₂} ⊥ {_x₂ => r _x₂} j _x₁
 
 --------------------[hcom-type.cooltt]--------------------
-hcom-type.cooltt:17.8-17.13 [Info]:
+hcom-type.cooltt:16.3-16.8 [Info]:
   Emitted hole:
     _x : [ ⊤ ]
     i : 𝕀
@@ -1274,18 +1274,19 @@ hcom-type.cooltt:17.8-17.13 [Info]:
     |- ?asdf : nat
 
 
-hcom-type.cooltt:17.16-17.17 [Info]:
+hcom-type.cooltt:16.11-16.12 [Info]:
   Emitted hole:
     _x : [ ⊤ ]
     i : 𝕀
-    |- ? : (_x₁ : [ i = 0 ]) → nat
+    _x₁ : [ i = 0 ]
+    |- ? : nat
     
     Boundary:
-    i = 0 ∨ i = 1
-    |- _x₁ => [ ⊤ => ?asdf _x 0 * ]
+    ⊤
+    |- ?asdf _x 0 *
 
 
-hcom-type.cooltt:17.18-17.19 [Info]:
+hcom-type.cooltt:16.13-16.14 [Info]:
   Emitted hole:
     _x : [ ⊤ ]
     i : 𝕀
@@ -1293,7 +1294,7 @@ hcom-type.cooltt:17.18-17.19 [Info]:
     
     Boundary:
     i = 0 ∨ i = 0 ∨ i = 1
-    |- i = 0 => ?asdf _x 0 *
+    |- i = 0 => #3 _x 0 *
        i = 0 => ?asdf _x 0 *
        i = 1 => ?asdf _x 1 *
 
@@ -1789,7 +1790,7 @@ selfification.cooltt:8.11-8.18 [Info]:
    _x _x₁ _x₂ p _x₃ => [ fst {p _x₃} , snd {p _x₃} ]
 
 --------------------[v.cooltt]--------------------
-v.cooltt:13.11-13.17 [Info]:
+v.cooltt:12.11-12.17 [Info]:
   Computed normal form of v-test as
    r A =>
    V r {_x => A} A {_x =>
@@ -1808,10 +1809,10 @@ v.cooltt:13.11-13.17 [Info]:
                       ]
                     ]}
 
-v.cooltt:21.11-21.15 [Info]:
+v.cooltt:20.11-20.15 [Info]:
   Computed normal form of cool as A a => coe {_x => A} 0 1 a
 
-v.cooltt:22.11-22.16 [Info]:
+v.cooltt:21.11-21.16 [Info]:
   Computed normal form of cool2 as
    A a i =>
    hcom A 0 1 {i = 0}
@@ -1822,7 +1823,7 @@ v.cooltt:22.11-22.16 [Info]:
           {k _x₃ => [ k = 1 => a | _x = 1 => a | _x = 0 => a ]}
       ]}
 
-v.cooltt:28.11-28.16 [Info]:
+v.cooltt:27.11-27.16 [Info]:
   Computed normal form of cool3 as A a i => a
 
 --------------------[view.cooltt]--------------------

--- a/test/test.expected
+++ b/test/test.expected
@@ -1181,8 +1181,8 @@ cool-total-space.cooltt:33.7-33.27 [Info]:
 
 cool-total-space.cooltt:35.64-35.65 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
-    fam : (_x₁ : sig (x : nat) ) → type
+    _ : [ ⊤ ]
+    fam : (_x : sig (x : nat) ) → type
     |- ? : fam {struct (x : 0) }
 
 
@@ -1209,7 +1209,7 @@ elab.cooltt:33.6-33.13 [Info]:
 
 elab.cooltt:35.9-35.16 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     y : nat
     z : nat
     |- ?tmhole : (z₁ : nat) → ?tyhole y z z₁
@@ -1217,9 +1217,9 @@ elab.cooltt:35.9-35.16 [Info]:
 
 elab.cooltt:42.6-42.12 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     x : nat
-    |- ?hole1 : ext {i => nat} {i => i = 0 ∨ i = 1} {i _x₁ =>
+    |- ?hole1 : ext {i => nat} {i => i = 0 ∨ i = 1} {i _x =>
                                                      [ i = 0 => x
                                                      | i = 1 => x
                                                      ]}
@@ -1268,17 +1268,17 @@ groupoid-laws.cooltt:128.7-128.11 [Info]:
 --------------------[hcom-type.cooltt]--------------------
 hcom-type.cooltt:16.3-16.8 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     i : 𝕀
-    _x₁ : [ i = 0 ∨ i = 1 ]
+    _ : [ i = 0 ∨ i = 1 ]
     |- ?asdf : nat
 
 
 hcom-type.cooltt:16.11-16.12 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     i : 𝕀
-    _x₁ : [ i = 0 ]
+    _ : [ i = 0 ]
     |- ? : nat
     
     Boundary:
@@ -1288,7 +1288,7 @@ hcom-type.cooltt:16.11-16.12 [Info]:
 
 hcom-type.cooltt:16.13-16.14 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     i : 𝕀
     |- ? : nat
     
@@ -1312,9 +1312,9 @@ hlevel.cooltt:34.11-34.16 [Info]:
 --------------------[holes.cooltt]--------------------
 holes.cooltt:5.7-5.13 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     A : type
-    p : (_x₁ : 𝕀) → A
+    p : (_x : 𝕀) → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
     |- ? : A
@@ -1327,19 +1327,19 @@ holes.cooltt:5.7-5.13 [Info]:
 
 holes.cooltt:8.25-8.26 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     A : type
-    p : (_x₁ : 𝕀) → A
+    p : (_x : 𝕀) → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
-    |- ? : (_x₁ : 𝕀) → A
+    |- ? : (_x : 𝕀) → A
 
 
 holes.cooltt:8.27-8.28 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     A : type
-    p : (_x₁ : 𝕀) → A
+    p : (_x : 𝕀) → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
     |- ? : (i₁ : 𝕀) → sub A {i₁ = 0} {#2 * A p q i 1}
@@ -1347,9 +1347,9 @@ holes.cooltt:8.27-8.28 [Info]:
 
 holes.cooltt:8.7-8.35 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     A : type
-    p : (_x₁ : 𝕀) → A
+    p : (_x : 𝕀) → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
     |- {! trans/filler A {#2 * A p q i} {#3 * A p q i} 1 i !} : A
@@ -1362,12 +1362,12 @@ holes.cooltt:8.7-8.35 [Info]:
 
 holes.cooltt:11.7-11.35 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     A : type
-    p : (_x₁ : 𝕀) → A
+    p : (_x : 𝕀) → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
-    |- {! trans/filler A {_x₁ => p _x₁} {_x₁ => q _x₁} 0 i !} : A
+    |- {! trans/filler A {_x => p _x} {_x => q _x} 0 i !} : A
     
     Boundary (unsatisfied):
     i = 0 ∨ i = 1
@@ -1377,12 +1377,12 @@ holes.cooltt:11.7-11.35 [Info]:
 
 holes.cooltt:14.7-14.35 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     A : type
-    p : (_x₁ : 𝕀) → A
+    p : (_x : 𝕀) → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
-    |- {! trans/filler A {_x₁ => p _x₁} {_x₁ => q _x₁} 1 i !} : A
+    |- {! trans/filler A {_x => p _x} {_x => q _x} 1 i !} : A
     
     Boundary (satisfied):
     i = 0 ∨ i = 1
@@ -1392,12 +1392,12 @@ holes.cooltt:14.7-14.35 [Info]:
 
 holes.cooltt:18.26-18.30 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     A : type
-    p : (_x₁ : 𝕀) → A
+    p : (_x : 𝕀) → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
-    |- ? : (_x₁ : 𝕀) → (_x₂ : [ _x₁ = 0 ∨ i = 0 ∨ i = 1 ]) → A
+    |- ? : (_x : 𝕀) → (_ : [ _x = 0 ∨ i = 0 ∨ i = 1 ]) → A
 
 
 holes.cooltt:17.5-18.30 [Info]:
@@ -1649,7 +1649,7 @@ nat.cooltt:13.11-13.16 [Info]:
 --------------------[patch.cooltt]--------------------
 patch.cooltt:10.49-10.50 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     |- ? : type
     
     Boundary:
@@ -1659,7 +1659,7 @@ patch.cooltt:10.49-10.50 [Info]:
 
 patch.cooltt:10.57-10.58 [Info]:
   Emitted hole:
-    _x : [ ⊤ ]
+    _ : [ ⊤ ]
     |- ? : nat
     
     Boundary:

--- a/test/v.cooltt
+++ b/test/v.cooltt
@@ -1,14 +1,13 @@
 def v-test (r : 𝕀) (A : type) : type :=
-  V r {_ => A} A {_ =>
+  V r A A
     [ x => x
     , x =>
       [ [x, _ => x]
       , p i =>
-        let aux := hfill A 1 {∂ i} {k _ => [ k=1 => x | i=1 => {snd p} k | i=0 => x ] } in
+        let aux := hfill A 1 {∂ i} {k => [ k=1 => x | i=1 => {snd p} k | i=0 => x ] } in
         [aux 0, aux]
       ]
     ]
-  }
 
 #normalize v-test
 
@@ -16,13 +15,13 @@ def cool (A : type) (a : A) : sub A ⊤ {coe {_ => A} 0 1 a} :=
   coe {i => v-test i A} 0 1 a
 
 def cool2 (A : type) (a : A) (i : 𝕀) : A :=
-  coe {i => v-test i A} i 0 [_ => a, a]
+  coe {i => v-test i A} i 0 [a, a]
 
 #normalize cool
 #normalize cool2
 
 def cool3 (A : type) (a : A) (i : 𝕀) : sub A ⊤ a :=
-  let vin : v-test i A := [_ => a, a] in
+  let vin : v-test i A := [a, a] in
   vproj vin
 
 #normalize cool3


### PR DESCRIPTION
~~(emoji needed)~~

This PR makes functions out of cofibration proofs implicit. So to inhabit `[ϕ] -> A` we can simply write down an element of `A` and it will be elaborated to a function. Similarly, if we have `f :  [ϕ] -> A`, it will be elaborated to `f *`. 

The main thing this is lacking is nice printing. We still print( functions out of) and (applications to) cofibration proofs, because we do not have types when printing. Not printing applications to `*` is straightforward, but conditionally not printing lambdas is more difficult. We may need to add separate core terms for these constructs.

Regardless of printing, I think having these proofs clutter only the core is superior to having them clutter both the surface language and the core.