### PR TITLE
🙅 Delete true cofibration splits when quoting

### DIFF
--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -54,21 +54,37 @@ let rec quote_con (tp : D.tp) con =
   | D.TpPrf _, _ ->
     ret S.Prf
   | _, D.Split branches ->
-    let quote_branch (phi, clo) =
-      lift_cmp @@ CmpM.test_sequent [phi] CofBuilder.bot |>> function
-      | false ->
-        let+ tphi = quote_cof phi
-        and+ tbdy =
-          bind_var (D.TpPrf phi) @@ fun prf ->
-          let* body = lift_cmp @@ inst_tm_clo clo prf in
-          quote_con tp body
-        in
-        Some (tphi, tbdy)
-      | true ->
-        ret None
+    let rec reduce_if_true = function
+      | [] -> ret None
+      | (phi,clo) :: branches ->
+      lift_cmp @@ CmpM.test_sequent [] phi |>> function
+        | true -> 
+          let* body = lift_cmp @@ inst_tm_clo clo D.Prf in
+          let+ s = quote_con tp body in
+          Some s
+        | false -> reduce_if_true branches
     in
-    let* tbranches = MU.filter_map quote_branch branches in
-    ret @@ S.CofSplit tbranches
+    let* reduced = reduce_if_true branches in
+    begin
+    match reduced with
+      | Some e -> ret e
+      | None ->
+        let quote_branch (phi, clo) =
+          lift_cmp @@ CmpM.test_sequent [phi] CofBuilder.bot |>> function
+          | false ->
+            let+ tphi = quote_cof phi
+            and+ tbdy =
+              bind_var (D.TpPrf phi) @@ fun prf ->
+              let* body = lift_cmp @@ inst_tm_clo clo prf in
+              quote_con tp body
+            in
+            Some (tphi, tbdy)
+          | true ->
+            ret None
+        in
+        let* tbranches = MU.filter_map quote_branch branches in
+        ret @@ S.CofSplit tbranches
+    end
 
   | _, D.Cut {cut = (D.Var lvl, []); tp = TpDim} ->
     (* for dimension variables, check to see if we can prove them to be

--- a/src/core/Quote.ml
+++ b/src/core/Quote.ml
@@ -57,7 +57,7 @@ let rec quote_con (tp : D.tp) con =
     let rec reduce_if_true = function
       | [] -> ret None
       | (phi,clo) :: branches ->
-      lift_cmp @@ CmpM.test_sequent [] phi |>> function
+        lift_cmp @@ CmpM.test_sequent [] phi |>> function
         | true -> 
           let* body = lift_cmp @@ inst_tm_clo clo D.Prf in
           let+ s = quote_con tp body in
@@ -66,7 +66,7 @@ let rec quote_con (tp : D.tp) con =
     in
     let* reduced = reduce_if_true branches in
     begin
-    match reduced with
+      match reduced with
       | Some e -> ret e
       | None ->
         let quote_branch (phi, clo) =

--- a/src/core/Semantics.mli
+++ b/src/core/Semantics.mli
@@ -13,7 +13,10 @@ type 'a whnf = [`Done | `Reduce of 'a]
 val whnf_con : D.con -> D.con whnf compute
 val whnf_cut : D.cut -> D.con whnf compute
 val whnf_hd : D.hd -> D.con whnf compute
+val whnf_con_branches : (D.cof * D.tm_clo) list -> D.con whnf compute
 val whnf_tp : D.tp -> D.tp whnf compute
+val whnf_tp_branches : (D.cof * D.tp_clo) list -> D.tp whnf compute
+
 
 val whnf_tp_ : D.tp -> D.tp compute
 val whnf_con_ : D.con -> D.con compute

--- a/test/test.expected
+++ b/test/test.expected
@@ -1294,8 +1294,7 @@ hcom-type.cooltt:16.13-16.14 [Info]:
     
     Boundary:
     i = 0 ∨ i = 0 ∨ i = 1
-    |- i = 0 => #3 * 0 *
-       i = 0 => ?asdf * 0 *
+    |- i = 0 => ?asdf * 0 *
        i = 1 => ?asdf * 1 *
 
 
@@ -1403,7 +1402,7 @@ holes.cooltt:18.26-18.30 [Info]:
 holes.cooltt:17.5-18.30 [Info]:
   Failure encountered, as expected:
    Expected hcom A 0 1 {i = 0 ∨ i = 1} {_x₂ _x₃ => #10 * A p q i _x₂ *} =
-            [ i = 0 ∨ i = 1 => [ i = 0 => p 0 | i = 1 => q 1 ] ]
+            [ i = 0 => p 0 | i = 1 => q 1 ]
             : A
 
 
@@ -1415,8 +1414,8 @@ import.cooltt:23.0-23.1 [Error]:
 
 --------------------[inequality.cooltt]--------------------
 inequality.cooltt:11.7-11.10 [Info]:
-  def bar : ext nat ⊤ {_x => [ ⊤ => 0 ]} :=
-    [ ⊤ => 0 ]
+  def bar : ext nat ⊤ {_x => 0} :=
+    0
 
 --------------------[isos.cooltt]--------------------
 --------------------[monoid.cooltt]--------------------


### PR DESCRIPTION
This PR updates the behavior of quoting on cofibration splits, now if `φ` is true, `[ φ => e ]` is quoted as `e`. This simplifies the display of some terms and boundary conditions. For instance, with this change, a boundary that was previously displayed as
```
Boundary:
j = 0 ∨ j = 1 ∨ i = 0 ∨ i = 1
|- i = 0 => sq 0 0
   i = 1 => sq 0 0
   ⊤ => sq 0 0
   ⊤ => sq 0 0
   ⊤ => sq 0 0
   ⊤ => sq 0 0
   ⊤ => sq 0 0
   i = 0 => sq 0 1
   i = 1 => sq 0 1
   ⊤ => sq 0 1
   ⊤ => sq 0 1
   ⊤ => sq 0 1
   ⊤ => sq 0 1
   ⊤ => sq 0 1
   i = 0 => sq 0 j
   i = 1 => sq 0 j
```
becomes
```
Boundary:
j = 0 ∨ j = 1 ∨ i = 0 ∨ i = 1
|- j = 0 => sq 0 0
   j = 1 => sq 0 1
   i = 0 => sq 0 j
   i = 1 => sq 0 j
```