### PR TITLE
🌻 Improve pretty printing for underscores

### DIFF
--- a/test/test.expected
+++ b/test/test.expected
@@ -16,1173 +16,1170 @@ abstract.cooltt:107.7-107.15 [Info]:
 
 --------------------[base-types.cooltt]--------------------
 base-types.cooltt:44.7-44.11 [Info]:
-  def case : (A : type) → (B : type) → (P : (_x : sum A B) → type) → (P/inl : (a : A) → P {inl A B a}) → (P/inr : (b : B) → P {inr A B b}) → (s : sum A B) → P s :=
+  def case : (A : type) → (B : type) → (P : sum A B → type) → (P/inl : (a : A) → P {inl A B a}) → (P/inr : (b : B) → P {inr A B b}) → (s : sum A B) → P s :=
     A B P P/inl P/inr s =>
-    blocked[sum] * A B P P/inl P/inr s {_x₁ =>
-                                        elim _x₁ @ {_x₂ => type}
+    blocked[sum] * A B P P/inl P/inr s {_ =>
+                                        elim _ @ {_ => type}
                                           [ zero => B
-                                          | suc => _x₂ _x₃ => empty
+                                          | suc => _ _ => empty
                                           ]} {blocked[inr] * A B P P/inl P/inr s {
-    _x₁ => elim _x₁ @ {_x₂ => type} [ zero => B
-                                    | suc => _x₂ _x₃ => empty
-                                    ]}} {_x₁ =>
-                                         elim _x₁ @ {_x₂ => type}
-                                           [ zero => A
-                                           | suc => n _x₂ =>
-                                                    elim n @ {_x₃ => type}
-                                                      [ zero => B
-                                                      | suc => _x₃ _x₄ =>
-                                                               empty
-                                                      ]
-                                           ]} {blocked[sum,inl] * A B P P/inl P/inr s {
-    _x₁ => elim _x₁ @ {_x₂ => type} [ zero => B
-                                    | suc => _x₂ _x₃ => empty
-                                    ]} {blocked[inr] * A B P P/inl P/inr s {
-    _x₁ => elim _x₁ @ {_x₂ => type} [ zero => B
-                                    | suc => _x₂ _x₃ => empty
-                                    ]}} {_x₁ =>
-                                         elim _x₁ @ {_x₂ => type}
-                                           [ zero => A
-                                           | suc => n _x₂ =>
-                                                    elim n @ {_x₃ => type}
-                                                      [ zero => B
-                                                      | suc => _x₃ _x₄ =>
-                                                               empty
-                                                      ]
-                                           ]}}
+    _ => elim _ @ {_ => type} [ zero => B
+                              | suc => _ _ => empty
+                              ]}} {_ =>
+                                   elim _ @ {_ => type}
+                                     [ zero => A
+                                     | suc => n _ =>
+                                              elim n @ {_ => type}
+                                                [ zero => B
+                                                | suc => _ _ => empty
+                                                ]
+                                     ]} {blocked[sum,inl] * A B P P/inl P/inr s {
+    _ => elim _ @ {_ => type} [ zero => B
+                              | suc => _ _ => empty
+                              ]} {blocked[inr] * A B P P/inl P/inr s {
+    _ => elim _ @ {_ => type} [ zero => B
+                              | suc => _ _ => empty
+                              ]}} {_ =>
+                                   elim _ @ {_ => type}
+                                     [ zero => A
+                                     | suc => n _ =>
+                                              elim n @ {_ => type}
+                                                [ zero => B
+                                                | suc => _ _ => empty
+                                                ]
+                                     ]}}
 
 --------------------[circle.cooltt]--------------------
 circle.cooltt:20.11-20.22 [Info]:
   Computed normal form of loopn 100 as
    i =>
    hcom circle 0 1 {i = 0 ∨ i = 1}
-     {_x _x₁ =>
-      [ _x = 0 =>
+     {_ _ =>
+      [ _ = 0 =>
         hcom circle 0 1 {i = 0 ∨ i = 1}
-          {_x₃ _x₄ =>
-           [ _x₃ = 0 =>
+          {_ _ =>
+           [ _ = 0 =>
              hcom circle 0 1 {i = 0 ∨ i = 1}
-               {_x₆ _x₇ =>
-                [ _x₆ = 0 =>
+               {_ _ =>
+                [ _ = 0 =>
                   hcom circle 0 1 {i = 0 ∨ i = 1}
-                    {_x₉ _x₁₀ =>
-                     [ _x₉ = 0 =>
+                    {_ _ =>
+                     [ _ = 0 =>
                        hcom circle 0 1 {i = 0 ∨ i = 1}
-                         {_x₁₂ _x₁₃ =>
-                          [ _x₁₂ = 0 =>
+                         {_ _ =>
+                          [ _ = 0 =>
                             hcom circle 0 1 {i = 0 ∨ i = 1}
-                              {_x₁₅ _x₁₆ =>
-                               [ _x₁₅ = 0 =>
+                              {_ _ =>
+                               [ _ = 0 =>
                                  hcom circle 0 1 {i = 0 ∨ i = 1}
-                                   {_x₁₈ _x₁₉ =>
-                                    [ _x₁₈ = 0 =>
+                                   {_ _ =>
+                                    [ _ = 0 =>
                                       hcom circle 0 1 {i = 0 ∨ i = 1}
-                                        {_x₂₁ _x₂₂ =>
-                                         [ _x₂₁ = 0 =>
+                                        {_ _ =>
+                                         [ _ = 0 =>
                                            hcom circle 0 1 {i = 0 ∨ i = 1}
-                                             {_x₂₄ _x₂₅ =>
-                                              [ _x₂₄ = 0 =>
+                                             {_ _ =>
+                                              [ _ = 0 =>
                                                 hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                  {_x₂₇ _x₂₈ =>
-                                                   [ _x₂₇ = 0 =>
+                                                  {_ _ =>
+                                                   [ _ = 0 =>
                                                      hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                       {_x₃₀ _x₃₁ =>
-                                                        [ _x₃₀ = 0 =>
+                                                       {_ _ =>
+                                                        [ _ = 0 =>
                                                           hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                            {_x₃₃ _x₃₄ =>
-                                                             [ _x₃₃ = 0 =>
+                                                            {_ _ =>
+                                                             [ _ = 0 =>
                                                                hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                 {_x₃₆ _x₃₇ =>
-                                                                  [ _x₃₆ = 0 =>
+                                                                 {_ _ =>
+                                                                  [ _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₃₉ _x₄₀ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₃₉ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₄₂ _x₄₃ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₄₂ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₄₅ _x₄₆ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₄₅ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₄₈ _x₄₉ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₄₈ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₅₁ _x₅₂ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₅₁ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₅₄ _x₅₅ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₅₄ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₅₇ _x₅₈ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₅₇ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₆₀ _x₆₁ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₆₀ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₆₃ _x₆₄ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₆₃ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₆₆ _x₆₇ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₆₆ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₆₉ _x₇₀ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₆₉ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₇₂ _x₇₃ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₇₂ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₇₅ _x₇₆ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₇₅ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₇₈ _x₇₉ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₇₈ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₈₁ _x₈₂ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₈₁ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₈₄ _x₈₅ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₈₄ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₈₇ _x₈₈ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₈₇ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₉₀ _x₉₁ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₉₀ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₉₃ _x₉₄ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₉₃ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₉₆ _x₉₇ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₉₆ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₉₉ _x₁₀₀ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₉₉ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₀₂ _x₁₀₃ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₀₂ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₀₅ _x₁₀₆ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₀₅ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₀₈ _x₁₀₉ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₀₈ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₁₁ _x₁₁₂ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₁₁ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₁₄ _x₁₁₅ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₁₄ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₁₇ _x₁₁₈ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₁₇ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₂₀ _x₁₂₁ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₂₀ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₂₃ _x₁₂₄ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₂₃ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₂₆ _x₁₂₇ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₂₆ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₂₉ _x₁₃₀ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₂₉ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₃₂ _x₁₃₃ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₃₂ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₃₅ _x₁₃₆ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₃₅ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₃₈ _x₁₃₉ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₃₈ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₄₁ _x₁₄₂ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₄₁ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₄₄ _x₁₄₅ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₄₄ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₄₇ _x₁₄₈ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₄₇ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₅₀ _x₁₅₁ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₅₀ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₅₃ _x₁₅₄ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₅₃ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₅₆ _x₁₅₇ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₅₆ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₅₉ _x₁₆₀ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₅₉ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₆₂ _x₁₆₃ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₆₂ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₆₅ _x₁₆₆ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₆₅ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₆₈ _x₁₆₉ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₆₈ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₇₁ _x₁₇₂ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₇₁ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₇₄ _x₁₇₅ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₇₄ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₇₇ _x₁₇₈ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₇₇ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₈₀ _x₁₈₁ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₈₀ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₈₃ _x₁₈₄ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₈₃ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₈₆ _x₁₈₇ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₈₆ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₈₉ _x₁₉₀ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₈₉ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₉₂ _x₁₉₃ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₉₂ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₉₅ _x₁₉₆ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₉₅ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₁₉₈ _x₁₉₉ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₁₉₈ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₀₁ _x₂₀₂ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₀₁ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₀₄ _x₂₀₅ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₀₄ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₀₇ _x₂₀₈ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₀₇ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₁₀ _x₂₁₁ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₁₀ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₁₃ _x₂₁₄ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₁₃ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₁₆ _x₂₁₇ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₁₆ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₁₉ _x₂₂₀ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₁₉ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₂₂ _x₂₂₃ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₂₂ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₂₅ _x₂₂₆ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₂₅ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₂₈ _x₂₂₉ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₂₈ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₃₁ _x₂₃₂ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₃₁ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₃₄ _x₂₃₅ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₃₄ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₃₇ _x₂₃₈ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₃₇ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₄₀ _x₂₄₁ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₄₀ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₄₃ _x₂₄₄ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₄₃ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₄₆ _x₂₄₇ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₄₆ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₄₉ _x₂₅₀ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₄₉ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₅₂ _x₂₅₃ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₅₂ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₅₅ _x₂₅₆ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₅₅ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₅₈ _x₂₅₉ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₅₈ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₆₁ _x₂₆₂ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₆₁ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₆₄ _x₂₆₅ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₆₄ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₆₇ _x₂₆₈ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₆₇ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₇₀ _x₂₇₁ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₇₀ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₇₃ _x₂₇₄ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₇₃ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₇₆ _x₂₇₇ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₇₆ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₇₉ _x₂₈₀ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₇₉ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₈₂ _x₂₈₃ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₈₂ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₈₅ _x₂₈₆ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₈₅ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₈₈ _x₂₈₉ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₈₈ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₉₁ _x₂₉₂ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₉₁ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₉₄ _x₂₉₅ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₉₄ = 0 =>
+                                                                    _ = 0 =>
                                                                     hcom circle 0 1 {i = 0 ∨ i = 1}
-                                                                    {_x₂₉₇ _x₂₉₈ =>
+                                                                    {_ _ =>
                                                                     [ 
-                                                                    _x₂₉₇ = 0 =>
+                                                                    _ = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₉₇
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₉₄
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₉₁
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₈₈
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₈₅
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₈₂
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₇₉
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₇₆
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₇₃
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₇₀
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₆₇
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₆₄
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₆₁
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₅₈
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₅₅
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₅₂
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₄₉
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₄₆
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₄₃
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₄₀
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₃₇
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₃₄
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₃₁
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₂₈
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₂₅
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₂₂
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₁₉
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₁₆
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₁₃
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₁₀
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₀₇
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₀₄
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₂₀₁
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₉₈
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₉₅
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₉₂
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₈₉
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₈₆
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₈₃
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₈₀
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₇₇
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₇₄
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₇₁
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₆₈
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₆₅
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₆₂
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₅₉
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₅₆
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₅₃
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₅₀
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₄₇
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₄₄
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₄₁
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₃₈
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₃₅
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₃₂
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₂₉
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₂₆
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₂₃
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₂₀
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₁₇
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₁₄
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₁₁
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₀₈
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₀₅
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₁₀₂
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₉₉
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₉₆
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₉₃
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₉₀
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₈₇
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₈₄
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₈₁
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₇₈
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₇₅
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₇₂
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₆₉
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₆₆
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₆₃
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₆₀
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₅₇
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₅₄
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₅₁
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₄₈
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₄₅
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₄₂
+                                                                    loop _
                                                                     ]}
                                                                     | 
                                                                     i = 0 =>
                                                                     base
                                                                     | 
                                                                     i = 1 =>
-                                                                    loop _x₃₉
+                                                                    loop _
                                                                     ]}
                                                                   | i = 0 =>
                                                                     base
                                                                   | i = 1 =>
-                                                                    loop _x₃₆
+                                                                    loop _
                                                                   ]}
                                                              | i = 0 => base
                                                              | i = 1 =>
-                                                               loop _x₃₃
+                                                               loop _
                                                              ]}
                                                         | i = 0 => base
-                                                        | i = 1 => loop _x₃₀
+                                                        | i = 1 => loop _
                                                         ]}
                                                    | i = 0 => base
-                                                   | i = 1 => loop _x₂₇
+                                                   | i = 1 => loop _
                                                    ]}
                                               | i = 0 => base
-                                              | i = 1 => loop _x₂₄
+                                              | i = 1 => loop _
                                               ]}
                                          | i = 0 => base
-                                         | i = 1 => loop _x₂₁
+                                         | i = 1 => loop _
                                          ]}
                                     | i = 0 => base
-                                    | i = 1 => loop _x₁₈
+                                    | i = 1 => loop _
                                     ]}
                                | i = 0 => base
-                               | i = 1 => loop _x₁₅
+                               | i = 1 => loop _
                                ]}
                           | i = 0 => base
-                          | i = 1 => loop _x₁₂
+                          | i = 1 => loop _
                           ]}
                      | i = 0 => base
-                     | i = 1 => loop _x₉
+                     | i = 1 => loop _
                      ]}
                 | i = 0 => base
-                | i = 1 => loop _x₆
+                | i = 1 => loop _
                 ]}
            | i = 0 => base
-           | i = 1 => loop _x₃
+           | i = 1 => loop _
            ]}
       | i = 0 => base
-      | i = 1 => loop _x
+      | i = 1 => loop _
       ]}
 
 --------------------[com.cooltt]--------------------
 com.cooltt:21.11-21.20 [Info]:
   Computed normal form of mycom/fun as
    A B com/A com/B r φ p i x =>
-   com/B r φ {j _x => p j * {com/A i ⊥ {_x₁ _x₂ => x} j}} i
+   com/B r φ {j _ => p j * {com/A i ⊥ {_ _ => x} j}} i
 
 com.cooltt:34.11-34.17 [Info]:
   Computed normal form of coe/pi as
-   A B r r' f _x =>
-   coe {_x₁ => B _x₁ {coe {_x₂ => A _x₂} r' _x₁ _x}} r r'
-     {f {coe {_x₁ => A _x₁} r' r _x}}
+   A B r r' f _ =>
+   coe {_ => B _ {coe {_ => A _} r' _ _}} r r' {f {coe {_ => A _} r' r _}}
 
 com.cooltt:44.11-44.20 [Info]:
   Computed normal form of coe/sigma as
    A B r r' p =>
-   [ coe {_x => A _x} r r' {fst p}
-   , coe {_x => B _x {coe {_x₁ => A _x₁} r _x {fst p}}} r r' {snd p}
+   [ coe {_ => A _} r r' {fst p}
+   , coe {_ => B _ {coe {_ => A _} r _ {fst p}}} r r' {snd p}
    ]
 
 com.cooltt:64.11-64.20 [Info]:
   Computed normal form of coe/pathd as
-   A r r' a b m _x =>
-   hcom {A r' _x} r r' {_x = 0 ∨ _x = 1}
-     {_x₁ _x₂ =>
-      coe {_x₃ => A _x₃ _x} _x₁ r'
-        [ _x = 0 ∨ _x = 1 => [ _x = 0 => a _x₁ | _x = 1 => b _x₁ ]
-        | _x₁ ≤ r ∧ r ≤ _x₁ => m _x
+   A r r' a b m _ =>
+   hcom {A r' _} r r' {_ = 0 ∨ _ = 1}
+     {_ _ =>
+      coe {_ => A _ _} _ r'
+        [ _ = 0 ∨ _ = 1 => [ _ = 0 => a _ | _ = 1 => b _ ]
+        | _ ≤ r ∧ r ≤ _ => m _
         ]}
 
 com.cooltt:80.11-80.19 [Info]:
   Computed normal form of hcom/fun as
-   A B r r' φ p _x => hcom B r r' φ {_x₁ _x₂ => p _x₁ * _x}
+   A B r r' φ p _ => hcom B r r' φ {_ _ => p _ * _}
 
 com.cooltt:89.11-89.20 [Info]:
   Computed normal form of com/intro as
-   A r r' φ p =>
-   hcom {A r'} r r' φ {_x _x₁ => coe {_x₂ => A _x₂} _x r' {p _x *}}
+   A r r' φ p => hcom {A r'} r r' φ {_ _ => coe {_ => A _} _ r' {p _ *}}
 
 --------------------[cool-total-space.cooltt]--------------------
 cool-total-space.cooltt:6.7-6.20 [Info]:
-  def fully-patched : (fam : (_x : sig (x : nat) ) → type) → (fib : fam {
-  struct (x : 0) }) → sig (x : ext nat ⊤ {_x => 0}) 
-                      (fib : fam {struct (x : 0) })  :=
+  def fully-patched : (fam : sig (x : nat)  → type) → (fib : fam {struct (x : 0)
+                                                                  }) → 
+  sig (x : ext nat ⊤ {_ => 0}) (fib : fam {struct (x : 0) })  :=
     fam fib => struct (x : 0) (fib : fib) 
 
 cool-total-space.cooltt:10.7-10.24 [Info]:
-  def not-fully-patched : (fam : (_x : sig (x : nat) ) → type) → (fib : fam {
+  def not-fully-patched : (fam : sig (x : nat)  → type) → (fib : fam {
   struct (x : 0) }) → sig (x : nat) (fib : fam {struct (x : x) })  :=
     fam fib => struct (x : 0) (fib : fib) 
 
 cool-total-space.cooltt:14.7-14.20 [Info]:
-  def no-insert-fib : (fam : (_x : sig (x : nat) ) → type) → (total : 
-  sig (x : nat) (fib : fam {struct (x : x) }) ) → nat :=
+  def no-insert-fib : (fam : sig (x : nat)  → type) → (total : sig (x : nat) 
+                                                               (fib : fam {
+                                                               struct (x : x) })
+                                                               ) → nat :=
     fam total => total @ x
 
 cool-total-space.cooltt:18.7-18.23 [Info]:
-  def insert-fib-plain : (fam : (_x : sig (x : nat) ) → type) → (total : 
-  sig (x : nat) (fib : fam {struct (x : x) }) ) → fam {struct (x : total @ x) } :=
+  def insert-fib-plain : (fam : sig (x : nat)  → type) → (total : sig (x : nat)
+                                                                  (fib : fam {
+                                                                  struct (x : x)
+                                                                  }) ) → fam {
+  struct (x : total @ x) } :=
     fam total => total @ fib
 
 cool-total-space.cooltt:23.7-23.20 [Info]:
-  def insert-fib-pi : sig (fam : (_x : sig (x : nat) ) → type) 
-                      (test : (_x : sig (x : nat) 
-                                    (fib : fam {struct (x : x) }) ) → nat)
+  def insert-fib-pi : sig (fam : sig (x : nat)  → type) 
+                      (test : sig (x : nat) (fib : fam {struct (x : x) })  → nat)
                        :=
-    struct (fam : {_x₁ => (_x₂ : nat) → nat}) 
-    (test : {total => {total @ fib} 0}) 
+    struct (fam : {_ => nat → nat}) (test : {total => {total @ fib} 0}) 
 
 cool-total-space.cooltt:28.7-28.20 [Info]:
-  def insert-fib-sg : sig (fam : (_x : sig (x : nat) ) → type) 
-                      (test : (_x : sig (x : nat) 
-                                    (fib : fam {struct (x : x) }) ) → nat)
+  def insert-fib-sg : sig (fam : sig (x : nat)  → type) 
+                      (test : sig (x : nat) (fib : fam {struct (x : x) })  → nat)
                        :=
-    struct (fam : {_x₁ => (_x₂ : nat) × nat}) 
-    (test : {total => fst {total @ fib}}) 
+    struct (fam : {_ => nat × nat}) (test : {total => fst {total @ fib}}) 
 
 cool-total-space.cooltt:33.7-33.27 [Info]:
-  def no-insert-fib-record : sig (fam : (_x : sig (x : nat) ) → type) 
-                             (test : (_x : sig (x : nat) 
-                                           (fib : fam {struct (x : x) }) ) → nat)
+  def no-insert-fib-record : sig (fam : sig (x : nat)  → type) 
+                             (test : sig (x : nat) 
+                                     (fib : fam {struct (x : x) })  → nat)
                               :=
-    struct (fam : {_x₁ => sig (y : nat) }) 
+    struct (fam : {_ => sig (y : nat) }) 
     (test : {total => {total @ fib} @ y}) 
 
 cool-total-space.cooltt:35.64-35.65 [Info]:
   Emitted hole:
     _ : [ ⊤ ]
-    fam : (_x : sig (x : nat) ) → type
+    fam : sig (x : nat)  → type
     |- ? : fam {struct (x : 0) }
 
 
@@ -1191,7 +1188,7 @@ cool-total-space.cooltt:35.64-35.65 [Info]:
 --------------------[elab.cooltt]--------------------
 elab.cooltt:7.11-7.24 [Info]:
   Computed normal form of boundary-test as
-   i _x => [ i = 1 => 5 | i = 0 => 19 ]
+   i _ => [ i = 1 => 5 | i = 0 => 19 ]
 
 elab.cooltt:18.11-18.23 [Info]:
   Computed normal form of pi-code-test as (x : nat) → nat
@@ -1219,7 +1216,7 @@ elab.cooltt:42.6-42.12 [Info]:
   Emitted hole:
     _ : [ ⊤ ]
     x : nat
-    |- ?hole1 : ext {i => nat} {i => i = 0 ∨ i = 1} {i _x =>
+    |- ?hole1 : ext {i => nat} {i => i = 0 ∨ i = 1} {i _ =>
                                                      [ i = 0 => x
                                                      | i = 1 => x
                                                      ]}
@@ -1230,40 +1227,39 @@ elab.cooltt:42.6-42.12 [Info]:
 --------------------[equation.cooltt]--------------------
 equation.cooltt:10.7-10.23 [Info]:
   def equational/trans : (a : type) → (x : a) → (y : a) → (z : a) → (p : 
-  ext {i => a} {i => i = 0 ∨ i = 1} {i _x => [ i = 0 => x | i = 1 => y ]}) → (q : 
-  ext {i => a} {i => i = 0 ∨ i = 1} {i _x => [ i = 0 => y | i = 1 => z ]}) → 
-  ext {i => a} {i => i = 0 ∨ i = 1} {i _x => [ i = 0 => x | i = 1 => z ]} :=
-    a x y z p q _x₁ =>
-    hcom a 0 1 {_x₁ = 0 ∨ _x₁ = 1}
-      {_x₂ _x₃ =>
-       [ _x₂ = 0 ∨ _x₁ = 0 => p _x₁
-       | _x₁ = 1 =>
-         hcom a 0 1 {_x₂ = 0 ∨ _x₂ = 1}
-           {_x₅ _x₆ => [ _x₅ = 0 ∨ _x₂ = 0 => q _x₂ | _x₂ = 1 => z ]}
+  ext {i => a} {i => i = 0 ∨ i = 1} {i _ => [ i = 0 => x | i = 1 => y ]}) → (q : 
+  ext {i => a} {i => i = 0 ∨ i = 1} {i _ => [ i = 0 => y | i = 1 => z ]}) → 
+  ext {i => a} {i => i = 0 ∨ i = 1} {i _ => [ i = 0 => x | i = 1 => z ]} :=
+    a x y z p q _ =>
+    hcom a 0 1 {_ = 0 ∨ _ = 1}
+      {_ _ =>
+       [ _ = 0 ∨ _ = 0 => p _
+       | _ = 1 =>
+         hcom a 0 1 {_ = 0 ∨ _ = 1}
+           {_ _ => [ _ = 0 ∨ _ = 0 => q _ | _ = 1 => z ]}
        ]}
 
 equation.cooltt:18.7-18.26 [Info]:
-  def equational/refl/nat : ext {i => nat} {i => i = 0 ∨ i = 1} {i _x =>
+  def equational/refl/nat : ext {i => nat} {i => i = 0 ∨ i = 1} {i _ =>
                                                                  [ i = 0 => 4
                                                                  | i = 1 => 4
                                                                  ]} :=
-    _x₁ =>
-    hcom nat 0 1 {_x₁ = 0 ∨ _x₁ = 1}
-      {_x₂ _x₃ => [ _x₂ = 0 ∨ _x₁ = 0 => 4 | _x₁ = 1 => 4 ]}
+    _ =>
+    hcom nat 0 1 {_ = 0 ∨ _ = 1} {_ _ => [ _ = 0 ∨ _ = 0 => 4 | _ = 1 => 4 ]}
 
 --------------------[evan.cooltt]--------------------
 --------------------[export.cooltt]--------------------
 export.cooltt:24.0-24.1 [Error]:
   Parse error near !
 
+--------------------[gronpoid.cooltt]--------------------
 --------------------[groupoid-laws.cooltt]--------------------
 groupoid-laws.cooltt:128.7-128.11 [Info]:
   def test : (A : type) → (p : (i : 𝕀) → A) → (q : (i : 𝕀) → sub A {i = 0}
                                                                    {p 1}) → (r : (i : 𝕀) → 
   sub A {i = 0} {q 1}) → (s : (i : 𝕀) → sub A {i = 0} {r 1}) → (j : 𝕀) → 
-  ext {i => A} {i => i = 0 ∨ i = 1} {i _x => [ i = 0 => p 0 | i = 1 => r 1 ]} :=
-    A p q r s j _x₁ =>
-    assoc A {_x₂ => p _x₂} ⊥ {_x₂ => q _x₂} ⊥ {_x₂ => r _x₂} j _x₁
+  ext {i => A} {i => i = 0 ∨ i = 1} {i _ => [ i = 0 => p 0 | i = 1 => r 1 ]} :=
+    A p q r s j _ => assoc A {_ => p _} ⊥ {_ => q _} ⊥ {_ => r _} j _
 
 --------------------[hcom-type.cooltt]--------------------
 hcom-type.cooltt:16.3-16.8 [Info]:
@@ -1314,7 +1310,7 @@ holes.cooltt:5.7-5.13 [Info]:
   Emitted hole:
     _ : [ ⊤ ]
     A : type
-    p : (_x : 𝕀) → A
+    p : 𝕀 → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
     |- ? : A
@@ -1329,17 +1325,17 @@ holes.cooltt:8.25-8.26 [Info]:
   Emitted hole:
     _ : [ ⊤ ]
     A : type
-    p : (_x : 𝕀) → A
+    p : 𝕀 → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
-    |- ? : (_x : 𝕀) → A
+    |- ? : 𝕀 → A
 
 
 holes.cooltt:8.27-8.28 [Info]:
   Emitted hole:
     _ : [ ⊤ ]
     A : type
-    p : (_x : 𝕀) → A
+    p : 𝕀 → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
     |- ? : (i₁ : 𝕀) → sub A {i₁ = 0} {#2 * A p q i 1}
@@ -1349,7 +1345,7 @@ holes.cooltt:8.7-8.35 [Info]:
   Emitted hole:
     _ : [ ⊤ ]
     A : type
-    p : (_x : 𝕀) → A
+    p : 𝕀 → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
     |- {! trans/filler A {#2 * A p q i} {#3 * A p q i} 1 i !} : A
@@ -1364,10 +1360,10 @@ holes.cooltt:11.7-11.35 [Info]:
   Emitted hole:
     _ : [ ⊤ ]
     A : type
-    p : (_x : 𝕀) → A
+    p : 𝕀 → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
-    |- {! trans/filler A {_x => p _x} {_x => q _x} 0 i !} : A
+    |- {! trans/filler A {_ => p _} {_ => q _} 0 i !} : A
     
     Boundary (unsatisfied):
     i = 0 ∨ i = 1
@@ -1379,10 +1375,10 @@ holes.cooltt:14.7-14.35 [Info]:
   Emitted hole:
     _ : [ ⊤ ]
     A : type
-    p : (_x : 𝕀) → A
+    p : 𝕀 → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
-    |- {! trans/filler A {_x => p _x} {_x => q _x} 1 i !} : A
+    |- {! trans/filler A {_ => p _} {_ => q _} 1 i !} : A
     
     Boundary (satisfied):
     i = 0 ∨ i = 1
@@ -1394,15 +1390,15 @@ holes.cooltt:18.26-18.30 [Info]:
   Emitted hole:
     _ : [ ⊤ ]
     A : type
-    p : (_x : 𝕀) → A
+    p : 𝕀 → A
     q : (i : 𝕀) → sub A {i = 0} {p 1}
     i : 𝕀
-    |- ? : (_x : 𝕀) → (_ : [ _x = 0 ∨ i = 0 ∨ i = 1 ]) → A
+    |- ? : 𝕀 → [ _ = 0 ∨ i = 0 ∨ i = 1 ] → A
 
 
 holes.cooltt:17.5-18.30 [Info]:
   Failure encountered, as expected:
-   Expected hcom A 0 1 {i = 0 ∨ i = 1} {_x₂ _x₃ => #10 * A p q i _x₂ *} =
+   Expected hcom A 0 1 {i = 0 ∨ i = 1} {_ _ => #10 * A p q i _ *} =
             [ i = 0 ∨ i = 1 => [ i = 0 => p 0 | i = 1 => q 1 ] ]
             : A
 
@@ -1415,7 +1411,7 @@ import.cooltt:23.0-23.1 [Error]:
 
 --------------------[inequality.cooltt]--------------------
 inequality.cooltt:11.7-11.10 [Info]:
-  def bar : ext nat ⊤ {_x => [ ⊤ => 0 ]} :=
+  def bar : ext nat ⊤ {_ => [ ⊤ => 0 ]} :=
     [ ⊤ => 0 ]
 
 --------------------[isos.cooltt]--------------------
@@ -1427,57 +1423,52 @@ nat.cooltt:13.11-13.16 [Info]:
   Computed normal form of + 2 3 as 5
 
 monoid.cooltt:19.7-19.17 [Info]:
-  def monoid/nat : sig (C : ext type ⊤ {_x => nat}) 
-                   (op : (_x : nat) → (_x₁ : nat) → nat) (z : nat) 
+  def monoid/nat : sig (C : ext type ⊤ {_ => nat}) (op : nat → nat → nat) 
+                   (z : nat) 
                    (idL : (x : nat) → ext {i => nat} {i => i = 0 ∨ i = 1} {
-                                      i _x =>
-                                      [ i = 0 => op z x | i = 1 => x ]})
+                                      i _ => [ i = 0 => op z x | i = 1 => x ]})
                    (idR : (x : nat) → ext {i => nat} {i => i = 0 ∨ i = 1} {
-                                      i _x =>
-                                      [ i = 0 => op x z | i = 1 => x ]})
+                                      i _ => [ i = 0 => op x z | i = 1 => x ]})
                    (assoc : (a : nat) → (b : nat) → (c : nat) → ext {
                                                                 i => nat} {
                                                                 i =>
                                                                 i = 0 ∨ i = 1} {
-                                                                i _x =>
+                                                                i _ =>
                                                                 [ i = 0 =>
                                                                   op {op a b} c
                                                                 | i = 1 =>
                                                                   op a {op b c}
                                                                 ]})
                     :=
-    struct (C : nat) (op : {_x₁ _x₂ => + _x₁ _x₂}) (z : 0) 
-    (idL : {_x₁ _x₂ => +-left-unit _x₁ _x₂}) 
-    (idR : {_x₁ _x₂ => +-right-unit _x₁ _x₂}) 
-    (assoc : {_x₁ _x₂ _x₃ _x₄ => +-assoc _x₁ _x₂ _x₃ _x₄}) 
+    struct (C : nat) (op : {_ _ => + _ _}) (z : 0) 
+    (idL : {_ _ => +-left-unit _ _}) (idR : {_ _ => +-right-unit _ _}) 
+    (assoc : {_ _ _ _ => +-assoc _ _ _ _}) 
 
 monoid.cooltt:27.7-27.19 [Info]:
-  def monoid/nat/+ : sig (C : ext type ⊤ {_x => nat}) 
-                     (op : ext {(_x : nat) → (_x₁ : nat) → nat} ⊤ {_x _x₁ _x₂ =>
-                                                                   + _x₁ _x₂})
+  def monoid/nat/+ : sig (C : ext type ⊤ {_ => nat}) 
+                     (op : ext {nat → nat → nat} ⊤ {_ _ _ => + _ _}) 
                      (z : nat) 
                      (idL : (x : nat) → ext {i => nat} {i => i = 0 ∨ i = 1} {
-                                        i _x =>
+                                        i _ =>
                                         [ i = 0 => + z x | i = 1 => x ]})
                      (idR : (x : nat) → ext {i => nat} {i => i = 0 ∨ i = 1} {
-                                        i _x =>
+                                        i _ =>
                                         [ i = 0 => + x z | i = 1 => x ]})
                      (assoc : (a : nat) → (b : nat) → (c : nat) → ext {
                                                                   i => 
                                                                   nat} {
                                                                   i =>
                                                                   i = 0 ∨ i = 1} {
-                                                                  i _x =>
+                                                                  i _ =>
                                                                   [ i = 0 =>
                                                                     + {+ a b} c
                                                                   | i = 1 =>
                                                                     + a {+ b c}
                                                                   ]})
                       :=
-    struct (C : nat) (op : {_x₁ _x₂ => + _x₁ _x₂}) (z : 0) 
-    (idL : {_x₁ _x₂ => +-left-unit _x₁ _x₂}) 
-    (idR : {_x₁ _x₂ => +-right-unit _x₁ _x₂}) 
-    (assoc : {_x₁ _x₂ _x₃ _x₄ => +-assoc _x₁ _x₂ _x₃ _x₄}) 
+    struct (C : nat) (op : {_ _ => + _ _}) (z : 0) 
+    (idL : {_ _ => +-left-unit _ _}) (idR : {_ _ => +-right-unit _ _}) 
+    (assoc : {_ _ _ _ => +-assoc _ _ _ _}) 
 
 --------------------[names.cooltt]--------------------
 names.cooltt:5.7-5.14 [Info]:
@@ -1495,9 +1486,9 @@ nat-path.cooltt:17.11-17.12 [Info]:
   Computed normal form of J as
    A p C d =>
    coe {i =>
-        C {_x =>
-           hcom A 0 _x {i = 0 ∨ i = 1}
-             {k _x₁ => [ k = 0 ∨ i = 0 => p 0 | i = 1 => p k ]}}} 0 1
+        C {_ =>
+           hcom A 0 _ {i = 0 ∨ i = 1}
+             {k _ => [ k = 0 ∨ i = 0 => p 0 | i = 1 => p k ]}}} 0 1
      d
 
 nat-path.cooltt:58.11-58.18 [Info]:
@@ -1505,107 +1496,99 @@ nat-path.cooltt:58.11-58.18 [Info]:
 
 nat-path.cooltt:61.11-61.18 [Info]:
   Computed normal form of +-assoc as
-   _x =>
-   elim _x @ {_x₁ =>
-              (y : nat) → (z : nat) → ext {i => nat} {i => i = 0 ∨ i = 1} {
-                                      i _x₂ =>
-                                      [ i = 0 =>
-                                        elim {elim _x₁ @ {_x₄ =>
-                                                          (_x₅ : nat) → nat}
-                                                [ zero => n => n
-                                                | suc => _x₄ ih n =>
-                                                         suc {ih n}
-                                                ] y} @ {_x₄ =>
-                                                        (_x₅ : nat) → nat}
-                                          [ zero => n => n
-                                          | suc => _x₄ ih n => suc {ih n}
-                                          ] z
-                                      | i = 1 =>
-                                        elim _x₁ @ {_x₄ => (_x₅ : nat) → nat}
-                                          [ zero => n => n
-                                          | suc => _x₄ ih n => suc {ih n}
-                                          ] {elim y @ {_x₄ =>
-                                                       (_x₅ : nat) → nat}
+   _ =>
+   elim _ @ {_ =>
+             (y : nat) → (z : nat) → ext {i => nat} {i => i = 0 ∨ i = 1} {
+                                     i _ =>
+                                     [ i = 0 =>
+                                       elim {elim _ @ {_ => nat → nat}
                                                [ zero => n => n
-                                               | suc => _x₄ ih n =>
-                                                        suc {ih n}
-                                               ] z}
-                                      ]}}
-     [ zero => y z _x₁ =>
-               hcom nat 0 1 {_x₁ = 0 ∨ _x₁ = 1}
-                 {_x₂ _x₃ =>
-                  [ _x₂ = 0 ∨ _x₁ = 0 =>
-                    elim y @ {_x₅ => (_x₆ : nat) → nat}
+                                               | suc => _ ih n => suc {ih n}
+                                               ] y} @ {_ => nat → nat}
+                                         [ zero => n => n
+                                         | suc => _ ih n => suc {ih n}
+                                         ] z
+                                     | i = 1 =>
+                                       elim _ @ {_ => nat → nat}
+                                         [ zero => n => n
+                                         | suc => _ ih n => suc {ih n}
+                                         ] {elim y @ {_ => nat → nat}
+                                              [ zero => n => n
+                                              | suc => _ ih n => suc {ih n}
+                                              ] z}
+                                     ]}}
+     [ zero => y z _ =>
+               hcom nat 0 1 {_ = 0 ∨ _ = 1}
+                 {_ _ =>
+                  [ _ = 0 ∨ _ = 0 =>
+                    elim y @ {_ => nat → nat}
                       [ zero => n => n
-                      | suc => _x₅ ih n => suc {ih n}
+                      | suc => _ ih n => suc {ih n}
                       ] z
-                  | _x₁ = 1 =>
-                    hcom nat 0 1 {_x₂ = 0 ∨ _x₂ = 1}
-                      {_x₅ _x₆ =>
-                       [ _x₅ = 0 ∨ _x₂ = 0 =>
-                         symm nat {_x₈ =>
-                                   elim y @ {_x₉ => (_x₁₀ : nat) → nat}
+                  | _ = 1 =>
+                    hcom nat 0 1 {_ = 0 ∨ _ = 1}
+                      {_ _ =>
+                       [ _ = 0 ∨ _ = 0 =>
+                         symm nat {_ =>
+                                   elim y @ {_ => nat → nat}
                                      [ zero => n => n
-                                     | suc => _x₉ ih n => suc {ih n}
-                                     ] z} _x₂
-                       | _x₂ = 1 =>
-                         elim y @ {_x₈ => (_x₉ : nat) → nat}
+                                     | suc => _ ih n => suc {ih n}
+                                     ] z} _
+                       | _ = 1 =>
+                         elim y @ {_ => nat → nat}
                            [ zero => n => n
-                           | suc => _x₈ ih n => suc {ih n}
+                           | suc => _ ih n => suc {ih n}
                            ] z
                        ]}
                   ]}
-     | suc => x ih y z _x₁ =>
-              hcom nat 0 1 {_x₁ = 0 ∨ _x₁ = 1}
-                {_x₂ _x₃ =>
-                 [ _x₂ = 0 ∨ _x₁ = 0 =>
-                   suc {elim {elim x @ {_x₅ => (_x₆ : nat) → nat}
+     | suc => x ih y z _ =>
+              hcom nat 0 1 {_ = 0 ∨ _ = 1}
+                {_ _ =>
+                 [ _ = 0 ∨ _ = 0 =>
+                   suc {elim {elim x @ {_ => nat → nat}
                                 [ zero => n => n
-                                | suc => _x₅ ih₁ n => suc {ih₁ n}
-                                ] y} @ {_x₅ => (_x₆ : nat) → nat}
+                                | suc => _ ih₁ n => suc {ih₁ n}
+                                ] y} @ {_ => nat → nat}
                           [ zero => n => n
-                          | suc => _x₅ ih₁ n => suc {ih₁ n}
+                          | suc => _ ih₁ n => suc {ih₁ n}
                           ] z}
-                 | _x₁ = 1 =>
-                   hcom nat 0 1 {_x₂ = 0 ∨ _x₂ = 1}
-                     {_x₅ _x₆ =>
-                      [ _x₅ = 0 ∨ _x₂ = 0 =>
-                        suc {elim {elim x @ {_x₈ => (_x₉ : nat) → nat}
+                 | _ = 1 =>
+                   hcom nat 0 1 {_ = 0 ∨ _ = 1}
+                     {_ _ =>
+                      [ _ = 0 ∨ _ = 0 =>
+                        suc {elim {elim x @ {_ => nat → nat}
                                      [ zero => n => n
-                                     | suc => _x₈ ih₁ n => suc {ih₁ n}
-                                     ] y} @ {_x₈ => (_x₉ : nat) → nat}
+                                     | suc => _ ih₁ n => suc {ih₁ n}
+                                     ] y} @ {_ => nat → nat}
                                [ zero => n => n
-                               | suc => _x₈ ih₁ n => suc {ih₁ n}
+                               | suc => _ ih₁ n => suc {ih₁ n}
                                ] z}
-                      | _x₂ = 1 =>
-                        hcom nat 0 1 {_x₅ = 0 ∨ _x₅ = 1}
-                          {_x₈ _x₉ =>
-                           [ _x₈ = 0 ∨ _x₅ = 0 => suc {ih y z _x₅}
-                           | _x₅ = 1 =>
-                             hcom nat 0 1 {_x₈ = 0 ∨ _x₈ = 1}
-                               {_x₁₁ _x₁₂ =>
-                                [ _x₁₁ = 0 ∨ _x₈ = 0 =>
-                                  symm nat {_x₁₄ =>
-                                            suc {elim x @ {_x₁₅ =>
-                                                           (_x₁₆ : nat) → nat}
+                      | _ = 1 =>
+                        hcom nat 0 1 {_ = 0 ∨ _ = 1}
+                          {_ _ =>
+                           [ _ = 0 ∨ _ = 0 => suc {ih y z _}
+                           | _ = 1 =>
+                             hcom nat 0 1 {_ = 0 ∨ _ = 1}
+                               {_ _ =>
+                                [ _ = 0 ∨ _ = 0 =>
+                                  symm nat {_ =>
+                                            suc {elim x @ {_ => nat → nat}
                                                    [ zero => n => n
-                                                   | suc => _x₁₅ ih₁ n =>
+                                                   | suc => _ ih₁ n =>
                                                             suc {ih₁ n}
-                                                   ] {elim y @ {_x₁₅ =>
-                                                                (_x₁₆ : nat) → nat}
+                                                   ] {elim y @ {_ =>
+                                                                nat → nat}
                                                         [ zero => n => n
-                                                        | suc => _x₁₅ ih₁ n =>
+                                                        | suc => _ ih₁ n =>
                                                                  suc {ih₁ n}
-                                                        ] z}}} _x₈
-                                | _x₈ = 1 =>
-                                  suc {elim x @ {_x₁₄ => (_x₁₅ : nat) → nat}
+                                                        ] z}}} _
+                                | _ = 1 =>
+                                  suc {elim x @ {_ => nat → nat}
                                          [ zero => n => n
-                                         | suc => _x₁₄ ih₁ n => suc {ih₁ n}
-                                         ] {elim y @ {_x₁₄ =>
-                                                      (_x₁₅ : nat) → nat}
+                                         | suc => _ ih₁ n => suc {ih₁ n}
+                                         ] {elim y @ {_ => nat → nat}
                                               [ zero => n => n
-                                              | suc => _x₁₄ ih₁ n =>
-                                                       suc {ih₁ n}
+                                              | suc => _ ih₁ n => suc {ih₁ n}
                                               ] z}}
                                 ]}
                            ]}
@@ -1626,18 +1609,16 @@ nat-path.cooltt:65.11-65.26 [Info]:
 nat-path.cooltt:87.11-87.15 [Info]:
   Computed normal form of test as
    p i =>
-   elim {symm nat {_x => p _x} i} @ {_x => nat}
-     [ zero => 0
-     | suc => _x _x₁ => 0
-     ]
+   elim {symm nat {_ => p _} i} @ {_ => nat} [ zero => 0
+                                             | suc => _ _ => 0
+                                             ]
 
 nat-path.cooltt:89.11-89.16 [Info]:
   Computed normal form of test2 as
    i =>
-   elim {symm nat {_x => 0} i} @ {_x => nat}
-     [ zero => 0
-     | suc => _x _x₁ => 0
-     ]
+   elim {symm nat {_ => 0} i} @ {_ => nat} [ zero => 0
+                                           | suc => _ _ => 0
+                                           ]
 
 --------------------[nat.cooltt]--------------------
 nat.cooltt:10.11-10.16 [Info]:
@@ -1669,54 +1650,52 @@ patch.cooltt:10.57-10.58 [Info]:
 
 patch.cooltt:12.7-12.15 [Info]:
   def el-patch : type :=
-    sig (A : ext type ⊤ {_x₁ => nat}) (a : ext nat ⊤ {_x₁ => 4}) 
+    sig (A : ext type ⊤ {_ => nat}) (a : ext nat ⊤ {_ => 4}) 
 
 patch.cooltt:13.7-13.23 [Info]:
   def el-patch-partial : type :=
-    sig (A : ext type ⊤ {_x₁ => nat}) (a : nat) 
+    sig (A : ext type ⊤ {_ => nat}) (a : nat) 
 
 patch.cooltt:14.7-14.20 [Info]:
-  def patch/inhabit : sig (A : ext type ⊤ {_x => nat}) 
-                      (a : ext nat ⊤ {_x => 4})  :=
+  def patch/inhabit : sig (A : ext type ⊤ {_ => nat}) 
+                      (a : ext nat ⊤ {_ => 4})  :=
     struct (A : nat) (a : 4) 
 
 patch.cooltt:15.7-15.34 [Info]:
-  def patch-partial/inhabit/infer : sig (A : ext type ⊤ {_x => nat}) 
-                                    (a : nat)  :=
+  def patch-partial/inhabit/infer : sig (A : ext type ⊤ {_ => nat}) (a : nat)  :=
     struct (A : nat) (a : 4) 
 
 patch.cooltt:16.7-16.26 [Info]:
-  def patch/inhabit/infer : sig (A : ext type ⊤ {_x => nat}) 
-                            (a : ext nat ⊤ {_x => 4})  :=
+  def patch/inhabit/infer : sig (A : ext type ⊤ {_ => nat}) 
+                            (a : ext nat ⊤ {_ => 4})  :=
     struct (A : nat) (a : 4) 
 
 patch.cooltt:19.7-19.20 [Info]:
   def patch-depends : type :=
-    sig (A : ext type ⊤ {_x₁ => nat}) (B : ext type ⊤ {_x₁ => nat}) 
+    sig (A : ext type ⊤ {_ => nat}) (B : ext type ⊤ {_ => nat}) 
 
 patch.cooltt:25.7-25.14 [Info]:
-  def testing : (A : type) → (Z : type) → (B : (_x : A) → type) → (p : (_x : Z) → 
-  sig (x : A) (bx : B x) ) → (z : Z) → sig (x : ext A ⊤ {_x => p z @ x}) 
-                                       (bx : ext {B {p z @ x}} ⊤ {_x =>
-                                                                  p z @ bx})
-                                        :=
+  def testing : (A : type) → (Z : type) → (B : A → type) → (p : Z → sig (x : A)
+                                                                    (bx : B x)
+                                                                    ) → (z : Z) → 
+  sig (x : ext A ⊤ {_ => p z @ x}) (bx : ext {B {p z @ x}} ⊤ {_ => p z @ bx})  :=
     A Z B p z => struct (x : p z @ x) (bx : p z @ bx) 
 
 patch.cooltt:28.5-28.88 [Info]:
   Failure encountered, as expected:
-   Expected type = (_x₁ : sig (A : type) (a : A) ) → (_x₂ : nat) → type
+   Expected type = sig (A : type) (a : A)  → nat → type
 
 
 patch.cooltt:57.7-57.16 [Info]:
-  def test-auto : (fam : (_x : sig (x : nat) ) → type) → type :=
+  def test-auto : (fam : sig (x : nat)  → type) → type :=
     fam => sig (x : nat) (fib : fam {struct (x : x) }) 
 
 patch.cooltt:60.7-60.22 [Info]:
-  def test-auto-patch : (fam : (_x : sig (x : nat) ) → type) → type :=
-    fam => sig (x : ext nat ⊤ {_x₁ => 0}) (fib : fam {struct (x : 0) }) 
+  def test-auto-patch : (fam : sig (x : nat)  → type) → type :=
+    fam => sig (x : ext nat ⊤ {_ => 0}) (fib : fam {struct (x : 0) }) 
 
 patch.cooltt:64.7-64.24 [Info]:
-  def test-unfold-total : (fam : (_x : sig (x : nat) ) → type) → type :=
+  def test-unfold-total : (fam : sig (x : nat)  → type) → type :=
     fam => sig (x : nat) (fib : fam {struct (x : x) }) 
 
 [Warn]:  There are 2 unsolved holes
@@ -1725,7 +1704,7 @@ patch.cooltt:64.7-64.24 [Info]:
 path-types.cooltt:8.11-8.20 [Info]:
   Computed normal form of formation as
    A a b =>
-   ext {i => A i} {i => i = 0 ∨ i = 1} {i _x => [ i = 0 => a | i = 1 => b ]}
+   ext {i => A i} {i => i = 0 ∨ i = 1} {i _ => [ i = 0 => a | i = 1 => b ]}
 
 path-types.cooltt:21.11-21.17 [Info]:
   Computed normal form of myrefl as A a i => a
@@ -1740,10 +1719,10 @@ path-types.cooltt:55.11-55.18 [Info]:
 --------------------[record.cooltt]--------------------
 record.cooltt:11.7-11.12 [Info]:
   def basic : type :=
-    sig (foo∷x : nat) (bar : (_x₁ : nat) → nat) 
+    sig (foo∷x : nat) (bar : nat → nat) 
 
 record.cooltt:12.7-12.21 [Info]:
-  def basic∷inhabit : sig (foo∷x : nat) (bar : (_x : nat) → nat)  :=
+  def basic∷inhabit : sig (foo∷x : nat) (bar : nat → nat)  :=
     struct (foo∷x : 1) (bar : {x => suc x}) 
 
 record.cooltt:13.11-13.25 [Info]:
@@ -1758,7 +1737,7 @@ record.cooltt:15.11-15.31 [Info]:
 
 record.cooltt:32.7-32.13 [Info]:
   def depend : type :=
-    sig (tp : type) (fun : (_x₁ : tp) → tp) 
+    sig (tp : type) (fun : tp → tp) 
 
 --------------------[repack.cooltt]--------------------
 repack.cooltt:12.0-12.1 [Error]:
@@ -1786,41 +1765,40 @@ Emitted namespace under ∷
 
 --------------------[selfification.cooltt]--------------------
 selfification.cooltt:8.11-8.18 [Info]:
-  Computed normal form of testing as
-   _x _x₁ _x₂ p _x₃ => [ fst {p _x₃} , snd {p _x₃} ]
+  Computed normal form of testing as _ _ _ p _ => [ fst {p _} , snd {p _} ]
 
 --------------------[v.cooltt]--------------------
 v.cooltt:12.11-12.17 [Info]:
   Computed normal form of v-test as
    r A =>
-   V r {_x => A} A {_x =>
-                    [ x => x
-                    , x =>
-                      [ [ x , _x₁ => x ]
-                      , p i =>
-                        [ hcom A 1 0 {i = 0 ∨ i = 1}
-                            {k _x₁ =>
-                             [ k = 1 => x | i = 1 => snd p k | i = 0 => x ]}
-                        , _x₁ =>
-                          hcom A 1 _x₁ {i = 0 ∨ i = 1}
-                            {k _x₂ =>
-                             [ k = 1 => x | i = 1 => snd p k | i = 0 => x ]}
-                        ]
-                      ]
-                    ]}
+   V r {_ => A} A {_ =>
+                   [ x => x
+                   , x =>
+                     [ [ x , _ => x ]
+                     , p i =>
+                       [ hcom A 1 0 {i = 0 ∨ i = 1}
+                           {k _ =>
+                            [ k = 1 => x | i = 1 => snd p k | i = 0 => x ]}
+                       , _ =>
+                         hcom A 1 _ {i = 0 ∨ i = 1}
+                           {k _ =>
+                            [ k = 1 => x | i = 1 => snd p k | i = 0 => x ]}
+                       ]
+                     ]
+                   ]}
 
 v.cooltt:20.11-20.15 [Info]:
-  Computed normal form of cool as A a => coe {_x => A} 0 1 a
+  Computed normal form of cool as A a => coe {_ => A} 0 1 a
 
 v.cooltt:21.11-21.16 [Info]:
   Computed normal form of cool2 as
    A a i =>
    hcom A 0 1 {i = 0}
-     {_x _x₁ =>
-      [ _x = 0 => coe {_x₃ => A} i 0 a
+     {_ _ =>
+      [ _ = 0 => coe {_ => A} i 0 a
       | i = 0 =>
-        hcom A 1 0 {_x = 0 ∨ _x = 1}
-          {k _x₃ => [ k = 1 => a | _x = 1 => a | _x = 0 => a ]}
+        hcom A 1 0 {_ = 0 ∨ _ = 1}
+          {k _ => [ k = 1 => a | _ = 1 => a | _ = 0 => a ]}
       ]}
 
 v.cooltt:27.11-27.16 [Info]:


### PR DESCRIPTION
## Patch Description

This is just a minor tweak to the pretty printer that prevents us from printing trash like `(_x : A) -> B`