### PR TITLE
❄️ Add building with Nix as an option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ setup.log
 
 # Local OPAM switch
 _opam/
+
+# for Nix
+result/

--- a/README.md
+++ b/README.md
@@ -11,11 +11,16 @@ by Gratzer, Sterling, and Birkedal. Code has been incorporated from
 [redtt](https://www.github.com/RedPRL/redtt), implemented by Sterling and
 Favonia.
 
-## building
+A small collection of example programs is contained in the `test/` directory.
+See `test/README.md` for a brief description of each program's purpose.
+
+## Building
 
 cooltt has been built with OCaml 4.13.0 with [opam
-2.0.8](https://opam.ocaml.org/). If you are running an older version of OCaml,
-try executing the following command:
+2.0.8](https://opam.ocaml.org/). 
+
+### With OPAM
+If you are running an older version of OCaml, try executing the following command:
 
 ```
 $ opam switch create 4.13.0
@@ -40,9 +45,24 @@ $ make upgrade-pins                     # update and upgrade dependencies in act
 $ dune exec cooltt                      # from the `cooltt` top-level directory
 ```
 
+### With Nix
+First, you'll need the [Nix package manager](https://nixos.org/download.html), and then
+you'll need to [install or enable flakes](https://nixos.wiki/wiki/Flakes).
 
-A small collection of example programs is contained in the `test/` directory.
-See `test/README.md` for a brief description of each program's purpose.
+Then, cooltt can be built with the command
+```
+nix build --impure
+```
+to put a binary `cooltt` in `result/bin/cooltt`. This is good for if you just want to build
+and play around with cooltt.
+
+If you're working on cooltt, you can enter a development shell with an OCaml compiler, dune,
+and other tools with
+```
+nix develop --impure
+```
+and then build as in the [with OPAM](https://github.com/RedPRL/cooltt/#with-opam=) section 
+above.
 
 ## Acknowledgments
 

--- a/cooltt.opam
+++ b/cooltt.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.10.0"}
   "ppx_deriving" {>= "4.4.1"}
-  "bantorra"
+  "bantorra" {>= "0.1" & < "0.2"}
   "bwd" {>= "1.2"}
   "cmdliner" {>= "1.1"}
   "containers" {>= "3.4"}

--- a/cooltt.opam
+++ b/cooltt.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.10.0"}
   "ppx_deriving" {>= "4.4.1"}
-  "bantorra" {>= "0.1" & < "0.2"}
+  "bantorra"
   "bwd" {>= "1.2"}
   "cmdliner" {>= "1.1"}
   "containers" {>= "3.4"}
@@ -26,7 +26,7 @@ depends: [
 ]
 pin-depends: [
   [ "kado.~dev" "git+https://github.com/RedPRL/kado" ]
-  [ "bantorra.0.1.0" "git+https://github.com/RedPRL/bantorra#0.1.0" ]
+  [ "bantorra.0.1.0" "git+https://github.com/RedPRL/bantorra#1e78633d9a2ef7104552a24585bb8bea36d4117b" ]
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656679828,
-        "narHash": "sha256-akGA97pR1BAQew1FrVTCME3p8qvYxJXB2X3a13aBphs=",
+        "lastModified": 1656947410,
+        "narHash": "sha256-htDR/PZvjUJGyrRJsVqDmXR8QeoswBaRLzHt13fd0iY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "915f5a5b3cc4f8ba206afd0b70e52ba4c6a2796b",
+        "rev": "e8d47977286a44955262adbc76f2c8a66e7419d5",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1656886523,
-        "narHash": "sha256-7wGohrz4Ux5Ld1HyyU3gqCAM5Z9aXcdCsgJhtZatq5A=",
+        "lastModified": 1657048488,
+        "narHash": "sha256-hoR9viiz3DxXGglZcntR2/b5DKCVOcBQfAenRG3j/JY=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "c9176ab87b2972f9a6bf6c6e36bd21b1a38fdeeb",
+        "rev": "0f1ccb994f625639f31c17273b757439f0944242",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1656767619,
-        "narHash": "sha256-FvqUlsOl0vJUAoHCUU9uOdnElphEVpBbOCsyA2PFBmM=",
+        "lastModified": 1657035053,
+        "narHash": "sha256-Vgt3iBauMn9xgB8iK0Gxzy+2rG/Q2GwsTNtOFl5UKXQ=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "97da9a1b68b824a65a09e5f7d071fcf2da35bd1b",
+        "rev": "2c86e8475c5f034ded996d82642b63d4551d6dcd",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,139 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1656679828,
+        "narHash": "sha256-akGA97pR1BAQew1FrVTCME3p8qvYxJXB2X3a13aBphs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "915f5a5b3cc4f8ba206afd0b70e52ba4c6a2796b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1640418986,
+        "narHash": "sha256-a8GGtxn2iL3WAkY5H+4E0s3Q7XJt6bTOvos9qqxT5OQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "opam-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "opam-repository": [
+          "opam-repository"
+        ],
+        "opam2json": "opam2json"
+      },
+      "locked": {
+        "lastModified": 1656886523,
+        "narHash": "sha256-7wGohrz4Ux5Ld1HyyU3gqCAM5Z9aXcdCsgJhtZatq5A=",
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "rev": "c9176ab87b2972f9a6bf6c6e36bd21b1a38fdeeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "type": "github"
+      }
+    },
+    "opam-repository": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656767619,
+        "narHash": "sha256-FvqUlsOl0vJUAoHCUU9uOdnElphEVpBbOCsyA2PFBmM=",
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "rev": "97da9a1b68b824a65a09e5f7d071fcf2da35bd1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "type": "github"
+      }
+    },
+    "opam2json": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1651529032,
+        "narHash": "sha256-fe8bm/V/4r2iNxgbitT2sXBqDHQ0GBSnSUSBg/1aXoI=",
+        "owner": "tweag",
+        "repo": "opam2json",
+        "rev": "e8e9f2fa86ef124b9f7b8db41d3d19471c1d8901",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam2json",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "opam-nix": "opam-nix",
+        "opam-repository": "opam-repository"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Experimental implementation of Cartesian cubical type theory";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    opam-repository = {
+      url = "github:ocaml/opam-repository";
+      flake = false;
+    };
+    
+    opam-nix = {
+      url = "github:tweag/opam-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.opam-repository.follows = "opam-repository";
+    };
+  };
+
+  outputs = { self
+            , flake-utils
+            , opam-nix
+            , nixpkgs
+            , opam-repository
+            }@inputs:
+    flake-utils.lib.eachDefaultSystem (system: {
+      legacyPackages = let
+        on = opam-nix.lib.${system};
+      in on.buildDuneProject { } "cooltt" ./. {
+        ocaml-base-compiler = null;
+      };
+
+      defaultPackage = self.legacyPackages.${system}."cooltt";
+    });
+}


### PR DESCRIPTION
This adds building with the Nix package manager as an option, which serves as a decent "just run this and it should work" option for those who don't want to bother to set up OPAM entirely, or for those who just want to *use* cooltt rather than *hack* on it.

This may be blocked on some issues in https://github.com/tweag/opam-nix:
- https://github.com/tweag/opam-nix/issues/12
- https://github.com/tweag/opam-nix/issues/13

However, it may be okay that the constraints on `bantorra`'s version are removed --- I'm not entirely sure about the implications of doing this, because I don't know your all's OPAM workflow.