### PR TITLE
🪜 Refactor HLevel code using records

### DIFF
--- a/test/hlevel.cooltt
+++ b/test/hlevel.cooltt
@@ -1,95 +1,109 @@
 import prelude
 
-def is-contr (C : type) : type :=
-  (c : C) × {(c' : C) → path C c c'}
-
-def is-prop (C : type) : type :=
-  (c : C) (c' : C) → path C c c'
 
 abstract
 def has-hlevel : nat → type → type :=
   let aux : nat → type → type :=
     elim [
-    | zero => is-prop
+    | zero => A => (a a' : A) → path A a a'
     | suc {l => ih} =>
       A => (a : A) (a' : A) → ih {path A a a'}
     ]
   in
   elim [
-  | zero => is-contr
-  | suc l => aux l
+    | zero => A => sig [pt : A, path : (pt' : A) → path A pt pt']
+    | suc l => A => aux l A
   ]
 
-def is-set : type → type := has-hlevel 2
-def is-groupoid : type → type := has-hlevel 3
+def htype : type :=
+  sig
+    def lvl : nat
+    def tp : type
+    def prf : has-hlevel lvl tp
+  end
 
-def hLevel (n : nat) : type :=
-  (A : type) × has-hlevel n A
+def contr : type :=  htype # [lvl := 0]
+def prop : type := htype # [lvl := 1]
+def set : type := htype # [lvl := 2]
+def groupoid : type := htype # [lvl := 3]
 
-def hProp : type := hLevel 1
-def hSet : type := hLevel 2
-def hGroupoid : type := hLevel 3
-
-#print hProp
-#normalize hProp
-
-abstract
-def contr-prop (A : type) (A/contr : is-contr A) : is-prop A :=
-  a a' => trans A {symm A {{snd A/contr} a}} {{snd A/contr} a'}
+#print prop
+#normalize prop
 
 abstract
-unfold has-hlevel
-def prop-set (A : type) (A/prop : is-prop A) : is-set A :=
-  a b p q i j =>
-  hcom A 0 1 {∂ i ∨ ∂ j} {k =>
-    [ k=0 ∨ ∂ j ∨ i=0 => A/prop a {p j} k
-    | i=1 => A/prop a {q j} k
-    ]
-  }
+def contr-prop (A : contr) : prop # [tp := A.tp] := 
+  open A in
+  struct
+    def prf := unfold has-hlevel in pt pt' => trans tp {symm tp {prf.path pt}} {prf.path pt'}
+  end 
 
 abstract
-unfold has-hlevel
-def raise-hlevel : (l : nat) (A : type) → has-hlevel l A → has-hlevel {suc l} A :=
-  let aux : (m : nat) → (B : type) → has-hlevel {suc m} B → has-hlevel {suc {suc m}} B :=
-    elim [
-    | zero => prop-set
-    | suc {l => ih} => B B/lvl b b' => ih {path B b b'} {B/lvl b b'}
-    ]
-  in
-  elim [
-  | zero => contr-prop
-  | suc l => aux l
-  ]
-
-abstract
-unfold has-hlevel
-def prop-hlevel : (l : nat) (A : type) → is-prop A → has-hlevel {suc l} A :=
-  elim [
-  | zero => _ A/prop => A/prop
-  | suc {l => ih} => A A/prop => raise-hlevel {suc l} A {ih A A/prop}
-  ]
-
-abstract
-unfold has-hlevel
-def path-hlevel
-  : (l : nat) (A : type) (A/level : has-hlevel {suc l} A) (a : A) (a' : A)
-  → has-hlevel l {path A a a'}
-:=
-  elim [
-  | zero => A A/prop a a' => [A/prop a a', p => prop-set A A/prop a a' {A/prop a a'} p]
-  | suc l => A A/lvl a a' => A/lvl a a'
-  ]
-
-abstract
-def path-based-contr (A : type) (a : A) : is-contr {(x : A) × path A a x} :=
-  [ [a, i => a]
-  , x i =>
-    let aux : 𝕀 → A := j =>
-      hcom A 0 j {∂ i} {k =>
-        [ k=0 ∨ i=0 => a
-        | i=1 => {snd x} k
+def prop-set (A : prop) : set # [tp := A.tp] :=
+  open A in
+  struct
+    def prf := unfold has-hlevel in a b p q i j => 
+      hcom tp 0 1 {∂ i ∨ ∂ j} {k =>
+        [ k=0 ∨ ∂ j ∨ i=0 => prf a {p j} k
+        | i=1 => prf a {q j} k
         ]
       }
-    in
-    [aux 1, aux]
+  end
+
+abstract
+def raise-hlevel (A : htype) : htype # [lvl := suc {A.lvl}, tp := A.tp] :=
+  let aux : (m : nat) (B : htype # [lvl := suc m]) → htype # [lvl := suc {suc m}, tp := B.tp] :=
+    elim [
+    | zero => prop-set
+    | suc {l => ih} => B => 
+      unfold has-hlevel in 
+      struct 
+        def prf := b b' => {ih {struct [tp := path {B.tp} b b', prf := B.prf b b']}}.prf
+      end
+    ]
+  in
+  let aux2 : (m : nat) (B : htype # [lvl := m]) → htype # [lvl := suc m, tp := B.tp] :=
+    elim [
+    | zero => contr-prop
+    | suc l => aux l
+    ]
+  in
+  aux2 {A.lvl} A
+
+abstract
+def prop-hlevel : (l : nat) (A : prop) → htype # [lvl := suc l, tp := A.tp] :=
+  elim [
+  | zero => A => A
+  | suc {l => ih} => A => raise-hlevel {ih A}
   ]
+
+abstract
+def path-hlevel : (l : nat) (A : htype # [lvl := suc l]) (a a' : A.tp) → htype # [lvl := l, tp := path {A.tp} a a'] :=
+  elim [
+  | zero => A a a' => 
+    unfold has-hlevel in 
+    struct 
+      def prf := struct [pt := A.prf a a', path := {prop-set A}.prf a a' {A.prf a a'}]
+    end
+  | suc l => 
+    unfold has-hlevel in
+    A a a' => struct [prf := {A.prf} a a']
+  ]
+
+abstract
+def path-based-contr (A : type) (a : A) : contr # [tp := (x : A) × path A a x] :=
+  struct
+    def prf := 
+      unfold has-hlevel in
+      struct
+        def pt := [a, i => a]
+        def path := x i =>
+         let aux : 𝕀 → A := j =>
+            hcom A 0 j {∂ i} {k =>
+              [ k=0 ∨ i=0 => a
+              | i=1 => {snd x} k
+              ]
+            }
+          in
+          [aux 1, aux]
+      end 
+  end

--- a/test/test.expected
+++ b/test/test.expected
@@ -1,15 +1,18 @@
 --------------------[abstract.cooltt]--------------------
-hlevel.cooltt:33.7-33.12 [Info]:
-  def hProp : type := (A : type) × has-hlevel 1 A
+hlevel.cooltt:30.7-30.11 [Info]:
+  def prop : type :=
+    sig
+      def lvl : ext nat ⊤ {_x₁ => 1} def tp : type def prf : has-hlevel 1 tp
+    end
 
-hlevel.cooltt:34.11-34.16 [Info]:
-  Computed normal form of hProp as (A : type) × has-hlevel 1 A
+hlevel.cooltt:31.11-31.15 [Info]:
+  Computed normal form of prop as
+   sig
+     def lvl : ext nat ⊤ {_x => 1} def tp : type def prf : has-hlevel 1 tp
+   end
 
-abstract.cooltt:104.7-104.15 [Info]:
-  def abs-test : nat := suc {abs-test∷foo *}
-
-abstract.cooltt:107.7-107.15 [Info]:
-  def abs-test : nat := 42
+abstract.cooltt:79.21-79.27 [Error]:
+  Unbound variable is-set
 
 --------------------[algebra.cooltt]--------------------
 nat.cooltt:10.7-10.8 [Info]:
@@ -1477,11 +1480,17 @@ hcom-type.cooltt:18.13-18.14 [Info]:
 [Warn]:  There are 3 unsolved holes
 
 --------------------[hlevel.cooltt]--------------------
-hlevel.cooltt:33.7-33.12 [Info]:
-  def hProp : type := (A : type) × has-hlevel 1 A
+hlevel.cooltt:30.7-30.11 [Info]:
+  def prop : type :=
+    sig
+      def lvl : ext nat ⊤ {_x₁ => 1} def tp : type def prf : has-hlevel 1 tp
+    end
 
-hlevel.cooltt:34.11-34.16 [Info]:
-  Computed normal form of hProp as (A : type) × has-hlevel 1 A
+hlevel.cooltt:31.11-31.15 [Info]:
+  Computed normal form of prop as
+   sig
+     def lvl : ext nat ⊤ {_x => 1} def tp : type def prf : has-hlevel 1 tp
+   end
 
 --------------------[holes.cooltt]--------------------
 holes.cooltt:5.7-5.13 [Info]:


### PR DESCRIPTION
Now we don't need to have separate `is-X` and `hX` definitions, and our functions can take fewer arguments.
I removed the `unfold has-hlevel` over all the property definitions because I found it helpful to keep it folded while interactively developing the eliminator branches. It's nice to see your goal in terms of `has-hlevel` before it gets unfolded.