### PR TITLE
Fixes flake.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# this line sources your `.envrc.local` file
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ _opam/
 
 # for Nix
 result/
+/.envrc.local
+/result
+/.direnv/

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,8 @@ setup.log
 _opam/
 
 # for Nix
-result/
+result
+
+# for Direnv
 /.envrc.local
-/result
 /.direnv/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ you'll need to [install or enable flakes](https://nixos.wiki/wiki/Flakes).
 Then, cooltt can be built with the command
 
 ```
-nix build --impure
+nix build
 ```
 
 to put a binary `cooltt` in `result/bin/cooltt`. This is good for if you just want to build
@@ -63,7 +63,7 @@ If you're working on cooltt, you can enter a development shell with an OCaml com
 and other tools with
 
 ```
-nix develop --impure
+nix develop
 ```
 
 and then build as in the [with OPAM](https://github.com/RedPRL/cooltt/#with-opam=) section

--- a/cooltt.opam
+++ b/cooltt.opam
@@ -25,8 +25,10 @@ depends: [
   "kado"
 ]
 pin-depends: [
-  [ "kado.~dev" "git+https://github.com/RedPRL/kado" ]
+  [ "kado.~dev" "git+https://github.com/RedPRL/kado#afe9b7916d532b67cdec10586ce2eefa8fe56de1" ]
   [ "bantorra.0.1.0" "git+https://github.com/RedPRL/bantorra#1e78633d9a2ef7104552a24585bb8bea36d4117b" ]
+  [ "yuujinchou.5.0.2" "git+https://github.com/RedPRL/yuujinchou#fdfbb1cfb31fb02420e968bcd75567ed9472e664" ]
+  [ "bwd.2.2.0" "git+https://github.com/RedPRL/ocaml-bwd#f7daa913d29f639886f33193c80e5120bf844d6d" ]
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/cooltt.opam
+++ b/cooltt.opam
@@ -25,7 +25,7 @@ depends: [
   "kado"
 ]
 pin-depends: [
-  [ "kado.~dev" "git+https://github.com/RedPRL/kado#afe9b7916d532b67cdec10586ce2eefa8fe56de1" ]
+  [ "kado.~dev" "git+https://github.com/RedPRL/kado#65573a1c0f14f6b09836f8ae317fda17f5900968" ]
   [ "bantorra.0.1.0" "git+https://github.com/RedPRL/bantorra#1e78633d9a2ef7104552a24585bb8bea36d4117b" ]
 ]
 build: [

--- a/cooltt.opam
+++ b/cooltt.opam
@@ -27,8 +27,6 @@ depends: [
 pin-depends: [
   [ "kado.~dev" "git+https://github.com/RedPRL/kado#afe9b7916d532b67cdec10586ce2eefa8fe56de1" ]
   [ "bantorra.0.1.0" "git+https://github.com/RedPRL/bantorra#1e78633d9a2ef7104552a24585bb8bea36d4117b" ]
-  [ "yuujinchou.5.0.2" "git+https://github.com/RedPRL/yuujinchou#fdfbb1cfb31fb02420e968bcd75567ed9472e664" ]
-  [ "bwd.2.2.0" "git+https://github.com/RedPRL/ocaml-bwd#f7daa913d29f639886f33193c80e5120bf844d6d" ]
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/flake.lock
+++ b/flake.lock
@@ -17,43 +17,61 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mirage-opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661959605,
+        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656947410,
-        "narHash": "sha256-htDR/PZvjUJGyrRJsVqDmXR8QeoswBaRLzHt13fd0iY=",
-        "owner": "NixOS",
+        "lastModified": 1682362401,
+        "narHash": "sha256-/UMUHtF2CyYNl4b60Z2y4wwTTdIWGKhj9H301EDcT9M=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8d47977286a44955262adbc76f2c8a66e7419d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1640418986,
-        "narHash": "sha256-a8GGtxn2iL3WAkY5H+4E0s3Q7XJt6bTOvos9qqxT5OQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2",
+        "rev": "884ac294018409e0d1adc0cae185439a44bd6b0b",
         "type": "github"
       },
       "original": {
@@ -66,23 +84,19 @@
     "opam-nix": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "opam-repository": [
-          "opam-repository"
-        ],
+        "flake-utils": "flake-utils_2",
+        "mirage-opam-overlays": "mirage-opam-overlays",
+        "nixpkgs": "nixpkgs",
+        "opam-overlays": "opam-overlays",
+        "opam-repository": "opam-repository",
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1657048488,
-        "narHash": "sha256-hoR9viiz3DxXGglZcntR2/b5DKCVOcBQfAenRG3j/JY=",
+        "lastModified": 1692284409,
+        "narHash": "sha256-Cql9CKy/k+LmSab3Rd2ZkuoEpmWVDb5oRhE/UHM4fT8=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "0f1ccb994f625639f31c17273b757439f0944242",
+        "rev": "e83bd1d949c5e330a49f89d394b51b744248e3ca",
         "type": "github"
       },
       "original": {
@@ -91,14 +105,30 @@
         "type": "github"
       }
     },
+    "opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654162756,
+        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "type": "github"
+      }
+    },
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1657035053,
-        "narHash": "sha256-Vgt3iBauMn9xgB8iK0Gxzy+2rG/Q2GwsTNtOFl5UKXQ=",
+        "lastModified": 1682021363,
+        "narHash": "sha256-nDUDFwyOTZDALeqqEDnF2PTPIHT4sVYdQXUbRt03oNs=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "2c86e8475c5f034ded996d82642b63d4551d6dcd",
+        "rev": "786c55fa77c37f07eceea7d6a9bec04d2225e302",
         "type": "github"
       },
       "original": {
@@ -109,14 +139,17 @@
     },
     "opam2json": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "opam-nix",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1651529032,
-        "narHash": "sha256-fe8bm/V/4r2iNxgbitT2sXBqDHQ0GBSnSUSBg/1aXoI=",
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
         "owner": "tweag",
         "repo": "opam2json",
-        "rev": "e8e9f2fa86ef124b9f7b8db41d3d19471c1d8901",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
         "type": "github"
       },
       "original": {
@@ -128,9 +161,26 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "opam-nix": "opam-nix",
-        "opam-repository": "opam-repository"
+        "nixpkgs": [
+          "opam-nix",
+          "nixpkgs"
+        ],
+        "opam-nix": "opam-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -88,7 +88,9 @@
         "mirage-opam-overlays": "mirage-opam-overlays",
         "nixpkgs": "nixpkgs",
         "opam-overlays": "opam-overlays",
-        "opam-repository": "opam-repository",
+        "opam-repository": [
+          "opam-repository"
+        ],
         "opam2json": "opam2json"
       },
       "locked": {
@@ -124,11 +126,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1682021363,
-        "narHash": "sha256-nDUDFwyOTZDALeqqEDnF2PTPIHT4sVYdQXUbRt03oNs=",
+        "lastModified": 1693414331,
+        "narHash": "sha256-4lcerZ9XBJ5nMGw+cxYrIcvxNQzuKu7ZPiE4R7PUJ3w=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "786c55fa77c37f07eceea7d6a9bec04d2225e302",
+        "rev": "aa09a2fd2386ae30b729a2ee438e7698c011e69c",
         "type": "github"
       },
       "original": {
@@ -165,7 +167,8 @@
           "opam-nix",
           "nixpkgs"
         ],
-        "opam-nix": "opam-nix"
+        "opam-nix": "opam-nix",
+        "opam-repository": "opam-repository"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,35 +2,45 @@
   description = "Experimental implementation of Cartesian cubical type theory";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    opam-nix.url = "github:tweag/opam-nix";
     flake-utils.url = "github:numtide/flake-utils";
-
-    opam-repository = {
-      url = "github:ocaml/opam-repository";
-      flake = false;
-    };
-    
-    opam-nix = {
-      url = "github:tweag/opam-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-      inputs.opam-repository.follows = "opam-repository";
-    };
+    nixpkgs.follows = "opam-nix/nixpkgs";
   };
 
-  outputs = { self
-            , flake-utils
-            , opam-nix
-            , nixpkgs
-            , opam-repository
-            }@inputs:
-    flake-utils.lib.eachDefaultSystem (system: {
-      legacyPackages = let
+  outputs = { self, flake-utils, opam-nix, nixpkgs }@inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
         on = opam-nix.lib.${system};
-      in on.buildDuneProject { } "cooltt" ./. {
-        ocaml-base-compiler = null;
-      };
+        localPackagesQuery = builtins.mapAttrs (_: pkgs.lib.last)
+          (on.listRepo (on.makeOpamRepo ./.));
+        devPackagesQuery = {
+          ocaml-lsp-server = "*";
+          ocp-indent = "*";
+          merlin = "*";
+        };
+        query = devPackagesQuery // {
+          ocaml-base-compiler = "*";
+        };
+        scope = on.buildDuneProject { } "cooltt" ./. query;
+        devPackages = builtins.attrValues
+          (pkgs.lib.getAttrs (builtins.attrNames devPackagesQuery) scope);
+        packages =
+          pkgs.lib.getAttrs (builtins.attrNames localPackagesQuery) scope;
+      in
+      {
+        legacyPackages = scope;
 
-      defaultPackage = self.legacyPackages.${system}."cooltt";
-    });
+        packages = packages // { default = packages.cooltt; };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = builtins.attrValues packages;
+          buildInputs = devPackages ++ [
+            pkgs.fd
+            pkgs.nixpkgs-fmt
+            pkgs.pkg-config
+            pkgs.shellcheck
+          ];
+        };
+      });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,17 @@
   description = "Experimental implementation of Cartesian cubical type theory";
 
   inputs = {
+    opam-repository = {
+      url = "github:ocaml/opam-repository";
+      flake = false;
+    };
     opam-nix.url = "github:tweag/opam-nix";
+    opam-nix.inputs.opam-repository.follows = "opam-repository";
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.follows = "opam-nix/nixpkgs";
   };
 
-  outputs = { self, flake-utils, opam-nix, nixpkgs }@inputs:
+  outputs = { self, flake-utils, opam-nix, opam-repository, nixpkgs }@inputs:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};


### PR DESCRIPTION
Rewrites flake.nix and pins some libraries to get the nix shell environment and nix builds working.

~Note that I had to pin `Kado` prior to `17206ca3d01fada34e34e60e1995b03609292b61` which has a breaking change.~